### PR TITLE
docs: Rename steelthreads to agriculturegovau

### DIFF
--- a/.changeset/curly-wasps-shave.md
+++ b/.changeset/curly-wasps-shave.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/docs': patch
 ---
 
-Update all references of `steelthreads` to `agriculture-gov-au`
+Update all references of `steelthreads` to `agriculturegovau`

--- a/.changeset/curly-wasps-shave.md
+++ b/.changeset/curly-wasps-shave.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+Update all references of `steelthreads` to `agriculture-gov-au`

--- a/.storybook/components/PageTemplate.tsx
+++ b/.storybook/components/PageTemplate.tsx
@@ -71,7 +71,7 @@ export function PageTemplate({
 								},
 								{
 									label: 'Starter kit',
-									href: 'https://github.com/steelthreads/agds-starter-kit',
+									href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
 								},
 							]}
 							horizontal

--- a/.storybook/components/PageTemplate.tsx
+++ b/.storybook/components/PageTemplate.tsx
@@ -71,7 +71,7 @@ export function PageTemplate({
 								},
 								{
 									label: 'Starter kit',
-									href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
+									href: 'https://github.com/agriculturegovau/agds-starter-kit',
 								},
 							]}
 							horizontal

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Agriculture Design System (AgDS) is a new design system for the Department o
 
 ## Before you clone this repository…
 
-If you are starting a new project, you should clone the [starter kit](https://github.com/agriculture-gov-au/agds-starter-kit).
+If you are starting a new project, you should clone the [starter kit](https://github.com/agriculturegovau/agds-starter-kit).
 
 If you are looking to implement AgDS components, you need to [install packages from NPM](https://design-system.agriculture.gov.au/guides/getting-started#if-youre-implementing-components-in-an-existing-project).
 
@@ -40,7 +40,7 @@ For development run one or more of the following commands:
 
 ### Website
 
-Deployment of the website is handled by [github actions](https://github.com/agriculture-gov-au/agds-next/actions/workflows/deploy-docs.yml). The site is deployed automatically anytime changes are merged to the `main` branch.
+Deployment of the website is handled by [github actions](https://github.com/agriculturegovau/agds-next/actions/workflows/deploy-docs.yml). The site is deployed automatically anytime changes are merged to the `main` branch.
 
 You can run the builds locally for testing. The order of commands here is important. Because storybook, playroom, the example site and example form site is being bundled into the docs site it must be built first.
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ The Agriculture Design System (AgDS) is a new design system for the Department o
 
 [Visit the AgDS website](https://design-system.agriculture.gov.au)
 
-## Before you clone this repository ...
+## Before you clone this repository…
 
-If you are starting a new project, you should clone the [starter kit](https://github.com/steelthreads/agds-starter-kit).
+If you are starting a new project, you should clone the [starter kit](https://github.com/agriculture-gov-au/agds-starter-kit).
 
 If you are looking to implement AgDS components, you need to [install packages from NPM](https://design-system.agriculture.gov.au/guides/getting-started#if-youre-implementing-components-in-an-existing-project).
 
-You should only clone this repo if you are looking to contribute to it, such as...
+You should only clone this repo if you are looking to contribute to it, such as…
 
 - Improving documentation
 - Updating existing components
@@ -40,7 +40,7 @@ For development run one or more of the following commands:
 
 ### Website
 
-Deployment of the website is handled by [github actions](https://github.com/steelthreads/agds-next/actions/workflows/deploy-docs.yml). The site is deployed automatically anytime changes are merged to the `main` branch.
+Deployment of the website is handled by [github actions](https://github.com/agriculture-gov-au/agds-next/actions/workflows/deploy-docs.yml). The site is deployed automatically anytime changes are merged to the `main` branch.
 
 You can run the builds locally for testing. The order of commands here is important. Because storybook, playroom, the example site and example form site is being bundled into the docs site it must be built first.
 

--- a/docs/components/EditPage.tsx
+++ b/docs/components/EditPage.tsx
@@ -1,6 +1,6 @@
 import { TextLink } from '@ag.ds-next/react/text-link';
 
-const ORG = 'steelthreads';
+const ORG = 'agriculture-gov-au';
 const REPO = 'agds-next';
 const BRANCH = 'main';
 

--- a/docs/components/EditPage.tsx
+++ b/docs/components/EditPage.tsx
@@ -1,6 +1,6 @@
 import { TextLink } from '@ag.ds-next/react/text-link';
 
-const ORG = 'agriculture-gov-au';
+const ORG = 'agriculturegovau';
 const REPO = 'agds-next';
 const BRANCH = 'main';
 

--- a/docs/components/PatternLayout.tsx
+++ b/docs/components/PatternLayout.tsx
@@ -67,7 +67,7 @@ export function PatternLayout({
 						{pattern.githubTemplatePath && (
 							<ButtonLink
 								variant="text"
-								href={`https://github.com/agriculture-gov-au/agds-next/blob/main${pattern.githubTemplatePath}`}
+								href={`https://github.com/agriculturegovau/agds-next/blob/main${pattern.githubTemplatePath}`}
 								iconBefore={GithubLogo}
 							>
 								View in Github

--- a/docs/components/PatternLayout.tsx
+++ b/docs/components/PatternLayout.tsx
@@ -67,7 +67,7 @@ export function PatternLayout({
 						{pattern.githubTemplatePath && (
 							<ButtonLink
 								variant="text"
-								href={`https://github.com/steelthreads/agds-next/blob/main${pattern.githubTemplatePath}`}
+								href={`https://github.com/agriculture-gov-au/agds-next/blob/main${pattern.githubTemplatePath}`}
 								iconBefore={GithubLogo}
 							>
 								View in Github

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -72,7 +72,7 @@ export function PkgLayout({
 
 								<ButtonLink
 									variant="text"
-									href={`https://github.com/agriculture-gov-au/agds-next/tree/main/packages/react/src/${pkg.slug}`}
+									href={`https://github.com/agriculturegovau/agds-next/tree/main/packages/react/src/${pkg.slug}`}
 									iconBefore={GithubLogo}
 								>
 									View in Github

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -72,7 +72,7 @@ export function PkgLayout({
 
 								<ButtonLink
 									variant="text"
-									href={`https://github.com/steelthreads/agds-next/tree/main/packages/react/src/${pkg.slug}`}
+									href={`https://github.com/agriculture-gov-au/agds-next/tree/main/packages/react/src/${pkg.slug}`}
 									iconBefore={GithubLogo}
 								>
 									View in Github

--- a/docs/components/PullRequestPreviewBanner.tsx
+++ b/docs/components/PullRequestPreviewBanner.tsx
@@ -2,7 +2,7 @@ import { GlobalAlert } from '@ag.ds-next/react/global-alert';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
 
-const ORG = 'steelthreads';
+const ORG = 'agriculture-gov-au';
 const REPO = 'agds-next';
 
 export function PullRequestPreviewBanner({

--- a/docs/components/PullRequestPreviewBanner.tsx
+++ b/docs/components/PullRequestPreviewBanner.tsx
@@ -2,7 +2,7 @@ import { GlobalAlert } from '@ag.ds-next/react/global-alert';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
 
-const ORG = 'agriculture-gov-au';
+const ORG = 'agriculturegovau';
 const REPO = 'agds-next';
 
 export function PullRequestPreviewBanner({

--- a/docs/components/SiteFooter.tsx
+++ b/docs/components/SiteFooter.tsx
@@ -23,7 +23,7 @@ const footerLinks = [
 	},
 	{
 		label: 'Starter kit',
-		href: 'https://github.com/steelthreads/agds-starter-kit',
+		href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
 	},
 ];
 

--- a/docs/components/SiteFooter.tsx
+++ b/docs/components/SiteFooter.tsx
@@ -23,7 +23,7 @@ const footerLinks = [
 	},
 	{
 		label: 'Starter kit',
-		href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
+		href: 'https://github.com/agriculturegovau/agds-starter-kit',
 	},
 ];
 

--- a/docs/components/SiteHeader.tsx
+++ b/docs/components/SiteHeader.tsx
@@ -18,7 +18,7 @@ const NAV_ITEMS = {
 	secondary: [
 		{
 			label: 'GitHub',
-			href: 'https://github.com/steelthreads/agds-next',
+			href: 'https://github.com/agriculture-gov-au/agds-next',
 			endElement: <GithubIcon />,
 		},
 	],

--- a/docs/components/SiteHeader.tsx
+++ b/docs/components/SiteHeader.tsx
@@ -18,7 +18,7 @@ const NAV_ITEMS = {
 	secondary: [
 		{
 			label: 'GitHub',
-			href: 'https://github.com/agriculture-gov-au/agds-next',
+			href: 'https://github.com/agriculturegovau/agds-next',
 			endElement: <GithubIcon />,
 		},
 	],

--- a/docs/components/TemplateLayout.tsx
+++ b/docs/components/TemplateLayout.tsx
@@ -78,7 +78,7 @@ export function TemplateLayout({
 						{template.githubTemplatePath && (
 							<ButtonLink
 								variant="text"
-								href={`https://github.com/agriculture-gov-au/agds-next/blob/main${template.githubTemplatePath}`}
+								href={`https://github.com/agriculturegovau/agds-next/blob/main${template.githubTemplatePath}`}
 								iconBefore={GithubLogo}
 							>
 								View in Github

--- a/docs/components/TemplateLayout.tsx
+++ b/docs/components/TemplateLayout.tsx
@@ -78,7 +78,7 @@ export function TemplateLayout({
 						{template.githubTemplatePath && (
 							<ButtonLink
 								variant="text"
-								href={`https://github.com/steelthreads/agds-next/blob/main${template.githubTemplatePath}`}
+								href={`https://github.com/agriculture-gov-au/agds-next/blob/main${template.githubTemplatePath}`}
 								iconBefore={GithubLogo}
 							>
 								View in Github

--- a/docs/content/about.mdx
+++ b/docs/content/about.mdx
@@ -29,4 +29,4 @@ If you are wondering what is next, please see our [roadmap](/roadmap).
 
 ## License
 
-This work is licensed under the [MIT license](https://github.com/steelthreads/agds-next/blob/main/LICENSE).
+This work is licensed under the [MIT license](https://github.com/agriculture-gov-au/agds-next/blob/main/LICENSE).

--- a/docs/content/about.mdx
+++ b/docs/content/about.mdx
@@ -29,4 +29,4 @@ If you are wondering what is next, please see our [roadmap](/roadmap).
 
 ## License
 
-This work is licensed under the [MIT license](https://github.com/agriculture-gov-au/agds-next/blob/main/LICENSE).
+This work is licensed under the [MIT license](https://github.com/agriculturegovau/agds-next/blob/main/LICENSE).

--- a/docs/content/foundations/accessibility.mdx
+++ b/docs/content/foundations/accessibility.mdx
@@ -59,4 +59,4 @@ For information about getting started with accessibility, we recommend visiting 
 
 ## Feedback
 
-The AgDS team is always looking at ways to improve the accessibility of our components. If you find a problem or think that AgDS is not meeting accessibility requirements, please reach out to the AgDS team via Microsoft Teams or by creating a [Github issue](https://github.com/agriculture-gov-au/agds-next/issues).
+The AgDS team is always looking at ways to improve the accessibility of our components. If you find a problem or think that AgDS is not meeting accessibility requirements, please reach out to the AgDS team via Microsoft Teams or by creating a [Github issue](https://github.com/agriculturegovau/agds-next/issues).

--- a/docs/content/foundations/accessibility.mdx
+++ b/docs/content/foundations/accessibility.mdx
@@ -59,4 +59,4 @@ For information about getting started with accessibility, we recommend visiting 
 
 ## Feedback
 
-The AgDS team is always looking at ways to improve the accessibility of our components. If you find a problem or think that AgDS is not meeting accessibility requirements, please reach out to the AgDS team via Microsoft Teams or by creating a [Github issue](https://github.com/steelthreads/agds-next/issues).
+The AgDS team is always looking at ways to improve the accessibility of our components. If you find a problem or think that AgDS is not meeting accessibility requirements, please reach out to the AgDS team via Microsoft Teams or by creating a [Github issue](https://github.com/agriculture-gov-au/agds-next/issues).

--- a/docs/content/foundations/technical-overview.mdx
+++ b/docs/content/foundations/technical-overview.mdx
@@ -31,4 +31,4 @@ Described as 'the SDK for the web', it handles the tooling and configuration nee
 
 We use NextJS to build our documentation site, templates and internal test applications.
 
-Unless you have strong technical reasons to use another framework, we highly recommend you clone our NextJS based [Starter Kit](https://github.com/steelthreads/agds-starter-kit) as the starting point for your next project.
+Unless you have strong technical reasons to use another framework, we highly recommend you clone our NextJS based [Starter Kit](https://github.com/agriculture-gov-au/agds-starter-kit) as the starting point for your next project.

--- a/docs/content/foundations/technical-overview.mdx
+++ b/docs/content/foundations/technical-overview.mdx
@@ -31,4 +31,4 @@ Described as 'the SDK for the web', it handles the tooling and configuration nee
 
 We use NextJS to build our documentation site, templates and internal test applications.
 
-Unless you have strong technical reasons to use another framework, we highly recommend you clone our NextJS based [Starter Kit](https://github.com/agriculture-gov-au/agds-starter-kit) as the starting point for your next project.
+Unless you have strong technical reasons to use another framework, we highly recommend you clone our NextJS based [Starter Kit](https://github.com/agriculturegovau/agds-starter-kit) as the starting point for your next project.

--- a/docs/content/guides/contribution.mdx
+++ b/docs/content/guides/contribution.mdx
@@ -63,7 +63,7 @@ Our design system is a continuation of the Australian Government Design System, 
 
 Accessibility is a foundation of AgDS. Any design or code contributed must meet WCAG 2.1 AA as a minimum.
 
-AgDS is built using React.js and Typescript. Any code contributions should meet minimum code hygiene levels outlined [in this guide](https://github.com/steelthreads/agds-next/blob/main/CONTRIBUTING.md). We work in GitHub so contribution can be made at [the AgDS repository](https://github.com/steelthreads/agds-next).
+AgDS is built using React.js and Typescript. Any code contributions should meet minimum code hygiene levels outlined [in this guide](https://github.com/agriculture-gov-au/agds-next/blob/main/CONTRIBUTING.md). We work in GitHub so contribution can be made at [the AgDS repository](https://github.com/agriculture-gov-au/agds-next).
 
 All patterns and components of AgDS are designed to be used across common screen sizes. All contributed patterns and components need to be responsive and function from 320px mobile to 1400px desktop viewports.
 

--- a/docs/content/guides/contribution.mdx
+++ b/docs/content/guides/contribution.mdx
@@ -63,7 +63,7 @@ Our design system is a continuation of the Australian Government Design System, 
 
 Accessibility is a foundation of AgDS. Any design or code contributed must meet WCAG 2.1 AA as a minimum.
 
-AgDS is built using React.js and Typescript. Any code contributions should meet minimum code hygiene levels outlined [in this guide](https://github.com/agriculture-gov-au/agds-next/blob/main/CONTRIBUTING.md). We work in GitHub so contribution can be made at [the AgDS repository](https://github.com/agriculture-gov-au/agds-next).
+AgDS is built using React.js and Typescript. Any code contributions should meet minimum code hygiene levels outlined [in this guide](https://github.com/agriculturegovau/agds-next/blob/main/CONTRIBUTING.md). We work in GitHub so contribution can be made at [the AgDS repository](https://github.com/agriculturegovau/agds-next).
 
 All patterns and components of AgDS are designed to be used across common screen sizes. All contributed patterns and components need to be responsive and function from 320px mobile to 1400px desktop viewports.
 

--- a/docs/content/guides/custom-theme.mdx
+++ b/docs/content/guides/custom-theme.mdx
@@ -132,7 +132,7 @@ export const myTheme: Theme = {
 };
 ```
 
-Typescript should help you by autocompleting token names. [The full schema is visible here](https://github.com/agriculture-gov-au/agds-next/blob/main/packages/react/src/core/goldTheme.ts).
+Typescript should help you by autocompleting token names. [The full schema is visible here](https://github.com/agriculturegovau/agds-next/blob/main/packages/react/src/core/goldTheme.ts).
 
 ### Tips for picking colours
 

--- a/docs/content/guides/custom-theme.mdx
+++ b/docs/content/guides/custom-theme.mdx
@@ -132,7 +132,7 @@ export const myTheme: Theme = {
 };
 ```
 
-Typescript should help you by autocompleting token names. [The full schema is visible here](https://github.com/steelthreads/agds-next/blob/main/packages/react/src/core/goldTheme.ts).
+Typescript should help you by autocompleting token names. [The full schema is visible here](https://github.com/agriculture-gov-au/agds-next/blob/main/packages/react/src/core/goldTheme.ts).
 
 ### Tips for picking colours
 

--- a/docs/content/guides/getting-started.mdx
+++ b/docs/content/guides/getting-started.mdx
@@ -13,14 +13,14 @@ If you’re new to React we recommend going through official [React getting star
 
 ## If you’re starting a new project…
 
-We have built a [starter kit](https://github.com/agriculture-gov-au/agds-starter-kit) in NextJS, Typescript and Emotion which you can clone and use as a starting point for your next project.
+We have built a [starter kit](https://github.com/agriculturegovau/agds-starter-kit) in NextJS, Typescript and Emotion which you can clone and use as a starting point for your next project.
 
 ### 1. Clone latest code
 
 These commands clone the latest starter kit code, without the version history or ties to the remote repository.
 
 ```sh
-git clone --depth=1 --branch=main git@github.com:agriculture-gov-au/agds-starter-kit.git my-app
+git clone --depth=1 --branch=main git@github.com:agriculturegovau/agds-starter-kit.git my-app
 rm -rf ./my-app/.git
 ```
 
@@ -87,7 +87,7 @@ yarn add @ag.ds-next/react
 
 ### 3. Wrap your application in our `Core` component
 
-The `Core` component needs to wrap your entire application and it is where you can configure the theme and routing/links. For an example of configuring routing/links in AgDS for a Next.js application, please see [the code for our example site](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site/components/LinkComponent.tsx).
+The `Core` component needs to wrap your entire application and it is where you can configure the theme and routing/links. For an example of configuring routing/links in AgDS for a Next.js application, please see [the code for our example site](https://github.com/agriculturegovau/agds-next/tree/main/example-site/components/LinkComponent.tsx).
 
 ```tsx
 // This example assumes you are using NextJS
@@ -112,11 +112,11 @@ export default function MyApp({ Component, pageProps }) {
 
 You can now start using our components!
 
-> We recommend using TypeScript to get the most out of these components. Our example site already uses TypeScript so you can use that as reference. [See code](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site).
+> We recommend using TypeScript to get the most out of these components. Our example site already uses TypeScript so you can use that as reference. [See code](https://github.com/agriculturegovau/agds-next/tree/main/example-site).
 
 ## What's next?
 
-[Explore our example site](/example-site) to see our list of interface examples, as well as the [related code on GitHub](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site).
+[Explore our example site](/example-site) to see our list of interface examples, as well as the [related code on GitHub](https://github.com/agriculturegovau/agds-next/tree/main/example-site).
 
 You should also explore our wide range of [components](/components), and install the ones you need in your application.
 

--- a/docs/content/guides/getting-started.mdx
+++ b/docs/content/guides/getting-started.mdx
@@ -13,14 +13,14 @@ If you’re new to React we recommend going through official [React getting star
 
 ## If you’re starting a new project…
 
-We have built a [starter kit](https://github.com/steelthreads/agds-starter-kit) in NextJS, Typescript and Emotion which you can clone and use as a starting point for your next project.
+We have built a [starter kit](https://github.com/agriculture-gov-au/agds-starter-kit) in NextJS, Typescript and Emotion which you can clone and use as a starting point for your next project.
 
 ### 1. Clone latest code
 
 These commands clone the latest starter kit code, without the version history or ties to the remote repository.
 
 ```sh
-git clone --depth=1 --branch=main git@github.com:steelthreads/agds-starter-kit.git my-app
+git clone --depth=1 --branch=main git@github.com:agriculture-gov-au/agds-starter-kit.git my-app
 rm -rf ./my-app/.git
 ```
 
@@ -87,7 +87,7 @@ yarn add @ag.ds-next/react
 
 ### 3. Wrap your application in our `Core` component
 
-The `Core` component needs to wrap your entire application and it is where you can configure the theme and routing/links. For an example of configuring routing/links in AgDS for a Next.js application, please see [the code for our example site](https://github.com/steelthreads/agds-next/tree/main/example-site/components/LinkComponent.tsx).
+The `Core` component needs to wrap your entire application and it is where you can configure the theme and routing/links. For an example of configuring routing/links in AgDS for a Next.js application, please see [the code for our example site](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site/components/LinkComponent.tsx).
 
 ```tsx
 // This example assumes you are using NextJS
@@ -112,11 +112,11 @@ export default function MyApp({ Component, pageProps }) {
 
 You can now start using our components!
 
-> We recommend using TypeScript to get the most out of these components. Our example site already uses TypeScript so you can use that as reference. [See code](https://github.com/steelthreads/agds-next/tree/main/example-site).
+> We recommend using TypeScript to get the most out of these components. Our example site already uses TypeScript so you can use that as reference. [See code](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site).
 
 ## What's next?
 
-[Explore our example site](/example-site) to see our list of interface examples, as well as the [related code on GitHub](https://github.com/steelthreads/agds-next/tree/main/example-site).
+[Explore our example site](/example-site) to see our list of interface examples, as well as the [related code on GitHub](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site).
 
 You should also explore our wide range of [components](/components), and install the ones you need in your application.
 

--- a/docs/content/patterns/focus-mode/index.mdx
+++ b/docs/content/patterns/focus-mode/index.mdx
@@ -42,7 +42,7 @@ Remove the [App layout sidebar](/components/app-layout#app-layout-sidebar) to si
 
 On informational websites, focus mode hides the main navigation and changes the header component to the small variant to save vertical space.
 
-To do this, please refer the code example in the [example site](https://github.com/steelthreads/agds-next/blob/main/example-site/components/SiteHeader.tsx).
+To do this, please refer the code example in the [example site](https://github.com/agriculture-gov-au/agds-next/blob/main/example-site/components/SiteHeader.tsx).
 
 <ImageWithBorder
 	alt="Example usage of the Header and Main nav components with an arrow pointing down to another example of these components in focus mode"

--- a/docs/content/patterns/focus-mode/index.mdx
+++ b/docs/content/patterns/focus-mode/index.mdx
@@ -42,7 +42,7 @@ Remove the [App layout sidebar](/components/app-layout#app-layout-sidebar) to si
 
 On informational websites, focus mode hides the main navigation and changes the header component to the small variant to save vertical space.
 
-To do this, please refer the code example in the [example site](https://github.com/agriculture-gov-au/agds-next/blob/main/example-site/components/SiteHeader.tsx).
+To do this, please refer the code example in the [example site](https://github.com/agriculturegovau/agds-next/blob/main/example-site/components/SiteHeader.tsx).
 
 <ImageWithBorder
 	alt="Example usage of the Header and Main nav components with an arrow pointing down to another example of these components in focus mode"

--- a/docs/content/updates/2022-01-05.mdx
+++ b/docs/content/updates/2022-01-05.mdx
@@ -28,4 +28,4 @@ This release contains the base set of core and primitive components (core, box, 
 
 ## Changelog
 
-You can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/24) in the related PR (https://github.com/steelthreads/agds-next/pull/24) for this release.
+You can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/24) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/24) for this release.

--- a/docs/content/updates/2022-01-05.mdx
+++ b/docs/content/updates/2022-01-05.mdx
@@ -28,4 +28,4 @@ This release contains the base set of core and primitive components (core, box, 
 
 ## Changelog
 
-You can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/24) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/24) for this release.
+You can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/24) in the related PR (https://github.com/agriculturegovau/agds-next/pull/24) for this release.

--- a/docs/content/updates/2022-01-07.mdx
+++ b/docs/content/updates/2022-01-07.mdx
@@ -29,4 +29,4 @@ Changes to improve usability of primitive components and to better enable using 
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-07), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/29) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-07), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/29) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/29) for this release.

--- a/docs/content/updates/2022-01-07.mdx
+++ b/docs/content/updates/2022-01-07.mdx
@@ -29,4 +29,4 @@ Changes to improve usability of primitive components and to better enable using 
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-07), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/29) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/29) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-07), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/29) in the related PR (https://github.com/agriculturegovau/agds-next/pull/29) for this release.

--- a/docs/content/updates/2022-01-24.mdx
+++ b/docs/content/updates/2022-01-24.mdx
@@ -32,4 +32,4 @@ Add new components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-24), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/50) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-24), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/29) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/50) for this release.

--- a/docs/content/updates/2022-01-24.mdx
+++ b/docs/content/updates/2022-01-24.mdx
@@ -32,4 +32,4 @@ Add new components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-24), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/29) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/50) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-24), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/29) in the related PR (https://github.com/agriculturegovau/agds-next/pull/50) for this release.

--- a/docs/content/updates/2022-02-08.mdx
+++ b/docs/content/updates/2022-02-08.mdx
@@ -35,4 +35,4 @@ Add New components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-08), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/55) in the related PR (https://github.com/steelthreads/agds-next/pull/55) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-08), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/55) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/55) for this release.

--- a/docs/content/updates/2022-02-08.mdx
+++ b/docs/content/updates/2022-02-08.mdx
@@ -35,4 +35,4 @@ Add New components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-08), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/55) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/55) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-08), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/55) in the related PR (https://github.com/agriculturegovau/agds-next/pull/55) for this release.

--- a/docs/content/updates/2022-02-23.mdx
+++ b/docs/content/updates/2022-02-23.mdx
@@ -47,4 +47,4 @@ In this release, we have focused on adding new form and interactive components i
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-23), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/112) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/112) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-23), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/112) in the related PR (https://github.com/agriculturegovau/agds-next/pull/112) for this release.

--- a/docs/content/updates/2022-02-23.mdx
+++ b/docs/content/updates/2022-02-23.mdx
@@ -47,4 +47,4 @@ In this release, we have focused on adding new form and interactive components i
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/112) in the related PR (https://github.com/steelthreads/agds-next/pull/112) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-23), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/112) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/112) for this release.

--- a/docs/content/updates/2022-03-02.mdx
+++ b/docs/content/updates/2022-03-02.mdx
@@ -26,7 +26,7 @@ In this release we have focused on delivering improvements for existing componen
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-02), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/153) in the related PR (https://github.com/steelthreads/agds-next/pull/153) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-02), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/153) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/153) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-02.mdx
+++ b/docs/content/updates/2022-03-02.mdx
@@ -26,7 +26,7 @@ In this release we have focused on delivering improvements for existing componen
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-02), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/153) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/153) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-02), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/153) in the related PR (https://github.com/agriculturegovau/agds-next/pull/153) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-03.mdx
+++ b/docs/content/updates/2022-03-03.mdx
@@ -18,7 +18,7 @@ description: Add InPage Nav. Bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-03), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/178) in the related PR (https://github.com/steelthreads/agds-next/pull/178) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-03), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/178) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/178) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-03.mdx
+++ b/docs/content/updates/2022-03-03.mdx
@@ -18,7 +18,7 @@ description: Add InPage Nav. Bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-03), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/178) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/178) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-03), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/178) in the related PR (https://github.com/agriculturegovau/agds-next/pull/178) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-16.mdx
+++ b/docs/content/updates/2022-03-16.mdx
@@ -100,7 +100,7 @@ description: Updated Icon API, new components, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-16), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/190) in the related PR (https://github.com/steelthreads/agds-next/pull/190) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-16), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/190) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/190) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-16.mdx
+++ b/docs/content/updates/2022-03-16.mdx
@@ -100,7 +100,7 @@ description: Updated Icon API, new components, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-16), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/190) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/190) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-16), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/190) in the related PR (https://github.com/agriculturegovau/agds-next/pull/190) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-23.mdx
+++ b/docs/content/updates/2022-03-23.mdx
@@ -89,7 +89,7 @@ description: Added PageAlert, new tone colours, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/229) in the related PR (https://github.com/steelthreads/agds-next/pull/229) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-23), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/229) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/229) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-23.mdx
+++ b/docs/content/updates/2022-03-23.mdx
@@ -89,7 +89,7 @@ description: Added PageAlert, new tone colours, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-23), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/229) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/229) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-23), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/229) in the related PR (https://github.com/agriculturegovau/agds-next/pull/229) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-04-01.mdx
+++ b/docs/content/updates/2022-04-01.mdx
@@ -62,7 +62,7 @@ description: Add DatePicker, Modal and Table. Various bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-01), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/260) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/260) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-01), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/260) in the related PR (https://github.com/agriculturegovau/agds-next/pull/260) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-04-01.mdx
+++ b/docs/content/updates/2022-04-01.mdx
@@ -62,7 +62,7 @@ description: Add DatePicker, Modal and Table. Various bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-01), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/260) in the related PR (https://github.com/steelthreads/agds-next/pull/260) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-01), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/260) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/260) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-04-28.mdx
+++ b/docs/content/updates/2022-04-28.mdx
@@ -111,7 +111,7 @@ description: Add HeroBanner and Loading. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/279) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/279) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/279) in the related PR (https://github.com/agriculturegovau/agds-next/pull/279) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-04-28.mdx
+++ b/docs/content/updates/2022-04-28.mdx
@@ -111,7 +111,7 @@ description: Add HeroBanner and Loading. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/279) in the related PR (https://github.com/steelthreads/agds-next/pull/279) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/279) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/279) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-05-16.mdx
+++ b/docs/content/updates/2022-05-16.mdx
@@ -102,7 +102,7 @@ description: Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/319) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/319) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/319) in the related PR (https://github.com/agriculturegovau/agds-next/pull/319) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-05-16.mdx
+++ b/docs/content/updates/2022-05-16.mdx
@@ -102,7 +102,7 @@ description: Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/319) in the related PR (https://github.com/steelthreads/agds-next/pull/319) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/319) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/319) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-05-30.mdx
+++ b/docs/content/updates/2022-05-30.mdx
@@ -106,7 +106,7 @@ description: Add ButtonGroup component. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-05-30), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/346) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/346) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-05-30), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/346) in the related PR (https://github.com/agriculturegovau/agds-next/pull/346) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-05-30.mdx
+++ b/docs/content/updates/2022-05-30.mdx
@@ -106,7 +106,7 @@ description: Add ButtonGroup component. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-05-30), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/346) in the related PR (https://github.com/steelthreads/agds-next/pull/346) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-05-30), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/346) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/346) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-06-15.mdx
+++ b/docs/content/updates/2022-06-15.mdx
@@ -14,7 +14,7 @@ description: Added support for React 18. Various bug fixes and improvements.
 ## Breaking Changes
 
 - `@ag.ds-next/text`: Moved `TextLink` and `TextLinkExternal` from `@ag.ds-next/text` to a new package `@ag.ds-next/text-link`. Please update imports accordingly.
-- `@ag.ds-next/core`: The `linkComponent` prop has been updated to support refs. Please wrap your `linkComponent` in `forwardRef` to avoid any warnings and errors. As an example you can the design systems [next.js example link component](https://github.com/agriculture-gov-au/agds-next/blob/main/example-site/components/LinkComponent.tsx)
+- `@ag.ds-next/core`: The `linkComponent` prop has been updated to support refs. Please wrap your `linkComponent` in `forwardRef` to avoid any warnings and errors. As an example you can the design systems [next.js example link component](https://github.com/agriculturegovau/agds-next/blob/main/example-site/components/LinkComponent.tsx)
 - `@ag.ds-next/content`: The `Content` component in has been replaced with 2 new components: `PageContent` and `SectionContent`. Please update usage accordingly.
 
 ## Updates
@@ -106,7 +106,7 @@ description: Added support for React 18. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-15), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/399) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/399) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-15), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/399) in the related PR (https://github.com/agriculturegovau/agds-next/pull/399) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-06-15.mdx
+++ b/docs/content/updates/2022-06-15.mdx
@@ -14,7 +14,7 @@ description: Added support for React 18. Various bug fixes and improvements.
 ## Breaking Changes
 
 - `@ag.ds-next/text`: Moved `TextLink` and `TextLinkExternal` from `@ag.ds-next/text` to a new package `@ag.ds-next/text-link`. Please update imports accordingly.
-- `@ag.ds-next/core`: The `linkComponent` prop has been updated to support refs. Please wrap your `linkComponent` in `forwardRef` to avoid any warnings and errors. As an example you can the design systems [next.js example link component](https://github.com/steelthreads/agds-next/blob/main/example-site/components/LinkComponent.tsx)
+- `@ag.ds-next/core`: The `linkComponent` prop has been updated to support refs. Please wrap your `linkComponent` in `forwardRef` to avoid any warnings and errors. As an example you can the design systems [next.js example link component](https://github.com/agriculture-gov-au/agds-next/blob/main/example-site/components/LinkComponent.tsx)
 - `@ag.ds-next/content`: The `Content` component in has been replaced with 2 new components: `PageContent` and `SectionContent`. Please update usage accordingly.
 
 ## Updates
@@ -106,7 +106,7 @@ description: Added support for React 18. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-15), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/399) in the related PR (https://github.com/steelthreads/agds-next/pull/399) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-15), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/399) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/399) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-06-28.mdx
+++ b/docs/content/updates/2022-06-28.mdx
@@ -55,7 +55,7 @@ description: New branding for Department of Agriculture, Fisheries and Forestry.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/466) in the related PR (https://github.com/steelthreads/agds-next/pull/466) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-28), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/466) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/466) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-06-28.mdx
+++ b/docs/content/updates/2022-06-28.mdx
@@ -55,7 +55,7 @@ description: New branding for Department of Agriculture, Fisheries and Forestry.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-28), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/466) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/466) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-28), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/466) in the related PR (https://github.com/agriculturegovau/agds-next/pull/466) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-07-27.mdx
+++ b/docs/content/updates/2022-07-27.mdx
@@ -301,7 +301,7 @@ In this release, we rethought our `<Columns />` component, improved many of our 
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-07-27), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/499) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/499) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-07-27), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/499) in the related PR (https://github.com/agriculturegovau/agds-next/pull/499) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-07-27.mdx
+++ b/docs/content/updates/2022-07-27.mdx
@@ -301,7 +301,7 @@ In this release, we rethought our `<Columns />` component, improved many of our 
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-07-27), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/499) in the related PR (https://github.com/steelthreads/agds-next/pull/499) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-07-27), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/499) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/499) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-08-26.mdx
+++ b/docs/content/updates/2022-08-26.mdx
@@ -214,7 +214,7 @@ Otherwise you **must** follow these steps when upgrading:
 </Box>
 ```
 
-Take a look at [Storybook](/storybook/index.html?path=/story/navigation-mainnav--header-right-links) and the [Storybook code](https://github.com/steelthreads/agds-next/blob/main/packages/main-nav/src/MainNav.stories.tsx) for more references.
+Take a look at [Storybook](/storybook/index.html?path=/story/navigation-mainnav--header-right-links) and the [Storybook code](https://github.com/agriculture-gov-au/agds-next/blob/main/packages/main-nav/src/MainNav.stories.tsx) for more references.
 
 If you have any questions, please reach out to Jordan Overbye or Nathan Simpson in the Design System team.
 

--- a/docs/content/updates/2022-08-26.mdx
+++ b/docs/content/updates/2022-08-26.mdx
@@ -214,7 +214,7 @@ Otherwise you **must** follow these steps when upgrading:
 </Box>
 ```
 
-Take a look at [Storybook](/storybook/index.html?path=/story/navigation-mainnav--header-right-links) and the [Storybook code](https://github.com/agriculture-gov-au/agds-next/blob/main/packages/main-nav/src/MainNav.stories.tsx) for more references.
+Take a look at [Storybook](/storybook/index.html?path=/story/navigation-mainnav--header-right-links) and the [Storybook code](https://github.com/agriculturegovau/agds-next/blob/main/packages/main-nav/src/MainNav.stories.tsx) for more references.
 
 If you have any questions, please reach out to Jordan Overbye or Nathan Simpson in the Design System team.
 

--- a/docs/content/updates/2023-01-04.mdx
+++ b/docs/content/updates/2023-01-04.mdx
@@ -168,7 +168,7 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-04), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/818) in the related PR (https://github.com/steelthreads/agds-next/pull/818) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-04), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/818) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/818) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2023-01-04.mdx
+++ b/docs/content/updates/2023-01-04.mdx
@@ -168,7 +168,7 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-04), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/818) in the related PR (https://github.com/agriculture-gov-au/agds-next/pull/818) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-04), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/818) in the related PR (https://github.com/agriculturegovau/agds-next/pull/818) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2023-01-09-beta.mdx
+++ b/docs/content/updates/2023-01-09-beta.mdx
@@ -65,4 +65,4 @@ This will result in changes that look similar to the following:
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-09-beta), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/908) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/908) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-09-beta), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/908) in the [related PR](https://github.com/agriculturegovau/agds-next/pull/908) for this release.

--- a/docs/content/updates/2023-01-09-beta.mdx
+++ b/docs/content/updates/2023-01-09-beta.mdx
@@ -65,4 +65,4 @@ This will result in changes that look similar to the following:
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-09-beta), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/908) in the [related PR](https://github.com/steelthreads/agds-next/pull/908) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-09-beta), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/908) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/908) for this release.

--- a/docs/content/updates/2023-01-30.mdx
+++ b/docs/content/updates/2023-01-30.mdx
@@ -45,4 +45,4 @@ A simple input for selecting files in a form. The `FileInput` component is a wra
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-30), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/924) in the [related PR](https://github.com/steelthreads/agds-next/pull/924) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-30), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/924) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/924) for this release.

--- a/docs/content/updates/2023-01-30.mdx
+++ b/docs/content/updates/2023-01-30.mdx
@@ -45,4 +45,4 @@ A simple input for selecting files in a form. The `FileInput` component is a wra
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-30), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/924) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/924) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-01-30), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/924) in the [related PR](https://github.com/agriculturegovau/agds-next/pull/924) for this release.

--- a/docs/content/updates/2023-02-17.mdx
+++ b/docs/content/updates/2023-02-17.mdx
@@ -56,4 +56,4 @@ User avatars help to quickly identify people in the system.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-17), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/947) in the [related PR](https://github.com/steelthreads/agds-next/pull/947) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-17), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/947) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/947) for this release.

--- a/docs/content/updates/2023-02-17.mdx
+++ b/docs/content/updates/2023-02-17.mdx
@@ -56,4 +56,4 @@ User avatars help to quickly identify people in the system.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-17), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/947) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/947) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-17), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/947) in the [related PR](https://github.com/agriculturegovau/agds-next/pull/947) for this release.

--- a/docs/content/updates/2023-02-23.mdx
+++ b/docs/content/updates/2023-02-23.mdx
@@ -8,15 +8,15 @@ description: Various bug fixes and improvements.
 
 ### [Avatar](/components/avatar)
 
-- Fixed flex shrinking bug ([PR #972](https://github.com/agriculture-gov-au/agds-next/pull/972))
+- Fixed flex shrinking bug ([PR #972](https://github.com/agriculturegovau/agds-next/pull/972))
 
 ### [Button](/components/button)
 
-- Replaced transparent background in the `secondary` variant from `transparent` with `body` background colour. ([PR #974](https://github.com/agriculture-gov-au/agds-next/pull/974))
+- Replaced transparent background in the `secondary` variant from `transparent` with `body` background colour. ([PR #974](https://github.com/agriculturegovau/agds-next/pull/974))
 
 ### [File Input](/components/file-input)
 
-- Updated file selector button size from `sm` to `md` ([PR #984](https://github.com/agriculture-gov-au/agds-next/pull/984))
+- Updated file selector button size from `sm` to `md` ([PR #984](https://github.com/agriculturegovau/agds-next/pull/984))
 
 ## Released packages
 
@@ -26,4 +26,4 @@ description: Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-23), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/978) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/978) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-23), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/978) in the [related PR](https://github.com/agriculturegovau/agds-next/pull/978) for this release.

--- a/docs/content/updates/2023-02-23.mdx
+++ b/docs/content/updates/2023-02-23.mdx
@@ -8,15 +8,15 @@ description: Various bug fixes and improvements.
 
 ### [Avatar](/components/avatar)
 
-- Fixed flex shrinking bug ([PR #972](https://github.com/steelthreads/agds-next/pull/972))
+- Fixed flex shrinking bug ([PR #972](https://github.com/agriculture-gov-au/agds-next/pull/972))
 
 ### [Button](/components/button)
 
-- Replaced transparent background in the `secondary` variant from `transparent` with `body` background colour. ([PR #974](https://github.com/steelthreads/agds-next/pull/974))
+- Replaced transparent background in the `secondary` variant from `transparent` with `body` background colour. ([PR #974](https://github.com/agriculture-gov-au/agds-next/pull/974))
 
 ### [File Input](/components/file-input)
 
-- Updated file selector button size from `sm` to `md` ([PR #984](https://github.com/steelthreads/agds-next/pull/984))
+- Updated file selector button size from `sm` to `md` ([PR #984](https://github.com/agriculture-gov-au/agds-next/pull/984))
 
 ## Released packages
 
@@ -26,4 +26,4 @@ description: Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/978) in the [related PR](https://github.com/steelthreads/agds-next/pull/978) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-02-23), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/978) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/978) for this release.

--- a/docs/content/updates/2023-03-20.mdx
+++ b/docs/content/updates/2023-03-20.mdx
@@ -8,88 +8,88 @@ description: Extended the functionality of Date picker and Date range picker, im
 
 ### [Autocomplete](/components/autocomplete)
 
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
 
 ### [Box](/components/box)
 
-- Updated the `palette` prop to accept responsive values. For example `<Box palette={["dark", "light"]} />`. ([PR #1021](https://github.com/steelthreads/agds-next/pull/1021))
+- Updated the `palette` prop to accept responsive values. For example `<Box palette={["dark", "light"]} />`. ([PR #1021](https://github.com/agriculture-gov-au/agds-next/pull/1021))
 
 ### [Combobox](/components/combobox)
 
-- Fixed bug where the dropdown trigger button and clear button were not being marked or shown as disabled ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
+- Fixed bug where the dropdown trigger button and clear button were not being marked or shown as disabled ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
 
 ### [Control Input](/components/control-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
 
 ### [Core](/components/core)
 
-- Removed dependency to Reach UI as it is no longer being maintained. The logic from `@reach/auto-id` has been forked and copied into the repo. ([PR #1002](https://github.com/steelthreads/agds-next/pull/1002))
+- Removed dependency to Reach UI as it is no longer being maintained. The logic from `@reach/auto-id` has been forked and copied into the repo. ([PR #1002](https://github.com/agriculture-gov-au/agds-next/pull/1002))
 
 ### [Date picker](/components/date-picker#date-picker)
 
-- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/steelthreads/agds-next/pull/1008))
-- Added new prop `onInputChange` which can be used to track the value of the text input ([PR #997](https://github.com/steelthreads/agds-next/pull/997))
-- Updated the type of the `value` prop so it can accept string (which represents the value of the text input) ([PR #997](https://github.com/steelthreads/agds-next/pull/997))
-- Removed unused prop `placeholder` ([PR #1016](https://github.com/steelthreads/agds-next/pull/1016))
-- Removed options `xs` and `sm` from `maxWidth` prop. These widths were too small to be used in this component. ([PR #1016](https://github.com/steelthreads/agds-next/pull/1016))
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
-- Improved test coverage ([PR #999](https://github.com/steelthreads/agds-next/pull/999))
+- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculture-gov-au/agds-next/pull/1008))
+- Added new prop `onInputChange` which can be used to track the value of the text input ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))
+- Updated the type of the `value` prop so it can accept string (which represents the value of the text input) ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))
+- Removed unused prop `placeholder` ([PR #1016](https://github.com/agriculture-gov-au/agds-next/pull/1016))
+- Removed options `xs` and `sm` from `maxWidth` prop. These widths were too small to be used in this component. ([PR #1016](https://github.com/agriculture-gov-au/agds-next/pull/1016))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved test coverage ([PR #999](https://github.com/agriculture-gov-au/agds-next/pull/999))
 
 ### [Date range picker](/components/date-picker#date-range-picker)
 
-- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/steelthreads/agds-next/pull/1008))
-- Updated the type of the `value` prop so it can accept string (which represents the value of the text inputs) ([PR #997](https://github.com/steelthreads/agds-next/pull/997))- Added new prop `onFromInputChange` and `onToInputChange` which can be used to track the value of the text inputs ([PR #997](https://github.com/steelthreads/agds-next/pull/997))
-- Added support for a legend to be supplied via a new `legend` prop. If no legend is supplied, a default legend of `Date range` will be rendered but will be visually hidden. ([PR #1000](https://github.com/steelthreads/agds-next/pull/1000))
-- Added support for hint text via the `hint` prop ([PR #1000](https://github.com/steelthreads/agds-next/pull/1000))
-- Added support for an invalid state via the `fromInvalid`, `toInvalid` and `message` prop ([PR #1000](https://github.com/steelthreads/agds-next/pull/1000))
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
-- Improved test coverage ([PR #999](https://github.com/steelthreads/agds-next/pull/999))
+- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculture-gov-au/agds-next/pull/1008))
+- Updated the type of the `value` prop so it can accept string (which represents the value of the text inputs) ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))- Added new prop `onFromInputChange` and `onToInputChange` which can be used to track the value of the text inputs ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))
+- Added support for a legend to be supplied via a new `legend` prop. If no legend is supplied, a default legend of `Date range` will be rendered but will be visually hidden. ([PR #1000](https://github.com/agriculture-gov-au/agds-next/pull/1000))
+- Added support for hint text via the `hint` prop ([PR #1000](https://github.com/agriculture-gov-au/agds-next/pull/1000))
+- Added support for an invalid state via the `fromInvalid`, `toInvalid` and `message` prop ([PR #1000](https://github.com/agriculture-gov-au/agds-next/pull/1000))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved test coverage ([PR #999](https://github.com/agriculture-gov-au/agds-next/pull/999))
 
 ### [Field](/components/field)
 
-- Updated behaviour of the `secondaryLabel` prop so it will prepend any text to the label instead of replacing default secondary label "(optional)". ([PR #1008](https://github.com/steelthreads/agds-next/pull/1008))
-- Added `className` prop to `FieldLabel` ([PR #998](https://github.com/steelthreads/agds-next/pull/998))
-- Fixed typos in hook `useScrollToField` ([PR #998](https://github.com/steelthreads/agds-next/pull/998))
-- Exported component props and added comments to props ([PR #998](https://github.com/steelthreads/agds-next/pull/998))
+- Updated behaviour of the `secondaryLabel` prop so it will prepend any text to the label instead of replacing default secondary label "(optional)". ([PR #1008](https://github.com/agriculture-gov-au/agds-next/pull/1008))
+- Added `className` prop to `FieldLabel` ([PR #998](https://github.com/agriculture-gov-au/agds-next/pull/998))
+- Fixed typos in hook `useScrollToField` ([PR #998](https://github.com/agriculture-gov-au/agds-next/pull/998))
+- Exported component props and added comments to props ([PR #998](https://github.com/agriculture-gov-au/agds-next/pull/998))
 
 ### [File input](/components/file-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
 
 ### [Icon](/components/icon)
 
-- Added new icons `ChevronsUpDownIcon`, `EmailIcon`, `FacebookIcon`, `InstagramIcon`, `LinkedInIcon`, `WebsiteIcon` and `TwitterIcon`. ([PR #1005](https://github.com/steelthreads/agds-next/pull/1005))
+- Added new icons `ChevronsUpDownIcon`, `EmailIcon`, `FacebookIcon`, `InstagramIcon`, `LinkedInIcon`, `WebsiteIcon` and `TwitterIcon`. ([PR #1005](https://github.com/agriculture-gov-au/agds-next/pull/1005))
 
 ### [Search input](/components/search-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
 
 ### [Side nav](/components/side-nav)
 
-- Updated interface of link list items as per latest designs ([PR #1023](https://github.com/steelthreads/agds-next/pull/1023))
-- Removed exports of primitive components and modular storybook example ([PR #1023](https://github.com/steelthreads/agds-next/pull/1023))
+- Updated interface of link list items as per latest designs ([PR #1023](https://github.com/agriculture-gov-au/agds-next/pull/1023))
+- Removed exports of primitive components and modular storybook example ([PR #1023](https://github.com/agriculture-gov-au/agds-next/pull/1023))
 
 ### [Summary list](/components/summary-list)
 
-- Fixed a text colour bug when this component was placed inside dark palette. This was done by adding an explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`. ([PR #1022](https://github.com/steelthreads/agds-next/pull/1022))
+- Fixed a text colour bug when this component was placed inside dark palette. This was done by adding an explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`. ([PR #1022](https://github.com/agriculture-gov-au/agds-next/pull/1022))
 
 ### [Table](/components/table)
 
-- Add support for `id` prop ([PR #1010](https://github.com/steelthreads/agds-next/pull/1010))
-- Add support for `table-layout` prop ([PR #1015](https://github.com/steelthreads/agds-next/pull/1015))
-- Add support for `aria-labelledby` and `aria-describedby` props ([PR #1007](https://github.com/steelthreads/agds-next/pull/1007))
-- Widen types for column widths ([PR #1015](https://github.com/steelthreads/agds-next/pull/1015))
-- `TableCell` supports usage as a row header (th) ([PR #1017](https://github.com/steelthreads/agds-next/pull/1017))
+- Add support for `id` prop ([PR #1010](https://github.com/agriculture-gov-au/agds-next/pull/1010))
+- Add support for `table-layout` prop ([PR #1015](https://github.com/agriculture-gov-au/agds-next/pull/1015))
+- Add support for `aria-labelledby` and `aria-describedby` props ([PR #1007](https://github.com/agriculture-gov-au/agds-next/pull/1007))
+- Widen types for column widths ([PR #1015](https://github.com/agriculture-gov-au/agds-next/pull/1015))
+- `TableCell` supports usage as a row header (th) ([PR #1017](https://github.com/agriculture-gov-au/agds-next/pull/1017))
 
 ### [Text input](/components/text-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
 
 ### [Textarea](/components/textarea)
 
-- Improved styles for disabled state ([PR #981](https://github.com/steelthreads/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
 
 ---
 
@@ -101,4 +101,4 @@ description: Extended the functionality of Date picker and Date range picker, im
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-20), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/992) in the [related PR](https://github.com/steelthreads/agds-next/pull/992) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-20), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/992) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/992) for this release.

--- a/docs/content/updates/2023-03-20.mdx
+++ b/docs/content/updates/2023-03-20.mdx
@@ -8,88 +8,88 @@ description: Extended the functionality of Date picker and Date range picker, im
 
 ### [Autocomplete](/components/autocomplete)
 
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
 
 ### [Box](/components/box)
 
-- Updated the `palette` prop to accept responsive values. For example `<Box palette={["dark", "light"]} />`. ([PR #1021](https://github.com/agriculture-gov-au/agds-next/pull/1021))
+- Updated the `palette` prop to accept responsive values. For example `<Box palette={["dark", "light"]} />`. ([PR #1021](https://github.com/agriculturegovau/agds-next/pull/1021))
 
 ### [Combobox](/components/combobox)
 
-- Fixed bug where the dropdown trigger button and clear button were not being marked or shown as disabled ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Fixed bug where the dropdown trigger button and clear button were not being marked or shown as disabled ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
 
 ### [Control Input](/components/control-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
 
 ### [Core](/components/core)
 
-- Removed dependency to Reach UI as it is no longer being maintained. The logic from `@reach/auto-id` has been forked and copied into the repo. ([PR #1002](https://github.com/agriculture-gov-au/agds-next/pull/1002))
+- Removed dependency to Reach UI as it is no longer being maintained. The logic from `@reach/auto-id` has been forked and copied into the repo. ([PR #1002](https://github.com/agriculturegovau/agds-next/pull/1002))
 
 ### [Date picker](/components/date-picker#date-picker)
 
-- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculture-gov-au/agds-next/pull/1008))
-- Added new prop `onInputChange` which can be used to track the value of the text input ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))
-- Updated the type of the `value` prop so it can accept string (which represents the value of the text input) ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))
-- Removed unused prop `placeholder` ([PR #1016](https://github.com/agriculture-gov-au/agds-next/pull/1016))
-- Removed options `xs` and `sm` from `maxWidth` prop. These widths were too small to be used in this component. ([PR #1016](https://github.com/agriculture-gov-au/agds-next/pull/1016))
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
-- Improved test coverage ([PR #999](https://github.com/agriculture-gov-au/agds-next/pull/999))
+- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
+- Added new prop `onInputChange` which can be used to track the value of the text input ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))
+- Updated the type of the `value` prop so it can accept string (which represents the value of the text input) ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))
+- Removed unused prop `placeholder` ([PR #1016](https://github.com/agriculturegovau/agds-next/pull/1016))
+- Removed options `xs` and `sm` from `maxWidth` prop. These widths were too small to be used in this component. ([PR #1016](https://github.com/agriculturegovau/agds-next/pull/1016))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
+- Improved test coverage ([PR #999](https://github.com/agriculturegovau/agds-next/pull/999))
 
 ### [Date range picker](/components/date-picker#date-range-picker)
 
-- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculture-gov-au/agds-next/pull/1008))
-- Updated the type of the `value` prop so it can accept string (which represents the value of the text inputs) ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))- Added new prop `onFromInputChange` and `onToInputChange` which can be used to track the value of the text inputs ([PR #997](https://github.com/agriculture-gov-au/agds-next/pull/997))
-- Added support for a legend to be supplied via a new `legend` prop. If no legend is supplied, a default legend of `Date range` will be rendered but will be visually hidden. ([PR #1000](https://github.com/agriculture-gov-au/agds-next/pull/1000))
-- Added support for hint text via the `hint` prop ([PR #1000](https://github.com/agriculture-gov-au/agds-next/pull/1000))
-- Added support for an invalid state via the `fromInvalid`, `toInvalid` and `message` prop ([PR #1000](https://github.com/agriculture-gov-au/agds-next/pull/1000))
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
-- Improved test coverage ([PR #999](https://github.com/agriculture-gov-au/agds-next/pull/999))
+- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
+- Updated the type of the `value` prop so it can accept string (which represents the value of the text inputs) ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))- Added new prop `onFromInputChange` and `onToInputChange` which can be used to track the value of the text inputs ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))
+- Added support for a legend to be supplied via a new `legend` prop. If no legend is supplied, a default legend of `Date range` will be rendered but will be visually hidden. ([PR #1000](https://github.com/agriculturegovau/agds-next/pull/1000))
+- Added support for hint text via the `hint` prop ([PR #1000](https://github.com/agriculturegovau/agds-next/pull/1000))
+- Added support for an invalid state via the `fromInvalid`, `toInvalid` and `message` prop ([PR #1000](https://github.com/agriculturegovau/agds-next/pull/1000))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
+- Improved test coverage ([PR #999](https://github.com/agriculturegovau/agds-next/pull/999))
 
 ### [Field](/components/field)
 
-- Updated behaviour of the `secondaryLabel` prop so it will prepend any text to the label instead of replacing default secondary label "(optional)". ([PR #1008](https://github.com/agriculture-gov-au/agds-next/pull/1008))
-- Added `className` prop to `FieldLabel` ([PR #998](https://github.com/agriculture-gov-au/agds-next/pull/998))
-- Fixed typos in hook `useScrollToField` ([PR #998](https://github.com/agriculture-gov-au/agds-next/pull/998))
-- Exported component props and added comments to props ([PR #998](https://github.com/agriculture-gov-au/agds-next/pull/998))
+- Updated behaviour of the `secondaryLabel` prop so it will prepend any text to the label instead of replacing default secondary label "(optional)". ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
+- Added `className` prop to `FieldLabel` ([PR #998](https://github.com/agriculturegovau/agds-next/pull/998))
+- Fixed typos in hook `useScrollToField` ([PR #998](https://github.com/agriculturegovau/agds-next/pull/998))
+- Exported component props and added comments to props ([PR #998](https://github.com/agriculturegovau/agds-next/pull/998))
 
 ### [File input](/components/file-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
 
 ### [Icon](/components/icon)
 
-- Added new icons `ChevronsUpDownIcon`, `EmailIcon`, `FacebookIcon`, `InstagramIcon`, `LinkedInIcon`, `WebsiteIcon` and `TwitterIcon`. ([PR #1005](https://github.com/agriculture-gov-au/agds-next/pull/1005))
+- Added new icons `ChevronsUpDownIcon`, `EmailIcon`, `FacebookIcon`, `InstagramIcon`, `LinkedInIcon`, `WebsiteIcon` and `TwitterIcon`. ([PR #1005](https://github.com/agriculturegovau/agds-next/pull/1005))
 
 ### [Search input](/components/search-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
 
 ### [Side nav](/components/side-nav)
 
-- Updated interface of link list items as per latest designs ([PR #1023](https://github.com/agriculture-gov-au/agds-next/pull/1023))
-- Removed exports of primitive components and modular storybook example ([PR #1023](https://github.com/agriculture-gov-au/agds-next/pull/1023))
+- Updated interface of link list items as per latest designs ([PR #1023](https://github.com/agriculturegovau/agds-next/pull/1023))
+- Removed exports of primitive components and modular storybook example ([PR #1023](https://github.com/agriculturegovau/agds-next/pull/1023))
 
 ### [Summary list](/components/summary-list)
 
-- Fixed a text colour bug when this component was placed inside dark palette. This was done by adding an explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`. ([PR #1022](https://github.com/agriculture-gov-au/agds-next/pull/1022))
+- Fixed a text colour bug when this component was placed inside dark palette. This was done by adding an explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`. ([PR #1022](https://github.com/agriculturegovau/agds-next/pull/1022))
 
 ### [Table](/components/table)
 
-- Add support for `id` prop ([PR #1010](https://github.com/agriculture-gov-au/agds-next/pull/1010))
-- Add support for `table-layout` prop ([PR #1015](https://github.com/agriculture-gov-au/agds-next/pull/1015))
-- Add support for `aria-labelledby` and `aria-describedby` props ([PR #1007](https://github.com/agriculture-gov-au/agds-next/pull/1007))
-- Widen types for column widths ([PR #1015](https://github.com/agriculture-gov-au/agds-next/pull/1015))
-- `TableCell` supports usage as a row header (th) ([PR #1017](https://github.com/agriculture-gov-au/agds-next/pull/1017))
+- Add support for `id` prop ([PR #1010](https://github.com/agriculturegovau/agds-next/pull/1010))
+- Add support for `table-layout` prop ([PR #1015](https://github.com/agriculturegovau/agds-next/pull/1015))
+- Add support for `aria-labelledby` and `aria-describedby` props ([PR #1007](https://github.com/agriculturegovau/agds-next/pull/1007))
+- Widen types for column widths ([PR #1015](https://github.com/agriculturegovau/agds-next/pull/1015))
+- `TableCell` supports usage as a row header (th) ([PR #1017](https://github.com/agriculturegovau/agds-next/pull/1017))
 
 ### [Text input](/components/text-input)
 
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
 
 ### [Textarea](/components/textarea)
 
-- Improved styles for disabled state ([PR #981](https://github.com/agriculture-gov-au/agds-next/pull/981))
+- Improved styles for disabled state ([PR #981](https://github.com/agriculturegovau/agds-next/pull/981))
 
 ---
 
@@ -101,4 +101,4 @@ description: Extended the functionality of Date picker and Date range picker, im
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-20), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/992) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/992) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-20), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/992) in the [related PR](https://github.com/agriculturegovau/agds-next/pull/992) for this release.

--- a/docs/content/updates/2023-03-30.mdx
+++ b/docs/content/updates/2023-03-30.mdx
@@ -8,15 +8,15 @@ description: Minor bug fixes and improvements.
 
 ### [Avatar](/components/avatar)
 
-- Render a span component ([PR #1026](https://github.com/agriculture-gov-au/agds-next/pull/1026))
+- Render a span component ([PR #1026](https://github.com/agriculturegovau/agds-next/pull/1026))
 
 ### [Select](/components/select)
 
-- Updated styles for disabled state to fix default browser styles overrides ([PR #1039](https://github.com/agriculture-gov-au/agds-next/pull/1039))
+- Updated styles for disabled state to fix default browser styles overrides ([PR #1039](https://github.com/agriculturegovau/agds-next/pull/1039))
 
 ### [Skip link](/components/skip-link)
 
-- Added high z-index to ensure the element is always placed above other elements on the page ([PR #1034](https://github.com/agriculture-gov-au/agds-next/pull/1034))
+- Added high z-index to ensure the element is always placed above other elements on the page ([PR #1034](https://github.com/agriculturegovau/agds-next/pull/1034))
 
 ---
 
@@ -28,4 +28,4 @@ description: Minor bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-30), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/1028) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1028) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-30), you can also view the [verbose change log](https://github.com/agriculturegovau/agds-next/pull/1028) in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1028) for this release.

--- a/docs/content/updates/2023-03-30.mdx
+++ b/docs/content/updates/2023-03-30.mdx
@@ -8,15 +8,15 @@ description: Minor bug fixes and improvements.
 
 ### [Avatar](/components/avatar)
 
-- Render a span component ([PR #1026](https://github.com/steelthreads/agds-next/pull/1026))
+- Render a span component ([PR #1026](https://github.com/agriculture-gov-au/agds-next/pull/1026))
 
 ### [Select](/components/select)
 
-- Updated styles for disabled state to fix default browser styles overrides ([PR #1039](https://github.com/steelthreads/agds-next/pull/1039))
+- Updated styles for disabled state to fix default browser styles overrides ([PR #1039](https://github.com/agriculture-gov-au/agds-next/pull/1039))
 
 ### [Skip link](/components/skip-link)
 
-- Added high z-index to ensure the element is always placed above other elements on the page ([PR #1034](https://github.com/steelthreads/agds-next/pull/1034))
+- Added high z-index to ensure the element is always placed above other elements on the page ([PR #1034](https://github.com/agriculture-gov-au/agds-next/pull/1034))
 
 ---
 
@@ -28,4 +28,4 @@ description: Minor bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-30), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/1028) in the [related PR](https://github.com/steelthreads/agds-next/pull/1028) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-03-30), you can also view the [verbose change log](https://github.com/agriculture-gov-au/agds-next/pull/1028) in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1028) for this release.

--- a/docs/content/updates/2023-04-19.mdx
+++ b/docs/content/updates/2023-04-19.mdx
@@ -8,44 +8,44 @@ description: Added multi-select combobox, extended progress indicator, various b
 
 ### [Autocomplete](/components/autocomplete)
 
-- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/steelthreads/agds-next/pull/993))
-- Updated documentation ([PR #993](https://github.com/steelthreads/agds-next/pull/993))
-- Fixed asynchronous test displaying a warning for performing a state update that is not wrapped in act ([PR #993](https://github.com/steelthreads/agds-next/pull/993))
+- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
+- Updated documentation ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
+- Fixed asynchronous test displaying a warning for performing a state update that is not wrapped in act ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
 
 ### [Badge](/components/badge)
 
-- Added support for the `aria-hidden` prop in `NotificationBadge` ([PR #1042](https://github.com/steelthreads/agds-next/pull/1042))
+- Added support for the `aria-hidden` prop in `NotificationBadge` ([PR #1042](https://github.com/agriculture-gov-au/agds-next/pull/1042))
 
 ### [Combobox](/components/combobox)
 
-- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/steelthreads/agds-next/pull/993))
-- Created new component `ComboboxMulti` which allows users to choose multiple items from a predefined list of options ([PR #993](https://github.com/steelthreads/agds-next/pull/993))
-- Created new component `ComboboxAsyncMulti` which allows users to choose multiple items from a list of options that needs to be fetched over the network ([PR #993](https://github.com/steelthreads/agds-next/pull/993))
+- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
+- Created new component `ComboboxMulti` which allows users to choose multiple items from a predefined list of options ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
+- Created new component `ComboboxAsyncMulti` which allows users to choose multiple items from a list of options that needs to be fetched over the network ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
 
 ### [Date picker](/components/date-picker)
 
-- Fixed text colour bug when using in dark palette ([PR #1067](https://github.com/steelthreads/agds-next/pull/1067))
+- Fixed text colour bug when using in dark palette ([PR #1067](https://github.com/agriculture-gov-au/agds-next/pull/1067))
 
 ### [Field](/components/field)
 
-- Update wrapping behaviour of label ([PR #1041](https://github.com/steelthreads/agds-next/pull/1041))
-- Extended the function returned from from `useScrollToField` to accept either a mouse event or an ID of a form field element. This change makes it easier for consumers to scroll and focus a form field on the same page in situations such as when a form first renders. ([PR #1038](https://github.com/steelthreads/agds-next/pull/1038))
+- Update wrapping behaviour of label ([PR #1041](https://github.com/agriculture-gov-au/agds-next/pull/1041))
+- Extended the function returned from from `useScrollToField` to accept either a mouse event or an ID of a form field element. This change makes it easier for consumers to scroll and focus a form field on the same page in situations such as when a form first renders. ([PR #1038](https://github.com/agriculture-gov-au/agds-next/pull/1038))
 
 ### [Icon](/components/icon)
 
-- Added new icons `HomeIcon` and `ExitIcon` ([PR #1062](https://github.com/steelthreads/agds-next/pull/1062))
+- Added new icons `HomeIcon` and `ExitIcon` ([PR #1062](https://github.com/agriculture-gov-au/agds-next/pull/1062))
 
 ### [Page alert](/components/page-alert)
 
-- Added flex growing to the content area ([PR #1066](https://github.com/steelthreads/agds-next/pull/1066))
+- Added flex growing to the content area ([PR #1066](https://github.com/agriculture-gov-au/agds-next/pull/1066))
 
 ### [Progress indicator](/components/progress-indicator)
 
-- Added new status `started` which can be used to indicate that the step has been partially completed but is not active or selected ([PR #1068](https://github.com/steelthreads/agds-next/pull/1068))
+- Added new status `started` which can be used to indicate that the step has been partially completed but is not active or selected ([PR #1068](https://github.com/agriculture-gov-au/agds-next/pull/1068))
 
 ### [Table](/components/table)
 
-- Created new component `TableHeaderSortable` which can be used in place of `TableHeader` when users can click a column header to sort the table ([PR #1047](https://github.com/steelthreads/agds-next/pull/1047))
+- Created new component `TableHeaderSortable` which can be used in place of `TableHeader` when users can click a column header to sort the table ([PR #1047](https://github.com/agriculture-gov-au/agds-next/pull/1047))
 
 ## Released packages
 
@@ -55,4 +55,4 @@ description: Added multi-select combobox, extended progress indicator, various b
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-19), you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1043) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-19), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1043) for this release.

--- a/docs/content/updates/2023-04-19.mdx
+++ b/docs/content/updates/2023-04-19.mdx
@@ -8,44 +8,44 @@ description: Added multi-select combobox, extended progress indicator, various b
 
 ### [Autocomplete](/components/autocomplete)
 
-- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
-- Updated documentation ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
-- Fixed asynchronous test displaying a warning for performing a state update that is not wrapped in act ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
+- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/agriculturegovau/agds-next/pull/993))
+- Updated documentation ([PR #993](https://github.com/agriculturegovau/agds-next/pull/993))
+- Fixed asynchronous test displaying a warning for performing a state update that is not wrapped in act ([PR #993](https://github.com/agriculturegovau/agds-next/pull/993))
 
 ### [Badge](/components/badge)
 
-- Added support for the `aria-hidden` prop in `NotificationBadge` ([PR #1042](https://github.com/agriculture-gov-au/agds-next/pull/1042))
+- Added support for the `aria-hidden` prop in `NotificationBadge` ([PR #1042](https://github.com/agriculturegovau/agds-next/pull/1042))
 
 ### [Combobox](/components/combobox)
 
-- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
-- Created new component `ComboboxMulti` which allows users to choose multiple items from a predefined list of options ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
-- Created new component `ComboboxAsyncMulti` which allows users to choose multiple items from a list of options that needs to be fetched over the network ([PR #993](https://github.com/agriculture-gov-au/agds-next/pull/993))
+- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern ([PR #993](https://github.com/agriculturegovau/agds-next/pull/993))
+- Created new component `ComboboxMulti` which allows users to choose multiple items from a predefined list of options ([PR #993](https://github.com/agriculturegovau/agds-next/pull/993))
+- Created new component `ComboboxAsyncMulti` which allows users to choose multiple items from a list of options that needs to be fetched over the network ([PR #993](https://github.com/agriculturegovau/agds-next/pull/993))
 
 ### [Date picker](/components/date-picker)
 
-- Fixed text colour bug when using in dark palette ([PR #1067](https://github.com/agriculture-gov-au/agds-next/pull/1067))
+- Fixed text colour bug when using in dark palette ([PR #1067](https://github.com/agriculturegovau/agds-next/pull/1067))
 
 ### [Field](/components/field)
 
-- Update wrapping behaviour of label ([PR #1041](https://github.com/agriculture-gov-au/agds-next/pull/1041))
-- Extended the function returned from from `useScrollToField` to accept either a mouse event or an ID of a form field element. This change makes it easier for consumers to scroll and focus a form field on the same page in situations such as when a form first renders. ([PR #1038](https://github.com/agriculture-gov-au/agds-next/pull/1038))
+- Update wrapping behaviour of label ([PR #1041](https://github.com/agriculturegovau/agds-next/pull/1041))
+- Extended the function returned from from `useScrollToField` to accept either a mouse event or an ID of a form field element. This change makes it easier for consumers to scroll and focus a form field on the same page in situations such as when a form first renders. ([PR #1038](https://github.com/agriculturegovau/agds-next/pull/1038))
 
 ### [Icon](/components/icon)
 
-- Added new icons `HomeIcon` and `ExitIcon` ([PR #1062](https://github.com/agriculture-gov-au/agds-next/pull/1062))
+- Added new icons `HomeIcon` and `ExitIcon` ([PR #1062](https://github.com/agriculturegovau/agds-next/pull/1062))
 
 ### [Page alert](/components/page-alert)
 
-- Added flex growing to the content area ([PR #1066](https://github.com/agriculture-gov-au/agds-next/pull/1066))
+- Added flex growing to the content area ([PR #1066](https://github.com/agriculturegovau/agds-next/pull/1066))
 
 ### [Progress indicator](/components/progress-indicator)
 
-- Added new status `started` which can be used to indicate that the step has been partially completed but is not active or selected ([PR #1068](https://github.com/agriculture-gov-au/agds-next/pull/1068))
+- Added new status `started` which can be used to indicate that the step has been partially completed but is not active or selected ([PR #1068](https://github.com/agriculturegovau/agds-next/pull/1068))
 
 ### [Table](/components/table)
 
-- Created new component `TableHeaderSortable` which can be used in place of `TableHeader` when users can click a column header to sort the table ([PR #1047](https://github.com/agriculture-gov-au/agds-next/pull/1047))
+- Created new component `TableHeaderSortable` which can be used in place of `TableHeader` when users can click a column header to sort the table ([PR #1047](https://github.com/agriculturegovau/agds-next/pull/1047))
 
 ## Released packages
 
@@ -55,4 +55,4 @@ description: Added multi-select combobox, extended progress indicator, various b
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-19), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1043) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-19), you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1043) for this release.

--- a/docs/content/updates/2023-04-21.mdx
+++ b/docs/content/updates/2023-04-21.mdx
@@ -8,12 +8,12 @@ description: Fixed controlled usage bug in multi-select combobox, added support 
 
 ### [Combobox](/components/combobox)
 
-- Fixed controlled usage bug where `value` and `onChange` props were not being used/called in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/steelthreads/agds-next/pull/1072))
-- Updated disabled state in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/steelthreads/agds-next/pull/1072))
+- Fixed controlled usage bug where `value` and `onChange` props were not being used/called in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/agriculture-gov-au/agds-next/pull/1072))
+- Updated disabled state in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/agriculture-gov-au/agds-next/pull/1072))
 
 ### [File upload](/components/file-upload)
 
-- Added support for `application/xml` and `text/xml` MIME types ([PR #1071](https://github.com/steelthreads/agds-next/pull/1071))
+- Added support for `application/xml` and `text/xml` MIME types ([PR #1071](https://github.com/agriculture-gov-au/agds-next/pull/1071))
 
 ## Released packages
 
@@ -23,4 +23,4 @@ description: Fixed controlled usage bug in multi-select combobox, added support 
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-21), you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1073) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-21), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1073) for this release.

--- a/docs/content/updates/2023-04-21.mdx
+++ b/docs/content/updates/2023-04-21.mdx
@@ -8,12 +8,12 @@ description: Fixed controlled usage bug in multi-select combobox, added support 
 
 ### [Combobox](/components/combobox)
 
-- Fixed controlled usage bug where `value` and `onChange` props were not being used/called in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/agriculture-gov-au/agds-next/pull/1072))
-- Updated disabled state in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/agriculture-gov-au/agds-next/pull/1072))
+- Fixed controlled usage bug where `value` and `onChange` props were not being used/called in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/agriculturegovau/agds-next/pull/1072))
+- Updated disabled state in `ComboboxMulti` and `ComboboxAsyncMulti` ([PR #1072](https://github.com/agriculturegovau/agds-next/pull/1072))
 
 ### [File upload](/components/file-upload)
 
-- Added support for `application/xml` and `text/xml` MIME types ([PR #1071](https://github.com/agriculture-gov-au/agds-next/pull/1071))
+- Added support for `application/xml` and `text/xml` MIME types ([PR #1071](https://github.com/agriculturegovau/agds-next/pull/1071))
 
 ## Released packages
 
@@ -23,4 +23,4 @@ description: Fixed controlled usage bug in multi-select combobox, added support 
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-21), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1073) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-04-21), you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1073) for this release.

--- a/docs/content/updates/2023-05-09.mdx
+++ b/docs/content/updates/2023-05-09.mdx
@@ -8,63 +8,63 @@ description: Initial release of App layout components, improved performance of a
 
 ### [Accordion](/components/accordion)
 
-- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ### [App layout](/components/app-layout)
 
-- Initial release of App layout, a collection of components that can be composed together to create a layout for the authenticated space. ([PR #1059](https://github.com/steelthreads/agds-next/pull/1059))
+- Initial release of App layout, a collection of components that can be composed together to create a layout for the authenticated space. ([PR #1059](https://github.com/agriculture-gov-au/agds-next/pull/1059))
 
 ### [Call to action](/components/call-to-action)
 
-- Removed icon animation on hover as it is inconsistent with AgDS interactions ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Removed icon animation on hover as it is inconsistent with AgDS interactions ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ### [Core](/components/core)
 
-- Added new border token `xxl` which has a value of `8px` ([PR #1095](https://github.com/steelthreads/agds-next/pull/1095))
+- Added new border token `xxl` which has a value of `8px` ([PR #1095](https://github.com/agriculture-gov-au/agds-next/pull/1095))
 
 ### [Combobox](/components/combobox)
 
-- Fixed exhaustive deps warning for the `onClear` function in `ComboboxAsyncMulti` ([PR #1076](https://github.com/steelthreads/agds-next/pull/1076))
+- Fixed exhaustive deps warning for the `onClear` function in `ComboboxAsyncMulti` ([PR #1076](https://github.com/agriculture-gov-au/agds-next/pull/1076))
 
 ### [Date picker](/components/date-picker)
 
-- Improved documentation examples and test coverage of `DateRangePicker` ([PR #1087](https://github.com/steelthreads/agds-next/pull/1087))
+- Improved documentation examples and test coverage of `DateRangePicker` ([PR #1087](https://github.com/agriculture-gov-au/agds-next/pull/1087))
 
 ### [Header](/components/header)
 
-- Updated header branding link size to match content ([PR #1101](https://github.com/steelthreads/agds-next/pull/1101))
+- Updated header branding link size to match content ([PR #1101](https://github.com/agriculture-gov-au/agds-next/pull/1101))
 
 ### [Icon](/components/icon)
 
-- Added new icons `ChevronsLeftIcon`, `ChevronsRightIcon` and `SettingsIcon` ([PR #1086](https://github.com/steelthreads/agds-next/pull/1086))
+- Added new icons `ChevronsLeftIcon`, `ChevronsRightIcon` and `SettingsIcon` ([PR #1086](https://github.com/agriculture-gov-au/agds-next/pull/1086))
 
 ### [Loading](/components/loading)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ### [Main nav](/components/main-nav)
 
-- Replaced custom inline icons with design system icons (`MenuIcon` and `CloseIcon`) ([PR #1080](https://github.com/steelthreads/agds-next/pull/1080))
+- Replaced custom inline icons with design system icons (`MenuIcon` and `CloseIcon`) ([PR #1080](https://github.com/agriculture-gov-au/agds-next/pull/1080))
 
 ### [Modal](/components/modal)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ### [Progress indicator](/components/progress-indicator)
 
-- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ### [Side nav](/components/side-nav)
 
-- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ### [Skeleton](/components/switch)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ### [Switch](/components/switch)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/steelthreads/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
 
 ## Released packages
 
@@ -74,4 +74,4 @@ description: Initial release of App layout components, improved performance of a
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-08), you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1078) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-08), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1078) for this release.

--- a/docs/content/updates/2023-05-09.mdx
+++ b/docs/content/updates/2023-05-09.mdx
@@ -8,63 +8,63 @@ description: Initial release of App layout components, improved performance of a
 
 ### [Accordion](/components/accordion)
 
-- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ### [App layout](/components/app-layout)
 
-- Initial release of App layout, a collection of components that can be composed together to create a layout for the authenticated space. ([PR #1059](https://github.com/agriculture-gov-au/agds-next/pull/1059))
+- Initial release of App layout, a collection of components that can be composed together to create a layout for the authenticated space. ([PR #1059](https://github.com/agriculturegovau/agds-next/pull/1059))
 
 ### [Call to action](/components/call-to-action)
 
-- Removed icon animation on hover as it is inconsistent with AgDS interactions ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Removed icon animation on hover as it is inconsistent with AgDS interactions ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ### [Core](/components/core)
 
-- Added new border token `xxl` which has a value of `8px` ([PR #1095](https://github.com/agriculture-gov-au/agds-next/pull/1095))
+- Added new border token `xxl` which has a value of `8px` ([PR #1095](https://github.com/agriculturegovau/agds-next/pull/1095))
 
 ### [Combobox](/components/combobox)
 
-- Fixed exhaustive deps warning for the `onClear` function in `ComboboxAsyncMulti` ([PR #1076](https://github.com/agriculture-gov-au/agds-next/pull/1076))
+- Fixed exhaustive deps warning for the `onClear` function in `ComboboxAsyncMulti` ([PR #1076](https://github.com/agriculturegovau/agds-next/pull/1076))
 
 ### [Date picker](/components/date-picker)
 
-- Improved documentation examples and test coverage of `DateRangePicker` ([PR #1087](https://github.com/agriculture-gov-au/agds-next/pull/1087))
+- Improved documentation examples and test coverage of `DateRangePicker` ([PR #1087](https://github.com/agriculturegovau/agds-next/pull/1087))
 
 ### [Header](/components/header)
 
-- Updated header branding link size to match content ([PR #1101](https://github.com/agriculture-gov-au/agds-next/pull/1101))
+- Updated header branding link size to match content ([PR #1101](https://github.com/agriculturegovau/agds-next/pull/1101))
 
 ### [Icon](/components/icon)
 
-- Added new icons `ChevronsLeftIcon`, `ChevronsRightIcon` and `SettingsIcon` ([PR #1086](https://github.com/agriculture-gov-au/agds-next/pull/1086))
+- Added new icons `ChevronsLeftIcon`, `ChevronsRightIcon` and `SettingsIcon` ([PR #1086](https://github.com/agriculturegovau/agds-next/pull/1086))
 
 ### [Loading](/components/loading)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ### [Main nav](/components/main-nav)
 
-- Replaced custom inline icons with design system icons (`MenuIcon` and `CloseIcon`) ([PR #1080](https://github.com/agriculture-gov-au/agds-next/pull/1080))
+- Replaced custom inline icons with design system icons (`MenuIcon` and `CloseIcon`) ([PR #1080](https://github.com/agriculturegovau/agds-next/pull/1080))
 
 ### [Modal](/components/modal)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ### [Progress indicator](/components/progress-indicator)
 
-- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ### [Side nav](/components/side-nav)
 
-- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Replaced chevron icon `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ### [Skeleton](/components/switch)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ### [Switch](/components/switch)
 
-- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculture-gov-au/agds-next/pull/1088))
+- Replaced `react-spring` animation with CSS animation ([PR #1088](https://github.com/agriculturegovau/agds-next/pull/1088))
 
 ## Released packages
 
@@ -74,4 +74,4 @@ description: Initial release of App layout components, improved performance of a
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-08), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1078) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-08), you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1078) for this release.

--- a/docs/content/updates/2023-05-15.mdx
+++ b/docs/content/updates/2023-05-15.mdx
@@ -8,8 +8,8 @@ description: Minor improvements and bug fixes to App layout components.
 
 ### [App layout](/components/app-layout)
 
-- Reduced spacing between user avatar and user name in `AppLayoutHeader` ([PR #1108](https://github.com/steelthreads/agds-next/pull/1108))
-- Fixed bug when server side rendering `AppLayoutSidebarDialog` ([PR #1111](https://github.com/steelthreads/agds-next/pull/1111))
+- Reduced spacing between user avatar and user name in `AppLayoutHeader` ([PR #1108](https://github.com/agriculture-gov-au/agds-next/pull/1108))
+- Fixed bug when server side rendering `AppLayoutSidebarDialog` ([PR #1111](https://github.com/agriculture-gov-au/agds-next/pull/1111))
 
 ## Released packages
 
@@ -19,4 +19,4 @@ description: Minor improvements and bug fixes to App layout components.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-15), you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1109) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-15), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1109) for this release.

--- a/docs/content/updates/2023-05-15.mdx
+++ b/docs/content/updates/2023-05-15.mdx
@@ -8,8 +8,8 @@ description: Minor improvements and bug fixes to App layout components.
 
 ### [App layout](/components/app-layout)
 
-- Reduced spacing between user avatar and user name in `AppLayoutHeader` ([PR #1108](https://github.com/agriculture-gov-au/agds-next/pull/1108))
-- Fixed bug when server side rendering `AppLayoutSidebarDialog` ([PR #1111](https://github.com/agriculture-gov-au/agds-next/pull/1111))
+- Reduced spacing between user avatar and user name in `AppLayoutHeader` ([PR #1108](https://github.com/agriculturegovau/agds-next/pull/1108))
+- Fixed bug when server side rendering `AppLayoutSidebarDialog` ([PR #1111](https://github.com/agriculturegovau/agds-next/pull/1111))
 
 ## Released packages
 
@@ -19,4 +19,4 @@ description: Minor improvements and bug fixes to App layout components.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-15), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1109) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-05-15), you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1109) for this release.

--- a/docs/content/updates/2023-06-12.mdx
+++ b/docs/content/updates/2023-06-12.mdx
@@ -8,13 +8,13 @@ description: Move nested components into their own entry points to improve docum
 
 ### [App layout](/components/app-layout)
 
-- Updated `AppLayoutFooterDivider` border color from `border` to `borderMuted` ([PR #1181](https://github.com/steelthreads/agds-next/pull/1181))
-- Adding missing aria dialog tags to mobile version of App layout sidebar ([PR #1119](https://github.com/steelthreads/agds-next/pull/1119))
+- Updated `AppLayoutFooterDivider` border color from `border` to `borderMuted` ([PR #1181](https://github.com/agriculture-gov-au/agds-next/pull/1181))
+- Adding missing aria dialog tags to mobile version of App layout sidebar ([PR #1119](https://github.com/agriculture-gov-au/agds-next/pull/1119))
 
 ### [Autocomplete](/components/autocomplete)
 
-- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/steelthreads/agds-next/pull/1123))
-- Added new prop `emptyResultsMessage` which can be used to display a message when no options match the users search term ([PR #1123](https://github.com/steelthreads/agds-next/pull/1123))
+- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculture-gov-au/agds-next/pull/1123))
+- Added new prop `emptyResultsMessage` which can be used to display a message when no options match the users search term ([PR #1123](https://github.com/agriculture-gov-au/agds-next/pull/1123))
 
 ### [Badge](/components/badge)
 
@@ -48,9 +48,9 @@ To upgrade, update the import when using these components.
 
 ### [Combobox](/components/combobox)
 
-- Remove `use-debounce` dependency ([PR #1131](https://github.com/steelthreads/agds-next/pull/1131))
-- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/steelthreads/agds-next/pull/1123))
-- Updated logic in the `splitLabel` helper function so options with special characters (brackets, slashes etc) are handled correctly ([PR #1176](https://github.com/steelthreads/agds-next/pull/1176))
+- Remove `use-debounce` dependency ([PR #1131](https://github.com/agriculture-gov-au/agds-next/pull/1131))
+- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculture-gov-au/agds-next/pull/1123))
+- Updated logic in the `splitLabel` helper function so options with special characters (brackets, slashes etc) are handled correctly ([PR #1176](https://github.com/agriculture-gov-au/agds-next/pull/1176))
 
 ### [Control input](/components/control-input)
 
@@ -69,8 +69,8 @@ To upgrade, update the import when using these components.
 
 ### [Core](/components/core)
 
-- Created new hook `useAriaModalPolyfill` which adds `aria-hidden="true"` to every direct child of the `body` element when a modal is opened. This hook consolidates code that was previously copied/pasted across Modal, App layout and Main nav. ([PR #1119](https://github.com/steelthreads/agds-next/pull/1119))
-- Created a new `overlay` design token which can be used as an overlay for modals and other components that sit on top of the main background ([PR #1147](https://github.com/steelthreads/agds-next/pull/1147))
+- Created new hook `useAriaModalPolyfill` which adds `aria-hidden="true"` to every direct child of the `body` element when a modal is opened. This hook consolidates code that was previously copied/pasted across Modal, App layout and Main nav. ([PR #1119](https://github.com/agriculture-gov-au/agds-next/pull/1119))
+- Created a new `overlay` design token which can be used as an overlay for modals and other components that sit on top of the main background ([PR #1147](https://github.com/agriculture-gov-au/agds-next/pull/1147))
 
 ### [Date picker](/components/date-picker)
 
@@ -87,24 +87,24 @@ To upgrade, update the import when using these components.
 
 ### [Date range picker](/components-date-range-picker)
 
-- Updated container wrapping behaviour to allow the component to be placed in tight areas such as sidebars ([PR #1177](https://github.com/steelthreads/agds-next/pull/1170))
+- Updated container wrapping behaviour to allow the component to be placed in tight areas such as sidebars ([PR #1177](https://github.com/agriculture-gov-au/agds-next/pull/1170))
 
 ### [Divider](/components/divider)
 
-- Created new component `Divider` which is a horizontal rule that separates blocks of content ([PR #1180](https://github.com/steelthreads/agds-next/pull/1180))
+- Created new component `Divider` which is a horizontal rule that separates blocks of content ([PR #1180](https://github.com/agriculture-gov-au/agds-next/pull/1180))
 
 ### [File upload](/components/file-upload)
 
-- Made internal types available to consumers ([PR #1183](https://github.com/steelthreads/agds-next/pull/1183))
-- Removed the filesize third party dependency ([PR #1110](https://github.com/steelthreads/agds-next/pull/1110))
+- Made internal types available to consumers ([PR #1183](https://github.com/agriculture-gov-au/agds-next/pull/1183))
+- Removed the filesize third party dependency ([PR #1110](https://github.com/agriculture-gov-au/agds-next/pull/1110))
 
 ### [Page alert](/components/page-alert)
 
-- Added support for a react element in the `title` prop ([PR #1177](https://github.com/steelthreads/agds-next/pull/1177))
+- Added support for a react element in the `title` prop ([PR #1177](https://github.com/agriculture-gov-au/agds-next/pull/1177))
 
 ### [Tags](/components/tags)
 
-- Enabled wrapping behaviour to allow tags to flow across multiple lines ([PR #1116](https://github.com/steelthreads/agds-next/pull/1116))
+- Enabled wrapping behaviour to allow tags to flow across multiple lines ([PR #1116](https://github.com/agriculture-gov-au/agds-next/pull/1116))
 
 ## Released packages
 
@@ -114,4 +114,4 @@ To upgrade, update the import when using these components.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-06-12), you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1118) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-06-12), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1118) for this release.

--- a/docs/content/updates/2023-06-12.mdx
+++ b/docs/content/updates/2023-06-12.mdx
@@ -8,13 +8,13 @@ description: Move nested components into their own entry points to improve docum
 
 ### [App layout](/components/app-layout)
 
-- Updated `AppLayoutFooterDivider` border color from `border` to `borderMuted` ([PR #1181](https://github.com/agriculture-gov-au/agds-next/pull/1181))
-- Adding missing aria dialog tags to mobile version of App layout sidebar ([PR #1119](https://github.com/agriculture-gov-au/agds-next/pull/1119))
+- Updated `AppLayoutFooterDivider` border color from `border` to `borderMuted` ([PR #1181](https://github.com/agriculturegovau/agds-next/pull/1181))
+- Adding missing aria dialog tags to mobile version of App layout sidebar ([PR #1119](https://github.com/agriculturegovau/agds-next/pull/1119))
 
 ### [Autocomplete](/components/autocomplete)
 
-- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculture-gov-au/agds-next/pull/1123))
-- Added new prop `emptyResultsMessage` which can be used to display a message when no options match the users search term ([PR #1123](https://github.com/agriculture-gov-au/agds-next/pull/1123))
+- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
+- Added new prop `emptyResultsMessage` which can be used to display a message when no options match the users search term ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
 
 ### [Badge](/components/badge)
 
@@ -48,9 +48,9 @@ To upgrade, update the import when using these components.
 
 ### [Combobox](/components/combobox)
 
-- Remove `use-debounce` dependency ([PR #1131](https://github.com/agriculture-gov-au/agds-next/pull/1131))
-- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculture-gov-au/agds-next/pull/1123))
-- Updated logic in the `splitLabel` helper function so options with special characters (brackets, slashes etc) are handled correctly ([PR #1176](https://github.com/agriculture-gov-au/agds-next/pull/1176))
+- Remove `use-debounce` dependency ([PR #1131](https://github.com/agriculturegovau/agds-next/pull/1131))
+- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
+- Updated logic in the `splitLabel` helper function so options with special characters (brackets, slashes etc) are handled correctly ([PR #1176](https://github.com/agriculturegovau/agds-next/pull/1176))
 
 ### [Control input](/components/control-input)
 
@@ -69,8 +69,8 @@ To upgrade, update the import when using these components.
 
 ### [Core](/components/core)
 
-- Created new hook `useAriaModalPolyfill` which adds `aria-hidden="true"` to every direct child of the `body` element when a modal is opened. This hook consolidates code that was previously copied/pasted across Modal, App layout and Main nav. ([PR #1119](https://github.com/agriculture-gov-au/agds-next/pull/1119))
-- Created a new `overlay` design token which can be used as an overlay for modals and other components that sit on top of the main background ([PR #1147](https://github.com/agriculture-gov-au/agds-next/pull/1147))
+- Created new hook `useAriaModalPolyfill` which adds `aria-hidden="true"` to every direct child of the `body` element when a modal is opened. This hook consolidates code that was previously copied/pasted across Modal, App layout and Main nav. ([PR #1119](https://github.com/agriculturegovau/agds-next/pull/1119))
+- Created a new `overlay` design token which can be used as an overlay for modals and other components that sit on top of the main background ([PR #1147](https://github.com/agriculturegovau/agds-next/pull/1147))
 
 ### [Date picker](/components/date-picker)
 
@@ -87,24 +87,24 @@ To upgrade, update the import when using these components.
 
 ### [Date range picker](/components-date-range-picker)
 
-- Updated container wrapping behaviour to allow the component to be placed in tight areas such as sidebars ([PR #1177](https://github.com/agriculture-gov-au/agds-next/pull/1170))
+- Updated container wrapping behaviour to allow the component to be placed in tight areas such as sidebars ([PR #1177](https://github.com/agriculturegovau/agds-next/pull/1170))
 
 ### [Divider](/components/divider)
 
-- Created new component `Divider` which is a horizontal rule that separates blocks of content ([PR #1180](https://github.com/agriculture-gov-au/agds-next/pull/1180))
+- Created new component `Divider` which is a horizontal rule that separates blocks of content ([PR #1180](https://github.com/agriculturegovau/agds-next/pull/1180))
 
 ### [File upload](/components/file-upload)
 
-- Made internal types available to consumers ([PR #1183](https://github.com/agriculture-gov-au/agds-next/pull/1183))
-- Removed the filesize third party dependency ([PR #1110](https://github.com/agriculture-gov-au/agds-next/pull/1110))
+- Made internal types available to consumers ([PR #1183](https://github.com/agriculturegovau/agds-next/pull/1183))
+- Removed the filesize third party dependency ([PR #1110](https://github.com/agriculturegovau/agds-next/pull/1110))
 
 ### [Page alert](/components/page-alert)
 
-- Added support for a react element in the `title` prop ([PR #1177](https://github.com/agriculture-gov-au/agds-next/pull/1177))
+- Added support for a react element in the `title` prop ([PR #1177](https://github.com/agriculturegovau/agds-next/pull/1177))
 
 ### [Tags](/components/tags)
 
-- Enabled wrapping behaviour to allow tags to flow across multiple lines ([PR #1116](https://github.com/agriculture-gov-au/agds-next/pull/1116))
+- Enabled wrapping behaviour to allow tags to flow across multiple lines ([PR #1116](https://github.com/agriculturegovau/agds-next/pull/1116))
 
 ## Released packages
 
@@ -114,4 +114,4 @@ To upgrade, update the import when using these components.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-06-12), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1118) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-06-12), you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1118) for this release.

--- a/docs/content/updates/2023-07-11.mdx
+++ b/docs/content/updates/2023-07-11.mdx
@@ -8,51 +8,51 @@ description: Initial release of Filter drawer, extended functionality in Page al
 
 ### [App layout](/components/app-layout)
 
-- Changed responsive behaviour so that the desktop layout is visible from the extra large breakpoint (1200px) ([PR #1213](https://github.com/agriculture-gov-au/agds-next/pull/1213))
-- Added new prop `badgeLabel` to `AppLayoutHeader` which can be used to indicate if an application is in a prerelease state ([PR #1241](https://github.com/agriculture-gov-au/agds-next/pull/1241))
+- Changed responsive behaviour so that the desktop layout is visible from the extra large breakpoint (1200px) ([PR #1213](https://github.com/agriculturegovau/agds-next/pull/1213))
+- Added new prop `badgeLabel` to `AppLayoutHeader` which can be used to indicate if an application is in a prerelease state ([PR #1241](https://github.com/agriculturegovau/agds-next/pull/1241))
 
 ### [Combobox](/components/combobox)
 
-- Improved hover styles ([PR #1242](https://github.com/agriculture-gov-au/agds-next/pull/1242))
+- Improved hover styles ([PR #1242](https://github.com/agriculturegovau/agds-next/pull/1242))
 
 ### [Core](/components/core)
 
-- Upgraded popover positioning dependency from React Popper to Floating UI ([PR #1207](https://github.com/agriculture-gov-au/agds-next/pull/1207))
-- Created a set of tokens for `z-index` ([PR #1210](https://github.com/agriculture-gov-au/agds-next/pull/1210))
-- Removed `modalDialog` and `mobileMenu` max-width tokens as they are related to specific components ([PR #1240](https://github.com/agriculture-gov-au/agds-next/pull/1240))
+- Upgraded popover positioning dependency from React Popper to Floating UI ([PR #1207](https://github.com/agriculturegovau/agds-next/pull/1207))
+- Created a set of tokens for `z-index` ([PR #1210](https://github.com/agriculturegovau/agds-next/pull/1210))
+- Removed `modalDialog` and `mobileMenu` max-width tokens as they are related to specific components ([PR #1240](https://github.com/agriculturegovau/agds-next/pull/1240))
 
 ### [Filter drawer](/components/filter-drawer)
 
-- Create initial component ([PR #1099](https://github.com/agriculture-gov-au/agds-next/pull/1099))
+- Create initial component ([PR #1099](https://github.com/agriculturegovau/agds-next/pull/1099))
 
 ### [File input](/components/file-input)
 
-- Removed red tint background from invalid state ([PR #1191](https://github.com/agriculture-gov-au/agds-next/pull/1191))
+- Removed red tint background from invalid state ([PR #1191](https://github.com/agriculturegovau/agds-next/pull/1191))
 
 ### [Icon](/components/icon)
 
-- Added new icon `FactoryIcon` ([PR #1226](https://github.com/agriculture-gov-au/agds-next/pull/1226))
+- Added new icon `FactoryIcon` ([PR #1226](https://github.com/agriculturegovau/agds-next/pull/1226))
 
 ### [Modal](/components/modal)
 
-- Fixed inconsistent padding on mobile ([PR #1205](https://github.com/agriculture-gov-au/agds-next/pull/1205))
+- Fixed inconsistent padding on mobile ([PR #1205](https://github.com/agriculturegovau/agds-next/pull/1205))
 
 ### [Page alert](/components/page-alert)
 
-- Added support for dismissing through a new `onDismiss` prop ([PR #1171](https://github.com/agriculture-gov-au/agds-next/pull/1171))
+- Added support for dismissing through a new `onDismiss` prop ([PR #1171](https://github.com/agriculturegovau/agds-next/pull/1171))
 
 ### [Prose](/components/prose)
 
-- Improved styles for `figcaption` ([PR #1094](https://github.com/agriculture-gov-au/agds-next/pull/1094))
-- Increased margin between `hr` elements ([PR #1233](https://github.com/agriculture-gov-au/agds-next/pull/1233))
+- Improved styles for `figcaption` ([PR #1094](https://github.com/agriculturegovau/agds-next/pull/1094))
+- Increased margin between `hr` elements ([PR #1233](https://github.com/agriculturegovau/agds-next/pull/1233))
 
 ### [Status badge](/components/status-badge)
 
-- Added new `weight` prop which can be used to set the visual weight of the badge. The two accepted values are `subtle` and `regular` (default) ([PR #1218](https://github.com/agriculture-gov-au/agds-next/pull/1218))
+- Added new `weight` prop which can be used to set the visual weight of the badge. The two accepted values are `subtle` and `regular` (default) ([PR #1218](https://github.com/agriculturegovau/agds-next/pull/1218))
 
 ### [Table](/components/table)
 
-- Added new `fontWeight` prop to `TableCell` ([PR #1238](https://github.com/agriculture-gov-au/agds-next/pull/1238))
+- Added new `fontWeight` prop to `TableCell` ([PR #1238](https://github.com/agriculturegovau/agds-next/pull/1238))
 
 ## Released packages
 
@@ -62,4 +62,4 @@ description: Initial release of Filter drawer, extended functionality in Page al
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-11), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1192) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-11), you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1192) for this release.

--- a/docs/content/updates/2023-07-11.mdx
+++ b/docs/content/updates/2023-07-11.mdx
@@ -8,51 +8,51 @@ description: Initial release of Filter drawer, extended functionality in Page al
 
 ### [App layout](/components/app-layout)
 
-- Changed responsive behaviour so that the desktop layout is visible from the extra large breakpoint (1200px) ([PR #1213](https://github.com/steelthreads/agds-next/pull/1213))
-- Added new prop `badgeLabel` to `AppLayoutHeader` which can be used to indicate if an application is in a prerelease state ([PR #1241](https://github.com/steelthreads/agds-next/pull/1241))
+- Changed responsive behaviour so that the desktop layout is visible from the extra large breakpoint (1200px) ([PR #1213](https://github.com/agriculture-gov-au/agds-next/pull/1213))
+- Added new prop `badgeLabel` to `AppLayoutHeader` which can be used to indicate if an application is in a prerelease state ([PR #1241](https://github.com/agriculture-gov-au/agds-next/pull/1241))
 
 ### [Combobox](/components/combobox)
 
-- Improved hover styles ([PR #1242](https://github.com/steelthreads/agds-next/pull/1242))
+- Improved hover styles ([PR #1242](https://github.com/agriculture-gov-au/agds-next/pull/1242))
 
 ### [Core](/components/core)
 
-- Upgraded popover positioning dependency from React Popper to Floating UI ([PR #1207](https://github.com/steelthreads/agds-next/pull/1207))
-- Created a set of tokens for `z-index` ([PR #1210](https://github.com/steelthreads/agds-next/pull/1210))
-- Removed `modalDialog` and `mobileMenu` max-width tokens as they are related to specific components ([PR #1240](https://github.com/steelthreads/agds-next/pull/1240))
+- Upgraded popover positioning dependency from React Popper to Floating UI ([PR #1207](https://github.com/agriculture-gov-au/agds-next/pull/1207))
+- Created a set of tokens for `z-index` ([PR #1210](https://github.com/agriculture-gov-au/agds-next/pull/1210))
+- Removed `modalDialog` and `mobileMenu` max-width tokens as they are related to specific components ([PR #1240](https://github.com/agriculture-gov-au/agds-next/pull/1240))
 
 ### [Filter drawer](/components/filter-drawer)
 
-- Create initial component ([PR #1099](https://github.com/steelthreads/agds-next/pull/1099))
+- Create initial component ([PR #1099](https://github.com/agriculture-gov-au/agds-next/pull/1099))
 
 ### [File input](/components/file-input)
 
-- Removed red tint background from invalid state ([PR #1191](https://github.com/steelthreads/agds-next/pull/1191))
+- Removed red tint background from invalid state ([PR #1191](https://github.com/agriculture-gov-au/agds-next/pull/1191))
 
 ### [Icon](/components/icon)
 
-- Added new icon `FactoryIcon` ([PR #1226](https://github.com/steelthreads/agds-next/pull/1226))
+- Added new icon `FactoryIcon` ([PR #1226](https://github.com/agriculture-gov-au/agds-next/pull/1226))
 
 ### [Modal](/components/modal)
 
-- Fixed inconsistent padding on mobile ([PR #1205](https://github.com/steelthreads/agds-next/pull/1205))
+- Fixed inconsistent padding on mobile ([PR #1205](https://github.com/agriculture-gov-au/agds-next/pull/1205))
 
 ### [Page alert](/components/page-alert)
 
-- Added support for dismissing through a new `onDismiss` prop ([PR #1171](https://github.com/steelthreads/agds-next/pull/1171))
+- Added support for dismissing through a new `onDismiss` prop ([PR #1171](https://github.com/agriculture-gov-au/agds-next/pull/1171))
 
 ### [Prose](/components/prose)
 
-- Improved styles for `figcaption` ([PR #1094](https://github.com/steelthreads/agds-next/pull/1094))
-- Increased margin between `hr` elements ([PR #1233](https://github.com/steelthreads/agds-next/pull/1233))
+- Improved styles for `figcaption` ([PR #1094](https://github.com/agriculture-gov-au/agds-next/pull/1094))
+- Increased margin between `hr` elements ([PR #1233](https://github.com/agriculture-gov-au/agds-next/pull/1233))
 
 ### [Status badge](/components/status-badge)
 
-- Added new `weight` prop which can be used to set the visual weight of the badge. The two accepted values are `subtle` and `regular` (default) ([PR #1218](https://github.com/steelthreads/agds-next/pull/1218))
+- Added new `weight` prop which can be used to set the visual weight of the badge. The two accepted values are `subtle` and `regular` (default) ([PR #1218](https://github.com/agriculture-gov-au/agds-next/pull/1218))
 
 ### [Table](/components/table)
 
-- Added new `fontWeight` prop to `TableCell` ([PR #1238](https://github.com/steelthreads/agds-next/pull/1238))
+- Added new `fontWeight` prop to `TableCell` ([PR #1238](https://github.com/agriculture-gov-au/agds-next/pull/1238))
 
 ## Released packages
 
@@ -62,4 +62,4 @@ description: Initial release of Filter drawer, extended functionality in Page al
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-11), you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1192) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-11), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1192) for this release.

--- a/docs/content/updates/2023-07-12.mdx
+++ b/docs/content/updates/2023-07-12.mdx
@@ -8,15 +8,15 @@ description: Patch release to ensure items in navigational components are highli
 
 ### [App layout](/components/app-layout)
 
-- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/agriculture-gov-au/agds-next/pull/1251))
+- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/agriculturegovau/agds-next/pull/1251))
 
 ### [Core](/components/sub-nav)
 
-- Deduplicated use of `findBestMatch` from navigational components () and moved into the core entry point ([PR #1251](https://github.com/agriculture-gov-au/agds-next/pull/1251))
+- Deduplicated use of `findBestMatch` from navigational components () and moved into the core entry point ([PR #1251](https://github.com/agriculturegovau/agds-next/pull/1251))
 
 ### [Sub nav](/components/sub-nav)
 
-- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/agriculture-gov-au/agds-next/pull/1251))
+- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/agriculturegovau/agds-next/pull/1251))
 
 ## Released packages
 
@@ -26,4 +26,4 @@ description: Patch release to ensure items in navigational components are highli
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-12), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1254) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-12), you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1254) for this release.

--- a/docs/content/updates/2023-07-12.mdx
+++ b/docs/content/updates/2023-07-12.mdx
@@ -8,15 +8,15 @@ description: Patch release to ensure items in navigational components are highli
 
 ### [App layout](/components/app-layout)
 
-- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/steelthreads/agds-next/pull/1251))
+- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/agriculture-gov-au/agds-next/pull/1251))
 
 ### [Core](/components/sub-nav)
 
-- Deduplicated use of `findBestMatch` from navigational components () and moved into the core entry point ([PR #1251](https://github.com/steelthreads/agds-next/pull/1251))
+- Deduplicated use of `findBestMatch` from navigational components () and moved into the core entry point ([PR #1251](https://github.com/agriculture-gov-au/agds-next/pull/1251))
 
 ### [Sub nav](/components/sub-nav)
 
-- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/steelthreads/agds-next/pull/1251))
+- Used `findBestMatch` utility function to ensure nav items are highlighted correctly based on the `activePath` ([PR #1251](https://github.com/agriculture-gov-au/agds-next/pull/1251))
 
 ## Released packages
 
@@ -26,4 +26,4 @@ description: Patch release to ensure items in navigational components are highli
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-12), you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1254) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2023-07-12), you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1254) for this release.

--- a/docs/content/updates/2023-07-14.mdx
+++ b/docs/content/updates/2023-07-14.mdx
@@ -8,11 +8,11 @@ description: Initial release of the Tabs component.
 
 ### [Button](/components/button)
 
-- Extended `BaseButton` to support `onKeyDown`, `onBlur`, `onFocus`, `role` and `tabIndex` props ([#PR 1232](https://github.com/steelthreads/agds-next/pull/1232))
+- Extended `BaseButton` to support `onKeyDown`, `onBlur`, `onFocus`, `role` and `tabIndex` props ([#PR 1232](https://github.com/agriculture-gov-au/agds-next/pull/1232))
 
 ### [Tabs](/components/tabs)
 
-- Initial release of the [Tabs](/components/tabs) component ([#PR 1232](https://github.com/steelthreads/agds-next/pull/1232))
+- Initial release of the [Tabs](/components/tabs) component ([#PR 1232](https://github.com/agriculture-gov-au/agds-next/pull/1232))
 
 ## Released packages
 
@@ -22,4 +22,4 @@ description: Initial release of the Tabs component.
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1259) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1259) for this release.

--- a/docs/content/updates/2023-07-14.mdx
+++ b/docs/content/updates/2023-07-14.mdx
@@ -8,11 +8,11 @@ description: Initial release of the Tabs component.
 
 ### [Button](/components/button)
 
-- Extended `BaseButton` to support `onKeyDown`, `onBlur`, `onFocus`, `role` and `tabIndex` props ([#PR 1232](https://github.com/agriculture-gov-au/agds-next/pull/1232))
+- Extended `BaseButton` to support `onKeyDown`, `onBlur`, `onFocus`, `role` and `tabIndex` props ([#PR 1232](https://github.com/agriculturegovau/agds-next/pull/1232))
 
 ### [Tabs](/components/tabs)
 
-- Initial release of the [Tabs](/components/tabs) component ([#PR 1232](https://github.com/agriculture-gov-au/agds-next/pull/1232))
+- Initial release of the [Tabs](/components/tabs) component ([#PR 1232](https://github.com/agriculturegovau/agds-next/pull/1232))
 
 ## Released packages
 
@@ -22,4 +22,4 @@ description: Initial release of the Tabs component.
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1259) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1259) for this release.

--- a/docs/content/updates/2023-07-24.mdx
+++ b/docs/content/updates/2023-07-24.mdx
@@ -8,11 +8,11 @@ description: Visual refresh of the Global alert component, updated App layout fo
 
 ### [App layout](/components/app-layout)
 
-Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version ([#PR 1281](https://github.com/agriculture-gov-au/agds-next/pull/1281))
+Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version ([#PR 1281](https://github.com/agriculturegovau/agds-next/pull/1281))
 
 ### [Box](/components/box)
 
-Extended the `Box` component so borders can be applied with the `accent` colour ([#PR 1185](https://github.com/agriculture-gov-au/agds-next/pull/1185))
+Extended the `Box` component so borders can be applied with the `accent` colour ([#PR 1185](https://github.com/agriculturegovau/agds-next/pull/1185))
 
 ```tsx
 <Box borderBottom borderBottomWidth="xxl" borderColor="accent">
@@ -22,24 +22,24 @@ Extended the `Box` component so borders can be applied with the `accent` colour 
 
 ### [Core](/components/core)
 
-Extended utility function `useClickOutside` to accept multiple refs ([#PR 1266](https://github.com/agriculture-gov-au/agds-next/pull/1266))
+Extended utility function `useClickOutside` to accept multiple refs ([#PR 1266](https://github.com/agriculturegovau/agds-next/pull/1266))
 
 ### [Date picker](/components/date-picker)
 
-Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/agriculture-gov-au/agds-next/pull/1270))
+Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/agriculturegovau/agds-next/pull/1270))
 
 ### [Date range picker](/components/date-range-picker)
 
-Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/agriculture-gov-au/agds-next/pull/1270))
+Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/agriculturegovau/agds-next/pull/1270))
 
 ### [Filter drawer](/components/filter-drawer)
 
-Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version. ([#PR 1281](https://github.com/agriculture-gov-au/agds-next/pull/1281))
+Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version. ([#PR 1281](https://github.com/agriculturegovau/agds-next/pull/1281))
 
 ### [Global alert](/components/global-alert)
 
-- Visual refresh ([#PR 1256](https://github.com/agriculture-gov-au/agds-next/pull/1256))
-- Added support for 'info' tone ([#PR 1256](https://github.com/agriculture-gov-au/agds-next/pull/1256))
+- Visual refresh ([#PR 1256](https://github.com/agriculturegovau/agds-next/pull/1256))
+- Added support for 'info' tone ([#PR 1256](https://github.com/agriculturegovau/agds-next/pull/1256))
 
 ## Released packages
 
@@ -49,4 +49,4 @@ Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility wi
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1269) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1269) for this release.

--- a/docs/content/updates/2023-07-24.mdx
+++ b/docs/content/updates/2023-07-24.mdx
@@ -8,11 +8,11 @@ description: Visual refresh of the Global alert component, updated App layout fo
 
 ### [App layout](/components/app-layout)
 
-Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version ([#PR 1281](https://github.com/steelthreads/agds-next/pull/1281))
+Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version ([#PR 1281](https://github.com/agriculture-gov-au/agds-next/pull/1281))
 
 ### [Box](/components/box)
 
-Extended the `Box` component so borders can be applied with the `accent` colour ([#PR 1185](https://github.com/steelthreads/agds-next/pull/1185))
+Extended the `Box` component so borders can be applied with the `accent` colour ([#PR 1185](https://github.com/agriculture-gov-au/agds-next/pull/1185))
 
 ```tsx
 <Box borderBottom borderBottomWidth="xxl" borderColor="accent">
@@ -22,24 +22,24 @@ Extended the `Box` component so borders can be applied with the `accent` colour 
 
 ### [Core](/components/core)
 
-Extended utility function `useClickOutside` to accept multiple refs ([#PR 1266](https://github.com/steelthreads/agds-next/pull/1266))
+Extended utility function `useClickOutside` to accept multiple refs ([#PR 1266](https://github.com/agriculture-gov-au/agds-next/pull/1266))
 
 ### [Date picker](/components/date-picker)
 
-Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/steelthreads/agds-next/pull/1270))
+Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/agriculture-gov-au/agds-next/pull/1270))
 
 ### [Date range picker](/components/date-range-picker)
 
-Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/steelthreads/agds-next/pull/1270))
+Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover ([#PR 1270](https://github.com/agriculture-gov-au/agds-next/pull/1270))
 
 ### [Filter drawer](/components/filter-drawer)
 
-Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version. ([#PR 1281](https://github.com/steelthreads/agds-next/pull/1281))
+Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility with latest version. ([#PR 1281](https://github.com/agriculture-gov-au/agds-next/pull/1281))
 
 ### [Global alert](/components/global-alert)
 
-- Visual refresh ([#PR 1256](https://github.com/steelthreads/agds-next/pull/1256))
-- Added support for 'info' tone ([#PR 1256](https://github.com/steelthreads/agds-next/pull/1256))
+- Visual refresh ([#PR 1256](https://github.com/agriculture-gov-au/agds-next/pull/1256))
+- Added support for 'info' tone ([#PR 1256](https://github.com/agriculture-gov-au/agds-next/pull/1256))
 
 ## Released packages
 
@@ -49,4 +49,4 @@ Fixed usage of `useTransition` by `@react-spring/web` to ensure compatibility wi
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1269) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1269) for this release.

--- a/docs/content/updates/2023-09-06.mdx
+++ b/docs/content/updates/2023-09-06.mdx
@@ -131,4 +131,4 @@ description: Initial release of Dropdown menu and List components, improved focu
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1288) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1288) for this release.

--- a/docs/content/updates/2023-09-06.mdx
+++ b/docs/content/updates/2023-09-06.mdx
@@ -131,4 +131,4 @@ description: Initial release of Dropdown menu and List components, improved focu
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1288) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1288) for this release.

--- a/docs/content/updates/2023-09-22.mdx
+++ b/docs/content/updates/2023-09-22.mdx
@@ -81,4 +81,4 @@ To upgrade, update the import and component name when using these components.
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1362) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1362) for this release.

--- a/docs/content/updates/2023-09-22.mdx
+++ b/docs/content/updates/2023-09-22.mdx
@@ -81,4 +81,4 @@ To upgrade, update the import and component name when using these components.
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1362) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1362) for this release.

--- a/docs/content/updates/2023-09-27.mdx
+++ b/docs/content/updates/2023-09-27.mdx
@@ -35,4 +35,4 @@ description: Extended App layout components to support the new account dropdown 
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1395) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1395) for this release.

--- a/docs/content/updates/2023-09-27.mdx
+++ b/docs/content/updates/2023-09-27.mdx
@@ -35,4 +35,4 @@ description: Extended App layout components to support the new account dropdown 
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1395) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1395) for this release.

--- a/docs/content/updates/2023-10-04.mdx
+++ b/docs/content/updates/2023-10-04.mdx
@@ -57,4 +57,4 @@ description: Small patches to App layout, extended Table primitives to support b
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1402) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1402) for this release.

--- a/docs/content/updates/2023-10-04.mdx
+++ b/docs/content/updates/2023-10-04.mdx
@@ -57,4 +57,4 @@ description: Small patches to App layout, extended Table primitives to support b
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1402) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1402) for this release.

--- a/docs/content/updates/2023-10-17.mdx
+++ b/docs/content/updates/2023-10-17.mdx
@@ -59,4 +59,4 @@ description: Extended Pagination to support items range text and items per page 
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1420) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1420) for this release.

--- a/docs/content/updates/2023-10-17.mdx
+++ b/docs/content/updates/2023-10-17.mdx
@@ -59,4 +59,4 @@ description: Extended Pagination to support items range text and items per page 
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1420) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1420) for this release.

--- a/docs/content/updates/2023-10-31.mdx
+++ b/docs/content/updates/2023-10-31.mdx
@@ -40,4 +40,4 @@ description: Various minor bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1441) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1441) for this release.

--- a/docs/content/updates/2023-10-31.mdx
+++ b/docs/content/updates/2023-10-31.mdx
@@ -40,4 +40,4 @@ description: Various minor bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1441) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1441) for this release.

--- a/docs/content/updates/2023-11-14.mdx
+++ b/docs/content/updates/2023-11-14.mdx
@@ -55,4 +55,4 @@ description: Initial release of Password input, improvements to Combobox, plus v
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1472) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1472) for this release.

--- a/docs/content/updates/2023-11-14.mdx
+++ b/docs/content/updates/2023-11-14.mdx
@@ -55,4 +55,4 @@ description: Initial release of Password input, improvements to Combobox, plus v
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1472) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculturegovau/agds-next/pull/1472) for this release.

--- a/docs/content/updates/2023-11-30.mdx
+++ b/docs/content/updates/2023-11-30.mdx
@@ -62,6 +62,6 @@ description: Small accessibility improvements, plus various minor bug fixes and 
 
 ## Full Changelog
 
-Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1492) for this release.
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/agriculture-gov-au/agds-next/pull/1492) for this release.
 
 This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to main, this PR will be updated.

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
 	"name": "@ag.ds-next/docs",
 	"version": "0.6.7",
 	"private": true,
-	"repository": "https://github.com/steelthreads/agds-next/tree/main/docs",
+	"repository": "https://github.com/agriculture-gov-au/agds-next/tree/main/docs",
 	"license": "MIT",
 	"scripts": {
 		"build": "yarn generate-component-props && next build && next-sitemap",

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
 	"name": "@ag.ds-next/docs",
 	"version": "0.6.7",
 	"private": true,
-	"repository": "https://github.com/agriculture-gov-au/agds-next/tree/main/docs",
+	"repository": "https://github.com/agriculturegovau/agds-next/tree/main/docs",
 	"license": "MIT",
 	"scripts": {
 		"build": "yarn generate-component-props && next build && next-sitemap",

--- a/docs/pages/components/[slug]/code.tsx
+++ b/docs/pages/components/[slug]/code.tsx
@@ -61,7 +61,7 @@ export default function PackagesCode({
 					<p>
 						You can view the full source code for this package on{' '}
 						<a
-							href={`https://github.com/steelthreads/agds-next/tree/main/packages/react/src/${pkg.slug}`}
+							href={`https://github.com/agriculture-gov-au/agds-next/tree/main/packages/react/src/${pkg.slug}`}
 						>
 							Github
 						</a>

--- a/docs/pages/components/[slug]/code.tsx
+++ b/docs/pages/components/[slug]/code.tsx
@@ -61,7 +61,7 @@ export default function PackagesCode({
 					<p>
 						You can view the full source code for this package on{' '}
 						<a
-							href={`https://github.com/agriculture-gov-au/agds-next/tree/main/packages/react/src/${pkg.slug}`}
+							href={`https://github.com/agriculturegovau/agds-next/tree/main/packages/react/src/${pkg.slug}`}
 						>
 							Github
 						</a>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -73,7 +73,7 @@ export default function Homepage() {
 								<PictogramCard
 									title="Starter kit"
 									pictogram="starter"
-									href="https://github.com/agriculture-gov-au/agds-starter-kit"
+									href="https://github.com/agriculturegovau/agds-starter-kit"
 								/>
 							</Columns>
 						</Stack>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -73,7 +73,7 @@ export default function Homepage() {
 								<PictogramCard
 									title="Starter kit"
 									pictogram="starter"
-									href="https://github.com/steelthreads/agds-starter-kit"
+									href="https://github.com/agriculture-gov-au/agds-starter-kit"
 								/>
 							</Columns>
 						</Stack>

--- a/example-site/components/SiteFooter.tsx
+++ b/example-site/components/SiteFooter.tsx
@@ -17,7 +17,7 @@ const footerLinks = [
 	},
 	{
 		label: 'Starter kit',
-		href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
+		href: 'https://github.com/agriculturegovau/agds-starter-kit',
 	},
 	{
 		label: 'Privacy',

--- a/example-site/components/SiteFooter.tsx
+++ b/example-site/components/SiteFooter.tsx
@@ -17,7 +17,7 @@ const footerLinks = [
 	},
 	{
 		label: 'Starter kit',
-		href: 'https://github.com/steelthreads/agds-starter-kit',
+		href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
 	},
 	{
 		label: 'Privacy',

--- a/packages/react/src/app-layout/AppLayout.stories.tsx
+++ b/packages/react/src/app-layout/AppLayout.stories.tsx
@@ -100,7 +100,7 @@ function AppLayoutTemplate({
 									},
 									{
 										label: 'Starter kit',
-										href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
+										href: 'https://github.com/agriculturegovau/agds-starter-kit',
 									},
 								]}
 								horizontal

--- a/packages/react/src/app-layout/AppLayout.stories.tsx
+++ b/packages/react/src/app-layout/AppLayout.stories.tsx
@@ -100,7 +100,7 @@ function AppLayoutTemplate({
 									},
 									{
 										label: 'Starter kit',
-										href: 'https://github.com/steelthreads/agds-starter-kit',
+										href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
 									},
 								]}
 								horizontal

--- a/packages/react/src/app-layout/AppLayoutFooter.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutFooter.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof AppLayoutFooter> = {
 							},
 							{
 								label: 'Starter kit',
-								href: 'https://github.com/steelthreads/agds-starter-kit',
+								href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
 							},
 						]}
 						horizontal

--- a/packages/react/src/app-layout/AppLayoutFooter.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutFooter.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof AppLayoutFooter> = {
 							},
 							{
 								label: 'Starter kit',
-								href: 'https://github.com/agriculture-gov-au/agds-starter-kit',
+								href: 'https://github.com/agriculturegovau/agds-starter-kit',
 							},
 						]}
 						horizontal

--- a/packages/react/src/core/docs/overview.mdx
+++ b/packages/react/src/core/docs/overview.mdx
@@ -25,7 +25,7 @@ export default function MyApp({ Component, pageProps }) {
 
 ## Routing / Linking
 
-Our component library has been designed to work with any react routing library. For an example of configuring routing/links in AgDS for a Next.js application, please see [our example site](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site/components/LinkComponent.tsx).
+Our component library has been designed to work with any react routing library. For an example of configuring routing/links in AgDS for a Next.js application, please see [our example site](https://github.com/agriculturegovau/agds-next/tree/main/example-site/components/LinkComponent.tsx).
 
 ```jsx
 import { Core } from '../core';

--- a/packages/react/src/core/docs/overview.mdx
+++ b/packages/react/src/core/docs/overview.mdx
@@ -25,7 +25,7 @@ export default function MyApp({ Component, pageProps }) {
 
 ## Routing / Linking
 
-Our component library has been designed to work with any react routing library. For an example of configuring routing/links in AgDS for a Next.js application, please see [our example site](https://github.com/steelthreads/agds-next/tree/main/example-site/components/LinkComponent.tsx).
+Our component library has been designed to work with any react routing library. For an example of configuring routing/links in AgDS for a Next.js application, please see [our example site](https://github.com/agriculture-gov-au/agds-next/tree/main/example-site/components/LinkComponent.tsx).
 
 ```jsx
 import { Core } from '../core';

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -121,7 +121,7 @@ To disable this behaviour, set the `hideThumbnails` prop to `true`.
 
 Use the `accept` prop to specify what file types are allowed to be selected.
 
-For a complete list allowed file formats, please refer to [the source code](https://github.com/steelthreads/agds-next/blob/main/packages/react/src/file-upload/utils.tsx).
+For a complete list allowed file formats, please refer to [the source code](https://github.com/agriculture-gov-au/agds-next/blob/main/packages/react/src/file-upload/utils.tsx).
 
 ```jsx
 <FileUpload label="Upload image" accept={['image/jpeg', 'image/png']} />

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -121,7 +121,7 @@ To disable this behaviour, set the `hideThumbnails` prop to `true`.
 
 Use the `accept` prop to specify what file types are allowed to be selected.
 
-For a complete list allowed file formats, please refer to [the source code](https://github.com/agriculture-gov-au/agds-next/blob/main/packages/react/src/file-upload/utils.tsx).
+For a complete list allowed file formats, please refer to [the source code](https://github.com/agriculturegovau/agds-next/blob/main/packages/react/src/file-upload/utils.tsx).
 
 ```jsx
 <FileUpload label="Upload image" accept={['image/jpeg', 'image/png']} />


### PR DESCRIPTION
Updated all references of `steelthreads` to `agriculturegovau`

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-[PR_NUMBER])

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets