### PR TITLE
table: Allow focus on TableWrapper to fix a11y for keyboard users

### DIFF
--- a/.changeset/modern-bats-raise.md
+++ b/.changeset/modern-bats-raise.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-table: Allow focus on TableWrapper to fix accessibility for keyboard users.
+table: Allow focus on `TableWrapper` to fix accessibility for keyboard users.

--- a/.changeset/modern-bats-raise.md
+++ b/.changeset/modern-bats-raise.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+table: Allow focus on TableWrapper to fix accessibility for keyboard users.

--- a/packages/react/src/table/TableWrapper.tsx
+++ b/packages/react/src/table/TableWrapper.tsx
@@ -1,5 +1,10 @@
 import { ReactNode } from 'react';
+import { Box } from '@ag.ds-next/react/box';
 
 export const TableWrapper = ({ children }: { children: ReactNode }) => {
-	return <div css={{ overflowX: 'auto' }}>{children}</div>;
+	return (
+		<Box css={{ overflowX: 'auto' }} focus tabIndex={0}>
+			{children}
+		</Box>
+	);
 };

--- a/packages/react/src/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/Table.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`Table with TableCaption renders correctly 1`] = `
 <div>
   <div
-    class="css-2ebmvj-TableWrapper"
+    class="css-19vvl7p-boxStyles-TableWrapper"
+    tabindex="0"
   >
     <table
       class="css-r11i27-boxStyles-Table"


### PR DESCRIPTION
Allow focus on tableWrapper to fix accessibility for keyboard users

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1517)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets