### PR TITLE
docs: Fix usage of apostrophes throughout

### DIFF
--- a/.changeset/heavy-dingos-cheat.md
+++ b/.changeset/heavy-dingos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+docs: Fix usage of apostrophes throughout.

--- a/.storybook/stories/DataFiltering/lib/generateBusinessData.ts
+++ b/.storybook/stories/DataFiltering/lib/generateBusinessData.ts
@@ -81,7 +81,7 @@ const EXAMPLE_BUSINESSES: Partial<BusinessForAudit>[] = [
 	},
 	{ businessName: 'The Land Down Under Livestock Co.' },
 	{ businessName: 'The Oz Harvest Co.' },
-	{ businessName: "The Aussie Farmer's Market" },
+	{ businessName: 'The Aussie Farmer’s Market' },
 	{ businessName: 'The Australian Crop Co.' },
 	{
 		businessName: 'The Great Barrier Reef Seafood Co.',

--- a/.storybook/stories/KitchenSink/KitchenSink.stories.tsx
+++ b/.storybook/stories/KitchenSink/KitchenSink.stories.tsx
@@ -128,7 +128,7 @@ const sideNavItems = [
 			},
 		],
 	},
-	{ href: '#four', label: "What's new for individuals" },
+	{ href: '#four', label: 'What’s new for individuals' },
 	{ href: '#five', label: 'Why you may receive a tax bill' },
 ];
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This is an idea that comes from Perl and can be used when thinking about how to 
 
 A simple example of this is the `LinkList` component.
 
-In it's simplest and most easy to use form, the component takes a `links` prop which is a list of the `href` and text `label` for each link.
+In it’s simplest and most easy to use form, the component takes a `links` prop which is a list of the `href` and text `label` for each link.
 
 ```jsx
 import { LinkList } from '@ag.ds-next/link-list';
@@ -77,7 +77,7 @@ So components which are a composition of several other components (like `LinkLis
 
 It is fully expected that almost every design-system component will depend on `core` and `box` but beyond that, we should try to limit cross dependencies as much as possible.
 
-> It's tempting to look, for example, at the `SideNavigation` component, see that in mobile it collapses to an accordion and then try to use the `Accordion` inside of `SideNavigation`.
+> It’s tempting to look, for example, at the `SideNavigation` component, see that in mobile it collapses to an accordion and then try to use the `Accordion` inside of `SideNavigation`.
 
 Going down this path is fraught.
 
@@ -90,15 +90,15 @@ A better choice here is to take the parts of `Accordion` which are common / reus
 
 This Design-System will likely be adopted either only partially or incrementally. For this reason it is important that we avoid polluting global namespaces and scopes in css and javascript.
 
-This is why the neither `core` or `prose` apply a default `fontFamily` or `color` and why the global reset is minimal and optional. For each component in the design system we need to consider whether it is appropriate for the component to apply styling to it's children.
+This is why the neither `core` or `prose` apply a default `fontFamily` or `color` and why the global reset is minimal and optional. For each component in the design system we need to consider whether it is appropriate for the component to apply styling to it’s children.
 
 #### Examples:
 
 In the context of `LinkList`, it makes sense to apply styles to the child `a` tags (`color`, `textDecoration`, `fontFamily` etc.). That is the purpose of the component.
 
-In the case of `Box` or `Stack`, unless the user has specified a property we should not apply anything that effects the component's children.
+In the case of `Box` or `Stack`, unless the user has specified a property we should not apply anything that effects the component’s children.
 
-When choosing defaults it's important to consider that some css properties will be inherited by child elements while others will not.
+When choosing defaults it’s important to consider that some css properties will be inherited by child elements while others will not.
 Eg, setting color on a `Box` will apply that color to child text nodes. Setting `width` will only change the width of the `Box` component itself.
 
 ## Component / Feature checklist
@@ -117,7 +117,7 @@ For new components or features, use the following check list to ensure you have 
 
 Can you answer the following questions:
 
-> If I couldn't see the screen how would I know:
+> If I couldn’t see the screen how would I know:
 >
 > - what this is?
 > - what this does?

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,11 +36,11 @@ Use this output in the next step.
 
 Search the repository for any components that have been marked as unreleased. You can do this by searching for `unreleased: true`. If there any components marked as unreleased, they would have been released in the previous step so this piece of frontmatter needs to be removed.
 
-Create a new `.mdx` file in `docs/content/updates` with todays date as the file name.
+Create a new `.mdx` file in `docs/content/updates` with today’s date as the file name.
 
 Use the latest release as the template for the release notes. It should include:
 
-- Summary headline of what's in the release
+- Summary headline of what’s in the release
 - Release description of what is new. This may be taken from the changelogs but should remove the noise. In some cases it may be better to write something new.
 - Verbose release notes link (link to the PR)
 

--- a/docs/components/DoDontHeading.tsx
+++ b/docs/components/DoDontHeading.tsx
@@ -14,7 +14,7 @@ export const DontHeading = () => (
 	<p>
 		<Flex as="span" alignItems="center" gap={0.5}>
 			<AlertFilledIcon color="error" />
-			<strong>Don&apos;t</strong>
+			<strong>Don’t</strong>
 		</Flex>
 	</p>
 );

--- a/docs/content/about.mdx
+++ b/docs/content/about.mdx
@@ -23,7 +23,7 @@ The Agriculture Design System is the best way to ensure we meet our legal obliga
 
 ## Connect with us
 
-Department of Agriculture Fisheries and Forestry staff can connect with us in the "Design System" chat in Microsoft Teams.
+Department of Agriculture Fisheries and Forestry staff can connect with us in the ‘Design System’ chat in Microsoft Teams.
 
 If you are wondering what is next, please see our [roadmap](/roadmap).
 

--- a/docs/content/about.mdx
+++ b/docs/content/about.mdx
@@ -19,7 +19,7 @@ The toolkit includes:
 
 AgDS is based on the [GOLD Design System](https://gold.designsystemau.org) which incorporates the highest usability and accessibility standards, helping us to deliver a consistent experience for all users, in line with the [Digital Service Standard](https://www.dta.gov.au/help-and-advice/about-digital-service-standard).
 
-The Agriculture Design System is the best way to ensure we meet our legal obligations to ensure accessibility. Under the Disability Discrimination Act 1992, Australian Government agencies are required to ensure information and services are provided in a non-discriminatory accessible manner. That is why AgDS&apos;s suite of components, templates and guides are designed with the highest accessibility standards.
+The Agriculture Design System is the best way to ensure we meet our legal obligations to ensure accessibility. Under the Disability Discrimination Act 1992, Australian Government agencies are required to ensure information and services are provided in a non-discriminatory accessible manner. That is why AgDS’s suite of components, templates and guides are designed with the highest accessibility standards.
 
 ## Connect with us
 

--- a/docs/content/content/content-patterns.mdx
+++ b/docs/content/content/content-patterns.mdx
@@ -46,7 +46,7 @@ If the outage is planned, you can use the [Scheduled third party outage (503)](/
 
 <BackToTop />
 
-## 'Need more help?' callouts
+## ‘Need more help?’ callouts
 
 Use this pattern and content to give users the option to call the Export Service support desk.
 

--- a/docs/content/content/content-styles.mdx
+++ b/docs/content/content/content-styles.mdx
@@ -34,7 +34,7 @@ That’s unless it’s a part of a proper noun or name.
 
 Use ‘and/or’ to indicate either or both possibilities to users in the Export Service.
 
-For example: "Register fish and/or fish products."
+For example: ‘Register fish and/or fish products.’
 
 <BackToTop />
 
@@ -44,7 +44,7 @@ We use capitalisation minimally in the Export Service and sentence case generall
 
 That is, use a capital on the first word only in a header or sentence. All other words are lower case, except proper nouns.
 
-For example, use 'Services you can use now' rather than 'Services You Can Use Now'.
+For example, use ‘Services you can use now’ rather than ‘Services You Can Use Now’.
 
 For more information, see Capitalisation in the DAFF Style guide (internal DAFF staff only).
 
@@ -58,29 +58,29 @@ Use simple contractions if it’s appropriate. For example, simple contractions 
 
 - don’t
 - can’t
-- won't
+- won’t
 - we’ll
 - we’re
 - we’ve
-- that's
+- that’s
 - it’s
-- let's
+- let’s
 - isn’t
 
 Avoid complex contractions which are harder to interpret. Some users may find these contractions hard to understand. For example, complex contractions include:
 
 - you’ll
 - you’re.
-- you're
+- you’re
 - they’re
-- there's
+- there’s
 - wouldn’t
 - shouldn’t
 - doesn’t
 - mustn’t
 - cannot
 - haven’t
-- hasn't
+- hasn’t
 - weren’t.
 - where’ve
 
@@ -124,7 +124,7 @@ You can use a full stop after an email address if it’s at the end of a sentenc
 </ExampleContent>
 
 <ExampleContent heading={<H3>Example</H3>}>
-	If you're interested in taking part or would like to find out more, email
+	If you’re interested in taking part or would like to find out more, email
 	[exportassurance@agriculture.gov.au](mailto:exportassurance@agriculture.gov.au)
 </ExampleContent>
 
@@ -159,7 +159,7 @@ An error message in the Export Service can be a:
 - [Page alert](/components/page-alert), or a
 - message about a form [Field](/components/field).
 
-There are also 'warning' messages that indicate urgent situations. For example, system alerts. For more information, see [Global alert](/components/global-alert).
+There are also ‘warning’ messages that indicate urgent situations. For example, system alerts. For more information, see [Global alert](/components/global-alert).
 
 When you create an error message:
 
@@ -167,7 +167,7 @@ When you create an error message:
 - use simpler language and the correct [Voice and tone](/content/voice-and-tone)
 - don’t blame the user for the error
 - be specific in describing how and when the error can be fixed
-- don't use sorry in the error message
+- don’t use sorry in the error message
 - use ‘please’ sparingly. That is, only if users’ need to do something extra and inconvenient. Or if the Export Service (or third-party systems) are to blame
 - include the error code in the message if possible. It may be helpful to a support agent if a user accesses human-led support.
 
@@ -300,7 +300,7 @@ Use a forward arrow (>) to separate the tabs or buttons users need to select.
 
 <ExampleContent heading={<H3>Example</H3>}>
 	To carry out any of these actions, sign in to the Export Service and select
-	the 'Establishments' tab.
+	the ‘Establishments’ tab.
 </ExampleContent>
 
 <ExampleContent heading={<H3>Example</H3>}>
@@ -391,7 +391,7 @@ For more information on links, see:
 
 ## Lists
 
-Don't use full stops at the end of the last item on a list if the item is next to a radio button or a multi-select checkbox. For example, lists in a form or interactive experience.
+Don’t use full stops at the end of the last item on a list if the item is next to a radio button or a multi-select checkbox. For example, lists in a form or interactive experience.
 
 Use a capital letter on the first word of listed items next to radio buttons or multi-select checkboxes.
 
@@ -504,7 +504,7 @@ For example, if you are asking them to give feedback on a web page. Use ‘thank
 ```jsx live exampleContentHeadingType="h3"
 <FormStack>
 	<H2>Thanks for your feedback</H2>
-	<Textarea label="Please tell us more" hint="Don't provide personal details" />
+	<Textarea label="Please tell us more" hint="Don’t provide personal details" />
 </FormStack>
 ```
 
@@ -597,7 +597,7 @@ Some of the preferred terms we use on common button labels in the Export Service
 - Sign in and Sign out
 - Get started
 - Start again
-- Change (instead of 'edit' or 'update')
+- Change (instead of ‘edit’ or ‘update’)
 - Manage [element]
 
 ```jsx live exampleContentHeadingType="h4"
@@ -628,7 +628,7 @@ For more information, see:
 
 <BackToTop />
 
-## Using 'for example'
+## Using ‘for example’
 
 Use ‘x (for example, y)’ to provide an example of x when it’s not critical to understand. Using parentheses () is a mental signal that the content can be safely ignored.
 
@@ -659,7 +659,7 @@ A search engine optimised (SEO) URL:
 - is easy to read
 - uses relevant categories/subfolders
 - has 20 to 70 characters if possible
-- is consistent with the H1 on the page if possible. But try not to repeat a word if it's already a part of the URL domain/folder URL stem.
+- is consistent with the H1 on the page if possible. But try not to repeat a word if it’s already a part of the URL domain/folder URL stem.
 
 <ExampleContent heading={<H3>Example</H3>}>
 	https://exports.agriculture.gov.au/help/register-establishment

--- a/docs/content/foundations/design-guidelines.mdx
+++ b/docs/content/foundations/design-guidelines.mdx
@@ -11,7 +11,7 @@ Avoid aligning actions and links to the right margin, as this could impact users
 
 ## Use the simplest pattern that works
 
-Users understand conventional form inputs and buttons. Don't reinvent the wheel and design new components when current ones meet the needs of the user.
+Users understand conventional form inputs and buttons. Don’t reinvent the wheel and design new components when current ones meet the needs of the user.
 
 ## Progressive disclosure
 
@@ -19,7 +19,7 @@ Progressive disclosure is a design pattern that allows users to access more info
 
 Avoid placing important information inside Progressive Disclosure patterns such as Accordions, Tabs or Details. This information should be visible to the user without having to expand the content.
 
-A [Modal](/components/modal) is another form of progressive disclosure. They are used in AgDS to confirm actions that are potentially destructive. They are also used in certain cases for displaying a list of fields to enable data filtering, when the amount of space needed isn't practical to display on the main app page. Modals should be used sparingly and only when other patterns, such as accordions, details or another page, are not suitable. Don't use a modal to contain a user flow such as a form or content.
+A [Modal](/components/modal) is another form of progressive disclosure. They are used in AgDS to confirm actions that are potentially destructive. They are also used in certain cases for displaying a list of fields to enable data filtering, when the amount of space needed isn’t practical to display on the main app page. Modals should be used sparingly and only when other patterns, such as accordions, details or another page, are not suitable. Don’t use a modal to contain a user flow such as a form or content.
 
 ## Dropdowns and tooltips
 
@@ -33,7 +33,7 @@ If you need to provide additional information, consider using a [Details](/compo
 
 When designing navigation components always consider small devices to make sure the solution is responsive and scalable.
 
-Don't rely on sideways scroll on nav bars unless you provide sufficient affordance that content is off the page.
+Don’t rely on sideways scroll on nav bars unless you provide sufficient affordance that content is off the page.
 
 ## Interactive elements
 

--- a/docs/content/foundations/icons.mdx
+++ b/docs/content/foundations/icons.mdx
@@ -6,9 +6,9 @@ description: The Agriculture Design System supports the use of universal system 
 
 ## Usage guidelines
 
-When using an icon, always provide a label and accessible name. Don't use icons without labels because you will confuse some users - even the simplest icons will be new or uncommon to some users
+When using an icon, always provide a label and accessible name. Don’t use icons without labels because you will confuse some users - even the simplest icons will be new or uncommon to some users
 
-Each icon in our library is meaningful and universal, to ensure users understand them. Icons should not be too detailed, to ensure it's clear at all sizes.
+Each icon in our library is meaningful and universal, to ensure users understand them. Icons should not be too detailed, to ensure it’s clear at all sizes.
 
 ## React component
 

--- a/docs/content/foundations/technical-overview.mdx
+++ b/docs/content/foundations/technical-overview.mdx
@@ -9,7 +9,7 @@ The AgDS component library has been built using [React](https://reactjs.org/). R
 
 ## NPM Packages
 
-The delivery method for the AgDS component library is via a single [NPM](https://www.npmjs.com/) package. NPM is the package manager for JavaScript and the world's largest software registry.
+The delivery method for the AgDS component library is via a single [NPM](https://www.npmjs.com/) package. NPM is the package manager for JavaScript and the world’s largest software registry.
 
 Every component in the AgDS component library has an individual entrypoint in the `@ag.ds-next/react` package. This keeps application bundles small and avoids end users downloading unnecessary dependencies.
 
@@ -17,17 +17,17 @@ Every component in the AgDS component library has an individual entrypoint in th
 
 All of the AgDS components are built using [Typescript](https://www.typescriptlang.org/), a typed superset of JavaScript that compiles to plain JavaScript.
 
-You don't need to be using Typescript in order to use the AgDS component library, but it is highly recommended.
+You don’t need to be using Typescript in order to use the AgDS component library, but it is highly recommended.
 
 ## Emotion
 
-[Emotion](https://emotion.sh/docs/introduction) is library designed for writing CSS styles with JavaScript. We use CSS-in-JS as it allows us to easily define and scope the styles for a component alongside it's definiton.
+[Emotion](https://emotion.sh/docs/introduction) is library designed for writing CSS styles with JavaScript. We use CSS-in-JS as it allows us to easily define and scope the styles for a component alongside its definiton.
 
 ## NextJS
 
 [NextJS](https://nextjs.org/) is a popular framework for building web applications with [React](https://reactjs.org/).
 
-Described as 'the SDK for the web', it handles the tooling and configuration needed for a React app, and provides additional structure, features, and optimizations for your application. It also has fantastic documentation and developer experience.
+Described as ‘the SDK for the web’, it handles the tooling and configuration needed for a React app, and provides additional structure, features, and optimizations for your application. It also has fantastic documentation and developer experience.
 
 We use NextJS to build our documentation site, templates and internal test applications.
 

--- a/docs/content/foundations/tokens/breakpoints.mdx
+++ b/docs/content/foundations/tokens/breakpoints.mdx
@@ -16,7 +16,7 @@ We encourage mobile design at 320px wide to encourage consideration of the small
 
 The AgDS React library provides first class support for responsive styles. The best way to take advantage of our breakpoints and responsive design is to use our **Responsive Props**. Instead of manually writing CSS media queries throughout your codebase, our primitive components allow you to provide objects to generate responsive styles in your project.
 
-In this example, we've made a simple Box, and passed an object to the `padding` prop. The keys in the object refer to the breakpoint name.
+In this example, we’ve made a simple Box, and passed an object to the `padding` prop. The keys in the object refer to the breakpoint name.
 
 ```tsx live showCode
 <Box background="shade" padding={{ xs: 1, sm: 2, md: 4 }}>
@@ -46,7 +46,7 @@ Under the hood, this simple example has generated the following CSS:
 
 You can see the breakpoints and internal media queries are written to be mobile-first. This means that the styles for the smallest breakpoint are applied first, and then progressively overridden as the viewport gets larger. The `padding` value is set to `1rem` by default - or from 0px, which is the `xs` breakpoint - and then we override it at each breakpoint, through a series of `min-width` media queries.
 
-You don't need to provide a value for every breakpoint. Just provide a value for mobile (xs), and add any additional breakpoint values as needed.
+You don’t need to provide a value for every breakpoint. Just provide a value for mobile (xs), and add any additional breakpoint values as needed.
 
 You can also define responsive styles as an array. To interpret array responsive values, we convert the values defined in our `breakpoints` token and sort them in ascending order. To skip certain breakpoints, you can pass `null` to any item in the array to avoid generating unnecessary CSS. This approach is not recommended.
 
@@ -58,7 +58,7 @@ You can also define responsive styles as an array. To interpret array responsive
 
 ### Usage in style objects
 
-Using our primitive components - including Responsive Props - is the best way to compose layouts. But sometimes primitive components don't support all of the style attributes you need. In these cases, you can use our breakpoints in your style objects, through the use of the `mq` and `mapResponsiveProp` functions.
+Using our primitive components - including Responsive Props - is the best way to compose layouts. But sometimes primitive components don’t support all of the style attributes you need. In these cases, you can use our breakpoints in your style objects, through the use of the `mq` and `mapResponsiveProp` functions.
 
 ```tsx
 import { mapResponsiveProp, mq } from '@ag.ds-next/react/core';

--- a/docs/content/guides/change-management.mdx
+++ b/docs/content/guides/change-management.mdx
@@ -25,7 +25,7 @@ We follow the [Semantic Versioning](https://semver.org/) system to classify chan
 
 ### Patch (fix)
 
-A change that fixes a bug or makes a small improvement which does not affect the API of the component. The consumer isn't expected to change their code to implement the update.
+A change that fixes a bug or makes a small improvement which does not affect the API of the component. The consumer isn’t expected to change their code to implement the update.
 
 For example…
 
@@ -36,7 +36,7 @@ The GitHub pull request related to a patch change can reviewed, merged, and rele
 
 ### Minor (feature)
 
-A new feature to an existing component, or the introduction of a new standalone component. The user can elect to implement the change but isn't forced to change existing code.
+A new feature to an existing component, or the introduction of a new standalone component. The user can elect to implement the change but isn’t forced to change existing code.
 
 For example…
 
@@ -58,13 +58,13 @@ For example…
 **Before this can be merged**, the community must be given a chance to give feedback on the change. Please follow the following steps.
 
 - Consult the Design System team of the change you intend to make
-- Open the PR as a draft, and add the "breaking" label. Notify the AgDS team
-- AgDS team will notify the community via the "Design System" chat in Microsoft Teams
+- Open the PR as a draft, and add the ‘breaking’ label. Notify the AgDS team
+- AgDS team will notify the community via the ‘Design System’ chat in Microsoft Teams
 - Leave the PR open for at least one week, to give the community a chance to give feedback by commenting on the GitHub Pull Request
 - Consider the feedback given and make any changes
 - The AgDS team will decide whether to merge the PR and release the change
 
-### 'No change'
+### ‘No change’
 
 Changes that do not affect our published artefacts such as the documentation website updates do not require any versioning updates.
 
@@ -74,7 +74,7 @@ As a rule, we do our best to design with the future in mind, to avoid breaking c
 
 Deprecation is a process of warning users that a component or prop will be removed in a future release. This gives users a chance to update their code before the change is made.
 
-If we intend to deprecate a component or prop, the process for communicating breaking changes, as outlined above, must be followed. A Github Pull Request will be created as a draft and will include the "deprecation" label. The community will be given one week to give feedback, before we decide whether to merge the PR and release the change.
+If we intend to deprecate a component or prop, the process for communicating breaking changes, as outlined above, must be followed. A Github Pull Request will be created as a draft and will include the ‘deprecation’ label. The community will be given one week to give feedback, before we decide whether to merge the PR and release the change.
 
 ## About Changesets
 

--- a/docs/content/guides/custom-theme.mdx
+++ b/docs/content/guides/custom-theme.mdx
@@ -15,7 +15,7 @@ Each foreground, background, border, and system colour has a specific purpose. T
 
 Each Theme has a dark and light palette. These can be used to divide an interface into sections. For example, the header and footer for this website uses the dark palette to make them more prominent, while the content area in between uses the light palette.
 
-Palettes are selected by setting the `palette` prop on a parent `Box`, `Flex` or `Stack`. The palette is _inherited_ by all of that element's children.
+Palettes are selected by setting the `palette` prop on a parent `Box`, `Flex` or `Stack`. The palette is _inherited_ by all of that element’s children.
 
 In the example below, change the palette prop in the parent Stack to see this behaviour in action.
 
@@ -89,7 +89,7 @@ import { Theme } from '@ag.ds-next/react/core';
 export const myTheme: Theme = {};
 ```
 
-..and import that into your application's Core component.
+..and import that into your application’s Core component.
 
 ```tsx
 // pages/_app.tsx

--- a/docs/content/guides/figma.mdx
+++ b/docs/content/guides/figma.mdx
@@ -16,7 +16,7 @@ For assistance with Figma accounts, please contact the Research Operations team.
 
 ## Get started
 
-To start using the AgDS Design System in Figma, you will need to enable the **AgDS Figma Component Library** in your team's project file. This will give you access to all of the components and tokens in AgDS. The component library is available in any Figma file you create in the DAFF Figma organisation. Simply select the latest version and activate it to enable all current components in any file.
+To start using the AgDS Design System in Figma, you will need to enable the **AgDS Figma Component Library** in your team’s project file. This will give you access to all of the components and tokens in AgDS. The component library is available in any Figma file you create in the DAFF Figma organisation. Simply select the latest version and activate it to enable all current components in any file.
 
 Once the library is enabled, you can copy the compositions in the Gallery and Templates pages of the AgDS Design file, and compose them to create interfaces for your product.
 
@@ -30,4 +30,4 @@ Our components are built using the same properties as the React components, so d
 
 The **[AgDS Figma File](https://www.figma.com/files/project/37217032/AgDS-Agriculture-Design-System?fuid=1049534194839136217)** contains all of the components, colours, icons, and font-styles needed to build applications for the Export Service. It also contains a gallery of examples of common components variants, and general design guidance for using the components. This file is also where the **AgDS Figma Component Library** is published from.
 
-The **AgDS Component development and testing file** is the Design System Team's working file. All new components, bug fixes and patterns are developed here. Please get in touch if you would like to contribute.
+The **AgDS Component development and testing file** is the Design System Team’s working file. All new components, bug fixes and patterns are developed here. Please get in touch if you would like to contribute.

--- a/docs/content/guides/forms.mdx
+++ b/docs/content/guides/forms.mdx
@@ -8,7 +8,7 @@ opener: Web forms are one of the main points of interaction between a user and a
 
 ## 1. Install AgDS
 
-If you haven't already installed AgDS in your application, please refer to the [Getting started guide](/guides/getting-started).
+If you haven’t already installed AgDS in your application, please refer to the [Getting started guide](/guides/getting-started).
 
 ## 2. Compose the user interface
 
@@ -250,7 +250,7 @@ export function FormExampleSignIn() {
 }
 ```
 
-## What's next?
+## What’s next?
 
 Take a look at our wide range of [form components](/components), and install the ones you need in your application.
 

--- a/docs/content/guides/getting-started.mdx
+++ b/docs/content/guides/getting-started.mdx
@@ -66,7 +66,7 @@ Your `.babelrc` should contain:
 }
 ```
 
-If you're using typescript, your TSConfig `compilerOptions` should contain:
+If you’re using typescript, your TSConfig `compilerOptions` should contain:
 
 ```
 
@@ -108,13 +108,13 @@ export default function MyApp({ Component, pageProps }) {
 }
 ```
 
-## That's it
+## That’s it
 
 You can now start using our components!
 
 > We recommend using TypeScript to get the most out of these components. Our example site already uses TypeScript so you can use that as reference. [See code](https://github.com/agriculturegovau/agds-next/tree/main/example-site).
 
-## What's next?
+## What’s next?
 
 [Explore our example site](/example-site) to see our list of interface examples, as well as the [related code on GitHub](https://github.com/agriculturegovau/agds-next/tree/main/example-site).
 

--- a/docs/content/guides/how-to-write-guidance/about-this-guide.mdx
+++ b/docs/content/guides/how-to-write-guidance/about-this-guide.mdx
@@ -29,7 +29,7 @@ It focuses on the Digital Services to Take Farmers to Markets (TFTM) program and
 
 But it should align with usage across [Busting Congestion](https://www.agriculture.gov.au/sites/default/files/documents/budget-2020-21-busting-congestion-for-agricultural-exporters.pdf), DAFF and wider government. It’s important to provide our end users with consistent and [Connected experiences](./types-of-content#connected-experiences) across government services.
 
-Please note, this guide and the Agriculture Design System's [Content](/content) section is not for use for DAFF staff engaged in regulatory work for agricultural exports.
+Please note, this guide and the Agriculture Design System’s [Content](/content) section is not for use for DAFF staff engaged in regulatory work for agricultural exports.
 
 These users require knowledge products that support good regulatory outcomes. For example, training packages and instructional materials.
 

--- a/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
+++ b/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
@@ -270,7 +270,7 @@ See the Export Service [Help](https://exports.agriculture.gov.au/help) section f
 
 ```jsx live enableProse exampleContentHeadingType="h4"
 <Prose>
-	<h2>To remove someone's access:</h2>
+	<h2>To remove someone’s access:</h2>
 	<ol>
 		<li>
 			<a href="https://authorisationmanager.gov.au/#/login">Log in</a> to
@@ -351,7 +351,7 @@ A user must select the checkbox to confirm their consent and continue to move th
 
 - **keep content concise**. Big chunks of legal guidance make complex information even harder to consume. Break long paragraphs into several short ones so users can read it more easily.
 
-- **use first and second-person point of view where appropriate**. For example, you can often update 'Commonwealth' to ‘we’ references in legal content. Check any updates you propose with the relevant legal team first.
+- **use first and second-person point of view where appropriate**. For example, you can often update ‘Commonwealth’ to ‘we’ references in legal content. Check any updates you propose with the relevant legal team first.
 
 - **maintain legal content**. You’re responsible for the ongoing management of legal content and its removal if it’s no longer needed. If you release a new feature, update any related privacy notice or disclaimer to cover the new functionality.
 

--- a/docs/content/guides/how-to-write-guidance/what-is-guidance-and-support.mdx
+++ b/docs/content/guides/how-to-write-guidance/what-is-guidance-and-support.mdx
@@ -1,5 +1,5 @@
 ---
-title: What is guidance, and what's support?
+title: What is guidance, and what’s support?
 overview: Find out what guidance and support are and how they connect in the Export Service.
 order: 2
 ---
@@ -24,7 +24,7 @@ Guidance is not just text content. Some common examples of guidance are:
 - forms, like a tailored response to user inputs or a field’s [hint text](/components/field)
 - patterns, like the interactive guidance tool to [Find an export guide for agricultural goods](https://exports.agriculture.gov.au/guides/export-guide-agricultural-goods)
 - templates, like those in [AgDS](/templates)
-- communications, like Austrade's Export Service [News](https://www.austrade.gov.au/news/latest-from-austrade/new-agriculture-export-service-to-make-it-easier-to-get-agri-goods-overseas) page
+- communications, like Austrade’s Export Service [News](https://www.austrade.gov.au/news/latest-from-austrade/new-agriculture-export-service-to-make-it-easier-to-get-agri-goods-overseas) page
 - legal content, like disclaimers and consent content.
 
 For more information, see [Types of content](./types-of-content).

--- a/docs/content/patterns/accessible-form-validation-and-recovery/index.mdx
+++ b/docs/content/patterns/accessible-form-validation-and-recovery/index.mdx
@@ -6,7 +6,7 @@ relatedComponents: ['page-alert']
 
 <DoHeading />
 
-- summarise the errors as a list inside of a [Page alert](/components/page-alert) component with the 'error' tone when more than one form validation error has occurred
+- summarise the errors as a list inside of a [Page alert](/components/page-alert) component with the ‘error’ tone when more than one form validation error has occurred
 - place the [Page alert](/components/page-alert) component near the top of the page, below the H1 and introductory paragraph, and focus immediately after a submission attempt
 - validate a form page when the user attempts to submit or save and continue
 - always display fields with form validation errors as invalid with error messages
@@ -31,7 +31,7 @@ It is important that users do not lose the data they have entered when they atte
 
 ## Summarising form validation errors
 
-When more than one form validation error has occurred, form validation errors should be summarised as a list inside of a [Page alert](/components/page-alert) component with the 'error' tone. The [Page alert](/components/page-alert) component should be placed at the top of the form and focused immediately after a submission attempt to ensure it is visible and announced to screen reader users.
+When more than one form validation error has occurred, form validation errors should be summarised as a list inside of a [Page alert](/components/page-alert) component with the `'error'` tone. The [Page alert](/components/page-alert) component should be placed at the top of the form and focused immediately after a submission attempt to ensure it is visible and announced to screen reader users.
 
 To helps users quickly identify and navigate to the problematic areas of the form, each error in the list should scroll and focus the user focus respective form field when clicked. This can be done with the [useScrollToField](/components/field#usescrolltofield) hook.
 

--- a/docs/content/patterns/focus-mode/index.mdx
+++ b/docs/content/patterns/focus-mode/index.mdx
@@ -10,7 +10,7 @@ Focus mode refers to temporarily hiding the main navigation of a website or appl
 
 - use focus mode on multi-page forms
 - trigger a [Modal](/components/modal) dialog if users navigate away from the form flow to help prevent them from losing data
-- always ensure the user can escape focus mode via a 'back', 'save and exit' or 'cancel' button.
+- always ensure the user can escape focus mode via a ‘back’, ‘save and exit’ or ‘cancel’ button.
 
 <DontHeading />
 
@@ -22,7 +22,7 @@ The [App layout sidebar](/components/app-layout#app-layout-sidebar) should be hi
 
 <DontHeading />
 
-Display the [App layout sidebar](/components/app-layout#app-layout-sidebar) with the [Progress indicator](/components/progress-indicator), as they're both navigational items that compete for attention. Displaying both on the screen also limits space for the main content.
+Display the [App layout sidebar](/components/app-layout#app-layout-sidebar) with the [Progress indicator](/components/progress-indicator), as they’re both navigational items that compete for attention. Displaying both on the screen also limits space for the main content.
 
 <ImageWithBorder
 	alt="Screenshot of App layout components with an outlined box highlighting the App layout sidebar component"
@@ -51,11 +51,11 @@ To do this, please refer the code example in the [example site](https://github.c
 
 ## Modal dialog
 
-Even though focus mode hides the main navigation, users could still navigate away from the form via the links in the header, footer, or even the browser back button. To help prevent users from losing data they've already entered into a form, trigger a [Modal](/components/modal) dialog in case they mistakenly navigated away from the form.
+Even though focus mode hides the main navigation, users could still navigate away from the form via the links in the header, footer, or even the browser back button. To help prevent users from losing data they’ve already entered into a form, trigger a [Modal](/components/modal) dialog in case they mistakenly navigated away from the form.
 
 [View storybook preview](/storybook/index.html?path=/story/content-modal--leaving-form-page)
 
 <ImageWithBorder
-	alt="Screenshot of an open Modal dialog with the title 'Are you sure you want to leave this page' and description 'You will lose all changes made since your last save.'"
+	alt="Screenshot of an open Modal dialog with the title ‘Are you sure you want to leave this page?’ and description ‘You will lose all changes made since your last save.’"
 	src="/img/patterns/focus-mode-modal.png"
 />

--- a/docs/content/patterns/messaging/index.mdx
+++ b/docs/content/patterns/messaging/index.mdx
@@ -69,7 +69,7 @@ A border is added to the left-margin of the input to group the message to the co
 
 [Callouts](/components/callout) are used draw attention to persistent, important or interesting information and should not be used to communicate validation or status.
 
-An information hierarchy can be created with Callouts by applying the Feature, Information and Neutral variants of the component. The Feature variant of Callout has a larger icon and heading to draw a users attention.
+An information hierarchy can be created with Callouts by applying the Feature, Information and Neutral variants of the component. The Feature variant of Callout has a larger icon and heading to draw a user’s attention.
 
 ```jsx live
 <Callout title="Callout heading">

--- a/docs/content/patterns/search-filters/index.mdx
+++ b/docs/content/patterns/search-filters/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: Search filters
-description: Search filters help users find what they're looking for by displaying options that meet specified criteria.
+description: Search filters help users find what they’re looking for by displaying options that meet specified criteria.
 figmaTemplateNodeId: 18586-56265
 githubTemplatePath: /.storybook/stories/DataFiltering
 storybookPath: story/patterns-search-filters--cards
 relatedComponents: ['card', 'drawer', 'filter-sidebar', 'pagination', 'table']
 ---
 
-Search filters help users find what they're looking for by displaying options that meet specified criteria.
+Search filters help users find what they’re looking for by displaying options that meet specified criteria.
 
 Applied filters are displayed as tags, so users can quickly see which filters have been applied to the dataset. Filters can be removed by dismissing the tags.
 
@@ -184,7 +184,7 @@ Filters are available in 3 sizes to accommodate a wide range of use cases and da
 
 ### Medium
 
-3-6 filters are displayed in an accordion that is triggered by a 'Show filters' button.
+3-6 filters are displayed in an accordion that is triggered by a ‘Show filters’ button.
 
 1 to 2 of the most used filters can be displayed outside the accordion to make them easier and faster to access.
 
@@ -199,7 +199,7 @@ Applied filters are displayed as tags under the filter inputs. This helps users 
 
 ### Large
 
-6 or more filters are displayed in a drawer that is triggered by a 'Show filters' button. The drawer has a submit button that applies the filters.
+6 or more filters are displayed in a drawer that is triggered by a ‘Show filters’ button. The drawer has a submit button that applies the filters.
 
 1 to 2 of the most used filters can be displayed outside the drawer to make them easier and faster to access.
 
@@ -218,8 +218,8 @@ The [Drawer](/components/drawer) component should contain a total of 4 actions:
 
 1. **Apply filters button:** When pressed, filters should be applied and the drawer should be closed.
 2. **Clear filters button:** When pressed, filters should be reset to their original state. The drawer should stay open.
-3. **Close button:** When pressed, the drawer should close. Any changes that have been made since opening the drawer should be discarded. This is essentially the same as the 'Cance' button.
-4. **Cancel button:** When pressed, the drawer should close. Any changes that have been made since opening the drawer should be discarded. This is essentially the same as the 'Close' button.
+3. **Close button:** When pressed, the drawer should close. Any changes that have been made since opening the drawer should be discarded. This is essentially the same as the ‘Cancel’ button.
+4. **Cancel button:** When pressed, the drawer should close. Any changes that have been made since opening the drawer should be discarded. This is essentially the same as the ‘Close’ button.
 
 ## Search filter sidebar
 
@@ -238,7 +238,7 @@ Since the filters are always visible, there is no need to also include tags to s
 
 ## Empty state
 
-When a search filter doesn't match any data, use an [empty state](/patterns/loading-error-empty-states) to let user’s know that they need to clear or change the search filter.
+When a search filter doesn’t match any data, use an [empty state](/patterns/loading-error-empty-states) to let user’s know that they need to clear or change the search filter.
 
 ```jsx live
 <Stack gap={3}>

--- a/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
+++ b/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
@@ -8,7 +8,7 @@ githubTemplatePath: /.storybook/stories/SelectableTableBatchActions
 
 ## Individual row selection
 
-To toggle the selection of an individual row, users can use the [Checkbox](/components/checkbox) in the first column which should have the row heading "Select".
+To toggle the selection of an individual row, users can use the [Checkbox](/components/checkbox) in the first column which should have the row heading ‘Select’.
 
 Selected rows have a solid action coloured outline, which is achieved by setting `selected={true}` on the `TableRow` component.
 
@@ -57,11 +57,11 @@ Selected rows have a solid action coloured outline, which is achieved by setting
 
 ## Selecting all rows
 
-To toggle the selection of all rows at once, users can use the "Select all rows" checkbox above the table. The "Select all rows" checkbox should always be placed just above the table element, with a border to divide the two elements.
+To toggle the selection of all rows at once, users can use the ‘Select all rows’ checkbox above the table. The ‘Select all rows’ checkbox should always be placed just above the table element, with a border to divide the two elements.
 
-Do not use `TableCaption` component in combination with the "Select all rows" checkbox as the caption will sit in between the checkbox and table. Instead, place a [Heading](/components/heading) component above the Checkbox and connect the heading and table using `aria-labelledby`. For more information, please refer to the [Labels and headings](/components/table#labels-and-headings) section of the table documentation.
+Do not use `TableCaption` component in combination with the ‘Select all rows’ checkbox as the caption will sit in between the checkbox and table. Instead, place a [Heading](/components/heading) component above the Checkbox and connect the heading and table using `aria-labelledby`. For more information, please refer to the [Labels and headings](/components/table#labels-and-headings) section of the table documentation.
 
-Unlike the checkboxes in each row, the "Select all rows" checkbox above the table has three states: checked, unchecked, and indeterminate. When some, but not all, rows are selected, the "Select all rows" checkbox should enter an indeterminate state. This visual indicator signals to users that not all rows are selected and allows them to toggle all rows on or off with a single click.
+Unlike the checkboxes in each row, the ‘Select all rows’ checkbox above the table has three states: checked, unchecked, and indeterminate. When some, but not all, rows are selected, the ‘Select all rows’ checkbox should enter an indeterminate state. This visual indicator signals to users that not all rows are selected and allows them to toggle all rows on or off with a single click.
 
 ```jsx live
 () => {
@@ -154,7 +154,7 @@ Only small [Buttons](/components/button) should be placed inside of the `TableBa
 <DoHeading />
 
 - ensure each batch action can be performed on every selectable row
-- include a "Cancel" button at the end of the batch actions button group
+- include a ‘Cancel’ button at the end of the batch actions button group
 - use small buttons for batch actions
 
 <DontHeading />

--- a/docs/content/templates/content/index.mdx
+++ b/docs/content/templates/content/index.mdx
@@ -10,9 +10,9 @@ storybookPath: /story/templates-content-page--with-side-nav
 
 ## Usage guidelines
 
-- Don't split content into multiple columns. Text and other content should be stacked in the right column.
-- Don't use the left column for content. It's reserved for optional side navigation.
+- Don’t split content into multiple columns. Text and other content should be stacked in the right column.
+- Don’t use the left column for content. It’s reserved for optional side navigation.
 - Add an [Inpage nav navigation component](/components/inpage-nav) to longer pages. If your page has more than 2 second-level headings, consider adding in-page navigation. This will help users find what they need quickly.
-- Don't overuse the [Callout component](/components/callout) or use them to display important information that isn't included elsewhere on the page. Users can mistake them for ads or banners and may ignore them.
+- Don’t overuse the [Callout component](/components/callout) or use them to display important information that isn’t included elsewhere on the page. Users can mistake them for ads or banners and may ignore them.
 - Keep important content at the top of the page.
 - Use clear descriptive headings.

--- a/docs/content/templates/error-page/Maintenance.tsx
+++ b/docs/content/templates/error-page/Maintenance.tsx
@@ -9,10 +9,10 @@ export const Maintenance = () => {
 		<PageContent>
 			<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
 				<Prose>
-					<h1>We&apos;re updating the Export Service</h1>
+					<h1>We’re updating the Export Service</h1>
 					<p>
-						While we&apos;re down for planned maintenance, you won&apos;t be
-						able to access our services.
+						While we’re down for planned maintenance, you won’t be able to
+						access our services.
 					</p>
 					<p>Please check back soon.</p>
 				</Prose>

--- a/docs/content/templates/error-page/ScheduledOutage.tsx
+++ b/docs/content/templates/error-page/ScheduledOutage.tsx
@@ -10,14 +10,14 @@ export const ScheduledThirdPartyOutage = () => {
 		<PageContent>
 			<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
 				<Prose>
-					<h1>There&apos;s a problem with the Export Service</h1>
+					<h1>There’s a problem with the Export Service</h1>
 					<p>
 						Relationship Autorisation Manager (RAM) is down for system
 						maintenance from 11:30 pm, 15 October to 7pm, 16 October.
 					</p>
 					<p>
-						During this time you can&apos;t create an account or sign into the
-						Export Service. Please try again later.
+						During this time you can’t create an account or sign into the Export
+						Service. Please try again later.
 					</p>
 				</Prose>
 				<Callout title="Need more help?">

--- a/docs/content/templates/error-page/ServerError.tsx
+++ b/docs/content/templates/error-page/ServerError.tsx
@@ -10,9 +10,9 @@ export const ServerError = () => {
 		<PageContent>
 			<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
 				<Prose>
-					<h1>Something's not right</h1>
+					<h1>Something’s not right</h1>
 					<p>
-						There's a problem with the Export Service. We're working to fix it.
+						There’s a problem with the Export Service. We’re working to fix it.
 						Please try again later.
 					</p>
 					<p>You may be able to access other parts of the Export Service.</p>

--- a/docs/content/templates/error-page/ThirdPartyOutage.tsx
+++ b/docs/content/templates/error-page/ThirdPartyOutage.tsx
@@ -10,9 +10,9 @@ export const ThirdPartyOutage = () => {
 		<PageContent>
 			<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
 				<Prose>
-					<h1>There&apos;s a problem with the Export Service</h1>
+					<h1>There’s a problem with the Export Service</h1>
 					<p>
-						Digital Identity is currently experiencing an outage. You can&apos;t
+						Digital Identity is currently experiencing an outage. You can’t
 						create an account or sign into the Export Service right now. Please
 						try again later.
 					</p>

--- a/docs/content/templates/index.mdx
+++ b/docs/content/templates/index.mdx
@@ -1,4 +1,4 @@
 ---
 title: Templates
-description: Templates can get your project up and running faster. They'll save your team time and resources and help get value to your users sooner.
+description: Templates can get your project up and running faster. They’ll save your team time and resources and help get value to your users sooner.
 ---

--- a/docs/content/templates/multi-page-form/index.mdx
+++ b/docs/content/templates/multi-page-form/index.mdx
@@ -12,20 +12,20 @@ storybookPath: /story/templates-multi-page-form--intro-page
 
 - Try to limit forms to a single question per page (a question could include multiple related fields).
 - Place the [Progress indicator component](/components/progress-indicator) in left column.
-- The mobile version of the [Progress indicator](/components/progress-indicator) compresses into accordion to ensure it's not in the way of filling out the form.
+- The mobile version of the [Progress indicator](/components/progress-indicator) compresses into accordion to ensure it’s not in the way of filling out the form.
 - Avoid using disabled buttons in the [Progress indicator](/components/progress-indicator).
 - Avoid adding or removing dynamic list items in [Progress indicator](/components/progress-indicator).
 - Include a sub heading above the [H1](/components/heading) to tie form steps together.
 - Include a [Button group](/components/button#button-groups) at the bottom.
-- Ensure primary button text is contextual, and consistent with the page heading - e.g 'Register establishment'. Avoid vague labels such as 'Submit'.
+- Ensure primary button text is contextual, and consistent with the page heading - e.g. ‘Register establishment’. Avoid vague labels such as ‘Submit’.
 - Hide [Breadcrumbs](/components/breadcrumbs) and [Side nav](/components/side-nav) to create focus on the form and reduce distractions.
-- Include a 'back' link at the top.
+- Include a ‘back’ link at the top.
 
-### Rationale behind having the 'back' link at the top:
+### Rationale behind having the ‘back’ link at the top:
 
-- It's a familiar position for the back button on mobile and web browsers.
-- It's a conventional position for secondary navigation - breadcrumbs and back button.
+- It’s a familiar position for the back button on mobile and web browsers.
+- It’s a conventional position for secondary navigation - breadcrumbs and back button.
 - People can quickly go back to check the previous form.
-- There's less chance of people going back and losing a filled form by mistake.
+- There’s less chance of people going back and losing a filled form by mistake.
 - It minimises the time for a user to proceed by reducing options near primary actions.
-- It maintains accurate visual hierarchy making the back action less prominent than the primary action 'Continue'.
+- It maintains accurate visual hierarchy making the back action less prominent than the primary action ‘Continue’.

--- a/docs/content/templates/sign-in/SignInForm.tsx
+++ b/docs/content/templates/sign-in/SignInForm.tsx
@@ -155,7 +155,7 @@ export const SignInFormPage = () => {
 						<Divider />
 						<Prose>
 							<p>
-								Don&apos;t have an account? <a href="#">Create account</a>
+								Don’t have an account? <a href="#">Create account</a>
 							</p>
 							<p>
 								Read our <a href="#">privacy policy</a>

--- a/docs/content/templates/single-page-form/index.mdx
+++ b/docs/content/templates/single-page-form/index.mdx
@@ -23,18 +23,18 @@ storybookPath: /story/templates-single-page-form--form-page
 
 Present forms in a single column layout for efficiency and to avoid people missing fields in other columns (especially those using screen magnifiers).
 
-Try to limit forms to a single question per page. A question could include multiple related inputs, such as a street address. Break up large forms [into multiple steps](multi-page-form) to decrease cognitive load. In cases where this isn't possible, group related fields using [fieldsets](/components/fieldset).
+Try to limit forms to a single question per page. A question could include multiple related inputs, such as a street address. Break up large forms [into multiple steps](multi-page-form) to decrease cognitive load. In cases where this isn’t possible, group related fields using [fieldsets](/components/fieldset).
 
 ### Required vs optional fields
 
-Try to only ask for necessary information. Avoid optional fields by asking users to opt in first. If you can’t avoid optional fields, indicate them with (optional) in label. Place text at the top of the page that says 'All fields are required unless marked optional.'
+Try to only ask for necessary information. Avoid optional fields by asking users to opt in first. If you can’t avoid optional fields, indicate them with (optional) in label. Place text at the top of the page that says ‘All fields are required unless marked optional’.
 
 ### Buttons
 
 Left align buttons, starting with the primary button on the far left. Right aligned buttons can be missed, especially by those using screen magnifyers.
 Only include one primary button per page.
 
-Use descriptive button text. A simple rule that works most of the time is to start with a verb and end with a noun. For example, 'Submit application'.
+Use descriptive button text. A simple rule that works most of the time is to start with a verb and end with a noun. For example, ‘Submit application’.
 
 Try to avoid disabled buttons as they can be problematic for some users - They don’t provide feedback why they’re not clickable causing people to get stuck. They are also hard to see for those with poor eyesight, and aren’t natively keyboard accessible.
 
@@ -42,7 +42,7 @@ Instead, allow users to interact with buttons and receive feedback.
 
 ### Error messages
 
-A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [Page alert](/components/page-alert) with the 'error' tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
+A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [Page alert](/components/page-alert) with the `'error'` tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
 
 ```tsx live
 <PageAlert tone="error" title="There is a problem">
@@ -83,7 +83,7 @@ An invalid field is highlighted with a red border and a red error message. They 
 
 ### Success messaging
 
-When a form is successfully completed, return the user to the entry point of the form and display a [Page alert](/components/page-alert) with the 'success' tone and a clear message which communicates the successful submission. When possible, provide persistent methods for a user to return and see the status of the submitted artefact, for example a reference number.
+When a form is successfully completed, return the user to the entry point of the form and display a [Page alert](/components/page-alert) with the `'success'` tone and a clear message which communicates the successful submission. When possible, provide persistent methods for a user to return and see the status of the submitted artefact, for example a reference number.
 
 ```tsx live
 <PageAlert

--- a/docs/content/updates/2022-01-24.mdx
+++ b/docs/content/updates/2022-01-24.mdx
@@ -1,6 +1,6 @@
 ---
 title: January 24th, 2022
-description: Add new components "Breadcrumbs", "Icon" and "SideNav".
+description: Add new components ‘Breadcrumbs’, ‘Icon’ and ‘SideNav’.
 ---
 
 Add new components!

--- a/docs/content/updates/2022-02-08.mdx
+++ b/docs/content/updates/2022-02-08.mdx
@@ -1,6 +1,6 @@
 ---
 title: February 8th, 2022
-description: Add new components "Button", "ButtonLink", "Columns", "Column" and "Card".
+description: Add new components ‘Button’, ‘ButtonLink’, ‘Columns’, ‘Column’ and ‘Card’.
 ---
 
 > ⚠️ Note: All releases under the `@ag.ds-next` package scope should be considered alpha pre-releases. Expect breaking changes. Once we are happy with the state of the core packages we will migrate all packages to `@ag.ds`.

--- a/docs/content/updates/2022-04-28.mdx
+++ b/docs/content/updates/2022-04-28.mdx
@@ -17,7 +17,7 @@ description: Add HeroBanner and Loading. Various bug fixes and improvements.
 ### @ag.ds-next/modal@2.0.0
 
 - Title is required. Also, resolves issue with Chrome not reading title in VoiceOver.
-- Buttons now appear at bottom of screen in Mobile view. We have achieved this by changing the way buttons are added to a modal - via a 'actions' prop on the Modal.
+- Buttons now appear at bottom of screen in Mobile view. We have achieved this by changing the way buttons are added to a modal - via an `actions` prop on the Modal.
 - Improve mobile styles
 - Design improvements
 - Prevented the body from being scrollable while modal is open

--- a/docs/content/updates/2022-05-30.mdx
+++ b/docs/content/updates/2022-05-30.mdx
@@ -60,7 +60,7 @@ description: Add ButtonGroup component. Various bug fixes and improvements.
 ### @ag.ds-next/breadcrumbs@9.0.0
 
 - Use ordered-list HTML element
-- Read out 'current page' for active item
+- Read out ‘current page’ for active item
 
 ### @ag.ds-next/call-to-action@5.0.0
 

--- a/docs/content/updates/2022-07-27.mdx
+++ b/docs/content/updates/2022-07-27.mdx
@@ -81,7 +81,7 @@ In this release, we rethought our `<Columns />` component, improved many of our 
 - Upgraded `react-day-picker` dependency
 - Added the ability to disable dates through new `minDate` and `maxDate` props
 - Fixed bug where incorrect element was being focused when calendar first opened
-- Fixed bug where users couldn't input a date using the text input after a value was set
+- Fixed bug where users couldn’t input a date using the text input after a value was set
 - Added `@babel/runtime` as a package dependency
 - Updated documentation
 

--- a/docs/content/updates/2022-08-26.mdx
+++ b/docs/content/updates/2022-08-26.mdx
@@ -25,7 +25,7 @@ description: Prose component. Text variant for Button. New Header, Footer and Ma
 
 ### @ag.ds-next/prose@1.0.0
 
-We've renamed our `Body` component to `Prose` to be more unique.
+We’ve renamed our `Body` component to `Prose` to be more unique.
 
 ```diff
 - import { Body } from '@ag.ds-next/react/body'
@@ -34,11 +34,11 @@ We've renamed our `Body` component to `Prose` to be more unique.
 
 ### @ag.ds-next/ag-branding@7.0.0
 
-We've improved our brand's background and system colours for the dark palette. The token schema matches the same shape as in `@ag.ds-next/core` (see below).
+We’ve improved our brand’s background and system colours for the dark palette. The token schema matches the same shape as in `@ag.ds-next/core` (see below).
 
 ### @ag.ds-next/core@4.0.0
 
-We've significantly improved the colour token schema by giving all system colours a light and dark version.
+We’ve significantly improved the colour token schema by giving all system colours a light and dark version.
 
 Going forward, `globalPalette` should be avoided. Use `boxPalette` where possible to apply colour tokens.
 
@@ -224,7 +224,7 @@ Added mobile variant which shows a link to the immediate parent.
 
 ### @ag.ds-next/button@11.0.0
 
-We've added a new `text` variant to the Button component. It replaces the TextButton component which used to come from `@ag.ds-next/text-link`.
+We’ve added a new `text` variant to the Button component. It replaces the TextButton component which used to come from `@ag.ds-next/text-link`.
 
 ```jsx live
 <Button variant="text">Edit</Button>

--- a/docs/content/updates/2022-10-24.mdx
+++ b/docs/content/updates/2022-10-24.mdx
@@ -188,8 +188,8 @@ You can [learn more about SummaryList in the component docs](https://design-syst
 
 ### @ag.ds-next/pagination@4.0.0
 
-- Improved accessibility by rading out 'current page' in `PaginationItemPageButton`
-- Improved accessibility by rading out 'ellipsis' in `PaginationItemSeperator`
+- Improved accessibility by reading out ‘current page’ in `PaginationItemPageButton`
+- Improved accessibility by reading out ‘ellipsis’ in `PaginationItemSeperator`
 
 ### @ag.ds-next/progress-indicator@13.0.0
 

--- a/docs/content/updates/2023-01-04.mdx
+++ b/docs/content/updates/2023-01-04.mdx
@@ -50,7 +50,7 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 - Improved styles to combobox buttons (dropdown indicator and clear button)
 - Added debouncing to prevent unnecessary network requests
 - Removed `valid` prop
-- Added new prop `hideOptionalLabel`. If true, "(optional)" will never be appended to the label even when `required` is `false`.
+- Added new prop `hideOptionalLabel`. If true, ‘(optional)’ will never be appended to the label even when `required` is `false`.
 - Adjusted form field max widths
 
 ### @ag.ds-next/icon@13.0.0
@@ -79,7 +79,7 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 
 - Removed `valid` prop
 - Added `aria-invalid` and `aria-describedby` to `Checkbox` and `Radio`
-- Added new prop `hideOptionalLabel`. If true, "(optional)" will never be appended to the label even when `required` is `false`.
+- Added new prop `hideOptionalLabel`. If true, ‘(optional)’ will never be appended to the label even when `required` is `false`.
 
 ### @ag.ds-next/date-picker@10.0.0
 
@@ -92,7 +92,7 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 ### @ag.ds-next/field@12.0.0
 
 - Removed `valid` prop
-- Added new prop `hideOptionalLabel`. If true, "(optional)" will never be appended to the label even when `required` is `false`.
+- Added new prop `hideOptionalLabel`. If true, ‘(optional)’ will never be appended to the label even when `required` is `false`.
 - Adjusted form field max widths
 
 ### @ag.ds-next/file-upload@8.0.0
@@ -100,7 +100,7 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 - Removed `valid` prop
 - Show multiple errors per rejected file
 - Updated visual styles for default and active drag state
-- Added new prop `hideOptionalLabel`. If true, "(optional)" will never be appended to the label even when `required` is `false`.
+- Added new prop `hideOptionalLabel`. If true, ‘(optional)’ will never be appended to the label even when `required` is `false`.
 
 ### @ag.ds-next/progress-indicator@14.0.0
 
@@ -112,7 +112,7 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 
 - Removed `valid` prop
 - Adjusted form field max width and removed `xs` and `sm` options from the `maxWidth` prop
-- Added new prop `hideOptionalLabel`. If true, "(optional)" will never be appended to the label even when `required` is `false`.
+- Added new prop `hideOptionalLabel`. If true, ‘(optional)’ will never be appended to the label even when `required` is `false`.
 
 ### @ag.ds-next/task-list@12.0.0
 
@@ -125,13 +125,13 @@ You can [learn more about SearchInput in the component docs](https://design-syst
 
 - Removed `valid` prop
 - Adjusted form field max widths
-- Added new prop `hideOptionalLabel`. If true, "(optional)" will never be appended to the label even when `required` is `false`.
+- Added new prop `hideOptionalLabel`. If true, ‘(optional)’ will never be appended to the label even when `required` is `false`.
 
 ### @ag.ds-next/textarea@13.0.0
 
 - Removed `valid` prop
 - Adjusted form field max widths and removed `xs` and `sm` options from the `maxWidth` prop
-- Added new prop `hideOptionalLabel`. If true, "(optional)" will never be appended to the label even when `required` is `false`.
+- Added new prop `hideOptionalLabel`. If true, ‘(optional)’ will never be appended to the label even when `required` is `false`.
 
 ### @ag.ds-next/card@9.0.0
 

--- a/docs/content/updates/2023-03-20.mdx
+++ b/docs/content/updates/2023-03-20.mdx
@@ -29,7 +29,7 @@ description: Extended the functionality of Date picker and Date range picker, im
 
 ### [Date picker](/components/date-picker#date-picker)
 
-- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
+- Updated default label to show ‘(optional)’ when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
 - Added new prop `onInputChange` which can be used to track the value of the text input ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))
 - Updated the type of the `value` prop so it can accept string (which represents the value of the text input) ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))
 - Removed unused prop `placeholder` ([PR #1016](https://github.com/agriculturegovau/agds-next/pull/1016))
@@ -39,7 +39,7 @@ description: Extended the functionality of Date picker and Date range picker, im
 
 ### [Date range picker](/components/date-picker#date-range-picker)
 
-- Updated default label to show "(optional)" when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
+- Updated default label to show ‘(optional)’ when the field is not required. This is consistent with all other form components in the design system. ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
 - Updated the type of the `value` prop so it can accept string (which represents the value of the text inputs) ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))- Added new prop `onFromInputChange` and `onToInputChange` which can be used to track the value of the text inputs ([PR #997](https://github.com/agriculturegovau/agds-next/pull/997))
 - Added support for a legend to be supplied via a new `legend` prop. If no legend is supplied, a default legend of `Date range` will be rendered but will be visually hidden. ([PR #1000](https://github.com/agriculturegovau/agds-next/pull/1000))
 - Added support for hint text via the `hint` prop ([PR #1000](https://github.com/agriculturegovau/agds-next/pull/1000))
@@ -49,7 +49,7 @@ description: Extended the functionality of Date picker and Date range picker, im
 
 ### [Field](/components/field)
 
-- Updated behaviour of the `secondaryLabel` prop so it will prepend any text to the label instead of replacing default secondary label "(optional)". ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
+- Updated behaviour of the `secondaryLabel` prop so it will prepend any text to the label instead of replacing default secondary label ‘(optional)’. ([PR #1008](https://github.com/agriculturegovau/agds-next/pull/1008))
 - Added `className` prop to `FieldLabel` ([PR #998](https://github.com/agriculturegovau/agds-next/pull/998))
 - Fixed typos in hook `useScrollToField` ([PR #998](https://github.com/agriculturegovau/agds-next/pull/998))
 - Exported component props and added comments to props ([PR #998](https://github.com/agriculturegovau/agds-next/pull/998))

--- a/docs/content/updates/2023-06-12.mdx
+++ b/docs/content/updates/2023-06-12.mdx
@@ -13,7 +13,7 @@ description: Move nested components into their own entry points to improve docum
 
 ### [Autocomplete](/components/autocomplete)
 
-- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
+- Fixed bug where the ‘Clear’ button was not being rendered as expected ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
 - Added new prop `emptyResultsMessage` which can be used to display a message when no options match the users search term ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
 
 ### [Badge](/components/badge)
@@ -49,7 +49,7 @@ To upgrade, update the import when using these components.
 ### [Combobox](/components/combobox)
 
 - Remove `use-debounce` dependency ([PR #1131](https://github.com/agriculturegovau/agds-next/pull/1131))
-- Fixed bug where the "Clear" button was not being rendered as expected ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
+- Fixed bug where the ‘Clear’ button was not being rendered as expected ([PR #1123](https://github.com/agriculturegovau/agds-next/pull/1123))
 - Updated logic in the `splitLabel` helper function so options with special characters (brackets, slashes etc) are handled correctly ([PR #1176](https://github.com/agriculturegovau/agds-next/pull/1176))
 
 ### [Control input](/components/control-input)
@@ -74,7 +74,7 @@ To upgrade, update the import when using these components.
 
 ### [Date picker](/components/date-picker)
 
-[Date range picker](/components/date-range-picker) has been moved to it's own entry point.
+[Date range picker](/components/date-range-picker) has been moved to its own entry point.
 
 `DateRangePicker` will continue to work out of the the `@ag.ds-next/react/date-picker` entrypoint, but this usage has been marked as deprecated and will be removed in the next major release.
 

--- a/docs/content/updates/2023-10-04.mdx
+++ b/docs/content/updates/2023-10-04.mdx
@@ -8,7 +8,7 @@ description: Small patches to App layout, extended Table primitives to support b
 
 ### [App layout](/components/app-layout)
 
-- Fixed small issue in `AppLayoutSidebar` where the text color wasn't being applied correctly to text list items in dark mode
+- Fixed small issue in `AppLayoutSidebar` where the text color wasn’t being applied correctly to text list items in dark mode
 - Extended the `items` prop in `AppLayoutSidebar` to accept an object with `options` and `items`. This allows consumers to control the padding between sidebar navigation groups.
 
 ### [File upload](/components/file-upload)
@@ -26,7 +26,7 @@ description: Small patches to App layout, extended Table primitives to support b
 
 - Created new components for batch table actions: `TableBatchActionsBar` and `TableBatchActionsTitle`
 
-- Created new `TableRow` component. If you're using the standard `<tr>` HTML element, you can optionally upgrade to this new component.
+- Created new `TableRow` component. If you’re using the standard `<tr>` HTML element, you can optionally upgrade to this new component.
 
 ```diff
 <Table>

--- a/docs/content/updates/2023-10-17.mdx
+++ b/docs/content/updates/2023-10-17.mdx
@@ -8,7 +8,7 @@ description: Extended Pagination to support items range text and items per page 
 
 ### [App layout](/components/app-layout)
 
-- Removed "Menu" button from mobile variant when in focus mode
+- Removed ‘Menu’ button from mobile variant when in focus mode
 
 ### [Checkbox](/components/checkbox)
 
@@ -22,7 +22,7 @@ description: Extended Pagination to support items range text and items per page 
 
 - Improved accessibility by ensuring that the `DropdownMenuButton` component always has a valid `aria-controls` attribute
 - Improved accessibility by allowing users to press `Enter`, `Space`, `ArrowDown` or `ArrowUp` keys to open up the dropdown menu and activate a child descendant
-- Fixed a bug where keyboard shortcuts couldn't be used when the dropdown menu was open - e.g. refresh the page using cmd + r
+- Fixed a bug where keyboard shortcuts couldn’t be used when the dropdown menu was open - e.g. refresh the page using cmd + r
 - Improved accessibility by significantly improving the logic for searching for a child descendant
 
 ### [Icon](/components/icon)

--- a/docs/content/updates/2023-11-14.mdx
+++ b/docs/content/updates/2023-11-14.mdx
@@ -31,7 +31,7 @@ description: Initial release of Password input, improvements to Combobox, plus v
 ### [File input](/components/file-input)
 
 - Increased visual prominence of when a file has been uploaded by changing the font weight when a file has been added
-- Decreased the "Choose files" button size
+- Decreased the ‘Choose files’ button size
 - Fixed hover styles in file selector button
 
 ### [File upload](/components/file-upload)

--- a/docs/pages/foundations/tokens/colour.tsx
+++ b/docs/pages/foundations/tokens/colour.tsx
@@ -193,10 +193,10 @@ export default function TokensColorPage() {
 							<strong>Do</strong> pair foreground and background colours.
 						</li>
 						<li>
-							<strong>Don&apos;t</strong> mix light and dark variables.
+							<strong>Don’t</strong> mix light and dark variables.
 						</li>
 						<li>
-							<strong>Don&apos;t</strong> pair foreground with foreground or
+							<strong>Don’t</strong> pair foreground with foreground or
 							background with background.
 						</li>
 					</ul>

--- a/docs/pages/foundations/tokens/typography.tsx
+++ b/docs/pages/foundations/tokens/typography.tsx
@@ -47,7 +47,7 @@ export default function TokensTypographyPage() {
 					</p>
 
 					<p>
-						Using the design system&apos;s typography values means any object
+						Using the design system’s typography values means any object
 						containing text is more likely to align with another element. This
 						appearance of a baseline grid is created by automatically rounding
 						the line-heights to the nearest grid value 4px, then converting them

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -1,6 +1,6 @@
 const boilerplateSiteTemplate = (content: string) => `
 	<Box dark><Header background="bodyAlt" logo={<Logo />} heading="Export Service" />
-    <MainNav items={[{ label: "Home", href: "/" }]} secondaryItems={[{ label: 'Sign in', endElement: <AvatarIcon />}]} /></Box>
+    <MainNav items={[{ label: 'Home', href: '/' }]} secondaryItems={[{ label: 'Sign in', endElement: <AvatarIcon />}]} /></Box>
 		<PageContent as="main">${content}</PageContent>
     <Box dark><Footer background="bodyAlt">
     <nav aria-label="footer">

--- a/example-site/pages/sign-in-form.tsx
+++ b/example-site/pages/sign-in-form.tsx
@@ -159,7 +159,7 @@ export default function SignInFormPage() {
 								<Divider />
 								<Prose>
 									<p>
-										Don&apos;t have an account? <a href="#">Create account</a>
+										Don’t have an account? <a href="#">Create account</a>
 									</p>
 									<p>
 										Read our <a href="#">privacy policy</a>

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -77,7 +77,7 @@
 
   dropdown-menu: Improved accessibility by allowing users to press `Enter`, `Space`, `ArrowDown` or `ArrowUp` keys to open up the dropdown menu and activate a child descendant
 
-  dropdown-menu: Fixed a bug where keyboard shortcuts couldn't be used when the dropdown menu was open - e.g. refresh the page using cmd + r.
+  dropdown-menu: Fixed a bug where keyboard shortcuts couldn’t be used when the dropdown menu was open - e.g. refresh the page using cmd + r.
 
   dropdown-menu: Improved accessibility by significantly improving the logic for searching for a child descendant
 
@@ -122,7 +122,7 @@
 
   file-upload: Extended the `accept` prop so MIME types that are not in the predefined list can be used
 
-- b3e2e03b04: table: Created new `TableRow` component. If you're using the standard `<tr>` HTML element, you can optionally upgrade to this new component.
+- b3e2e03b04: table: Created new `TableRow` component. If you’re using the standard `<tr>` HTML element, you can optionally upgrade to this new component.
 
   ```diff
   <Table>
@@ -148,7 +148,7 @@
 ### Patch Changes
 
 - 61b5fabd85: file-upload: Added thumbnails to selected files
-- 431294adf2: app-layout: Fixed small issue in `AppLayoutSidebar` where the text color wasn't being applied correctly to text list items in dark mode
+- 431294adf2: app-layout: Fixed small issue in `AppLayoutSidebar` where the text color wasn’t being applied correctly to text list items in dark mode
 - bd89ce82ad: file-upload: Exported `formatFileSize` utility function. Example usage:
 
   ```tsx
@@ -415,7 +415,7 @@
   + import { StatusBadge } from '@ag.ds-next/react/status-badge';
   ```
 
-- 0942aab35d: `DateRangePicker` has been moved to it's own entry point.
+- 0942aab35d: `DateRangePicker` has been moved to it’s own entry point.
 
   `DateRangePicker` will continue to work out of the the `@ag.ds-next/react/date-picker` entrypoint, but this usage has been marked as deprecated and will be removed in the next major release.
 
@@ -460,7 +460,7 @@
 
 ### Minor Changes
 
-- f4aed33922: Replaced some react spring animations with CSS animations/transitions. This change improves performance by removing Javascript and utilising the browser's ability to process CSS.
+- f4aed33922: Replaced some react spring animations with CSS animations/transitions. This change improves performance by removing Javascript and utilising the browser’s ability to process CSS.
 
   Accordion: Replaced chevron icon react spring animation with CSS animation
 

--- a/packages/react/src/accordion/docs/overview.mdx
+++ b/packages/react/src/accordion/docs/overview.mdx
@@ -29,7 +29,7 @@ relatedComponents: ['details', 'tabs']
 
 Users can open or close an accordion to decide the content they see.
 
-An accordion can save space when it’s limited. It can also help a user quickly scan page contents. Users can skim-read the list of headings in the accordion and get an overview of the content.
+An accordion can save space when its limited. It can also help a user quickly scan page contents. Users can skim-read the list of headings in the accordion and get an overview of the content.
 
 Generally speaking, [use accordions sparingly](/components/accordion/rationale).
 
@@ -166,7 +166,7 @@ This text is wrapped in the `AccordionContent` component.
 
 ## Backgrounds
 
-The background of the `AccordionItem` must pair with the background it is being placed on. For example, if AccordionItem is placed on a 'bodyAlt' background, please set the `background` prop to `bodyAlt`.
+The background of the `AccordionItem` must pair with the background it is being placed on. For example, if AccordionItem is placed on a `bodyAlt` background, please set the `background` prop to `'bodyAlt'`.
 
 ```jsx live
 <Stack background="bodyAlt" padding={3} gap={1}>
@@ -175,7 +175,7 @@ The background of the `AccordionItem` must pair with the background it is being 
 		<AccordionItem title="Accordion title" background="bodyAlt">
 			<AccordionItemContent>
 				<Text as="p">
-					This AccordionItem has background set to "bodyAlt", so it sits well
+					This AccordionItem has background set to ‘bodyAlt’, so it sits well
 					inside of this area.
 				</Text>
 			</AccordionItemContent>

--- a/packages/react/src/accordion/docs/rationale.mdx
+++ b/packages/react/src/accordion/docs/rationale.mdx
@@ -10,7 +10,7 @@ Accordions fragment a user’s experience. They make a user switch focus between
 
 Some users might also not understand how an accordion works. They may miss or ignore important information if it’s hidden.
 
-It can be hard for users to scan a web page with accordions for relevant content. For example, a web browser’s 'find on page' search function doesn’t detect content hidden by an accordion. Users can’t then use their existing tools and behaviours to find content.
+It can be hard for users to scan a web page with accordions for relevant content. For example, a web browser’s ‘find on page’ search function doesn’t detect content hidden by an accordion. Users can’t then use their existing tools and behaviours to find content.
 
 ## Single action accordion
 

--- a/packages/react/src/app-layout/docs/overview.mdx
+++ b/packages/react/src/app-layout/docs/overview.mdx
@@ -38,11 +38,11 @@ Use the app layout for web applications, not informational websites, as the layo
 
 ## App layout header
 
-The app layout header tells users what application they're using and displays the logo.
+The app layout header tells users what application they’re using and displays the logo.
 
 - **Heading and subline** - The heading should be set to the website or service title and the subline can be used to provide additional information to describe your website or service.
 
-- **Account details** - A user's name and avatar or entity information should be displayed in the top right corner to clearly show which account they're signed in to. Users can access their account settings via the dropdown.
+- **Account details** - A user’s name and avatar or entity information should be displayed in the top right corner to clearly show which account they’re signed in to. Users can access their account settings via the dropdown.
 
 ## App layout sidebar
 

--- a/packages/react/src/autocomplete/docs/overview.mdx
+++ b/packages/react/src/autocomplete/docs/overview.mdx
@@ -80,11 +80,11 @@ Use the `block` prop to expand the component to fill the available space.
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/box/docs/overview.mdx
+++ b/packages/react/src/box/docs/overview.mdx
@@ -12,7 +12,7 @@ The Box component is a primitive layout component that is heavily used to build 
 <Box>A simple Box</Box>
 ```
 
-## The "as" prop
+## The ‘as’ prop
 
 By default, the Box component renders a HTML `<div>` element. You can render it with a different HTML element tag by using the `as` prop.
 
@@ -22,7 +22,7 @@ By default, the Box component renders a HTML `<div>` element. You can render it 
 
 ## Styles
 
-Apply styles like padding, border radius, background color and more by using available props. Here's a small example:
+Apply styles like padding, border radius, background color and more by using available props. Here’s a small example:
 
 ```jsx live showCode
 <Box background="shade" border padding={1} rounded>

--- a/packages/react/src/button/docs/content.mdx
+++ b/packages/react/src/button/docs/content.mdx
@@ -10,7 +10,7 @@ Up to 30 characters.
 
 ### Label
 
-Start with a verb and end with a noun where there is space. Don’t use, conjunctions, prepositions and pronouns in between. Don't wrap labels with quotation marks.
+Start with a verb and end with a noun where there is space. Don’t use, conjunctions, prepositions and pronouns in between. Don’t wrap labels with quotation marks.
 
 For example, ‘Edit Establishment’, not ‘Edit my Establishment’ or ‘View corrective action’, not ‘View’. If space is limited, use a verb then only.
 
@@ -20,7 +20,7 @@ For example, ‘Edit Establishment’, not ‘Edit my Establishment’ or ‘Vie
 
 Use a concise, unique and meaningful text label. The label text should describe the specific action that happens next if the user selects it.
 
-Try to avoid using general labels that don't provide the full context. For example, ‘Read more’.
+Try to avoid using general labels that don’t provide the full context. For example, ‘Read more’.
 
 Refer to the glossary for consistent button labels we use and more guidance.
 

--- a/packages/react/src/button/docs/overview.mdx
+++ b/packages/react/src/button/docs/overview.mdx
@@ -23,8 +23,8 @@ Make sure you include a [meaningful text label](/components/button/rationale#mea
 <DoHeading />
 
 - left-align buttons from the most to least important action - right aligned buttons can be missed, especially on large screens or for screen magnifier users
-- create a meaningful button label with a verb and a noun that makes the action obvious to all users - e.g. "Register establishment"
-- avoid general labels that don't provide full context. - e.g. "Click here"
+- create a meaningful button label with a verb and a noun that makes the action obvious to all users - e.g. ‘Register establishment’
+- avoid general labels that don’t provide full context. - e.g. ‘Click here’
 - use the Loading property to let users know their action is being processed
 - add an icon if it helps users understand the action, and only in conjunction with a text label
 - use only one Primary button on a page. You can use more than one Secondary or Tertiary button.
@@ -34,7 +34,7 @@ Make sure you include a [meaningful text label](/components/button/rationale#mea
 - use a button if a user needs to go to another page – use a link or a link that looks like a button
 - use an icon without a text label
 - use disabled buttons as they can confuse users because they:
-  - don't tell users why the content is unavailable
+  - don’t tell users why the content is unavailable
   - are not keyboard accessible.
   - can be hard for users with a visual impairment to see.
 
@@ -168,7 +168,7 @@ The medium button should be used in most cases to provide a large click target.
 
 If a button sits inside an interface element that uses the light colour palette, make sure you use the light action colour for the button. If a button sits inside an interface element that uses the dark colour palette, make sure you use the dark action colour for the button.
 
-Don't draw attention to destructive actions like “delete” or “remove” by using red buttons. The colour red is reserved for errors.
+Don’t draw attention to destructive actions like “delete” or “remove” by using red buttons. The colour red is reserved for errors.
 
 ```jsx live
 <Box palette="dark" background="body" padding={1}>

--- a/packages/react/src/checkbox/docs/overview.mdx
+++ b/packages/react/src/checkbox/docs/overview.mdx
@@ -40,11 +40,11 @@ Use the [Control group component](/components/control-group) to group multiple r
 
 ## Hint
 
-Use the `hint` prop to provide help that's relevant to the majority of users, like how their information will be used, or where to find it.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <ControlGroup label="Example" hint="Hint text" block>
@@ -75,11 +75,11 @@ Use the `invalid` prop to indicate if the user input is invalid (does not valida
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/columns/docs/overview.mdx
+++ b/packages/react/src/columns/docs/overview.mdx
@@ -38,7 +38,7 @@ You can use `Column` to make an item span multiple columns.
 
 ### Column start and end
 
-The `columnStart` and `columnEnd` props can be used to determine the Column's start and end location within the row.
+The `columnStart` and `columnEnd` props can be used to determine the Column’s start and end location within the row.
 
 ```jsx live
 <Columns>

--- a/packages/react/src/combobox/docs/overview.mdx
+++ b/packages/react/src/combobox/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Combobox
-description: This component allows users to select from a list of options. It's especially useful when there are many options to choose from.
+description: This component allows users to select from a list of options. It’s especially useful when there are many options to choose from.
 group: Forms
 storybookPath: /story/forms-combobox-combobox--basic
 figmaGalleryNodeId: 12925%3A104632
@@ -149,11 +149,11 @@ Use the `block` prop to expand the component to fill the available space.
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/content/docs/overview.mdx
+++ b/packages/react/src/content/docs/overview.mdx
@@ -35,7 +35,7 @@ The `SectionContent` component should be used to wrap sections your applications
 
 ## Content
 
-The `Content` component can be used when you wrap content in a consistent container with a maximum width, but don't want any associated vertical padding.
+The `Content` component can be used when you wrap content in a consistent container with a maximum width, but don’t want any associated vertical padding.
 
 ```jsx
 <Content>

--- a/packages/react/src/control-group/docs/overview.mdx
+++ b/packages/react/src/control-group/docs/overview.mdx
@@ -96,9 +96,9 @@ Vertical stacking of options, with one choice per line, eliminates this potentia
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <ControlGroup label="Example" hint="Hint text" block>
@@ -156,11 +156,11 @@ Use the `invalid` prop to indicate if the user input is invalid (does not valida
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -76,9 +76,9 @@ To fix this issue, you can use the `onInputChange` prop to keep track of the use
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 () => {

--- a/packages/react/src/date-range-picker/docs/overview.mdx
+++ b/packages/react/src/date-range-picker/docs/overview.mdx
@@ -48,7 +48,7 @@ The Date range picker component has two methods of input:
 
 As we do not have any sort of input masking due to accessibility concerns, it is possible for the user to enter invalid values via the text inputs.
 
-You can use the `onFromInputChange` and `onToInputChange` props to keep track of the users input. The `value.from` and `value.to` props can also be set to a string, which represents the value of the text inputs.
+You can use the `onFromInputChange` and `onToInputChange` props to keep track of the user’s input. The `value.from` and `value.to` props can also be set to a string, which represents the value of the text inputs.
 
 ```jsx live
 () => {
@@ -106,9 +106,9 @@ Use the `legend` prop to describe the purpose of the group of fields.
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 () => {

--- a/packages/react/src/details/docs/accessibility.mdx
+++ b/packages/react/src/details/docs/accessibility.mdx
@@ -1,6 +1,6 @@
 Here are ways to make a Details component more accessible and inclusive of users of any ability or environment.
 
-Be aware some users avoid detail links if they think they will lose their place in the flow if the page doesn't open in a new tab.
+Be aware some users avoid detail links if they think they will lose their place in the flow if the page doesn’t open in a new tab.
 
 Consider that content inside the Detail does not print with the rest of the page.
 

--- a/packages/react/src/details/docs/overview.mdx
+++ b/packages/react/src/details/docs/overview.mdx
@@ -16,7 +16,7 @@ relatedComponents: ['accordion', 'tabs']
 </Details>
 ```
 
-Information is visible only when the widget is toggled into an "open" state. Unlike Accordion, inner content is surfacable in a page search (cmd/ctrl-f).
+Information is visible only when the widget is toggled into an ‘open’ state. Unlike Accordion, inner content is surfacable in a page search (cmd/ctrl-f).
 
 Details should only be used for 1 piece of content. If more sections are required, use an Accordion or Tab.
 

--- a/packages/react/src/direction-link/docs/overview.mdx
+++ b/packages/react/src/direction-link/docs/overview.mdx
@@ -26,9 +26,9 @@ relatedComponents: ['call-to-action', 'text-link']
 
 <DoHeading />
 
-- use to link `up` or `down` within a page - for example, Back to top
-- use to guide users `back` to a parent page
-- use to show `next` or `previous` pages.
+- use to link ‘up’ or ‘down’ within a page - for example, Back to top
+- use to guide users ‘back’ to a parent page
+- use to show ‘next’ or `previous` pages.
 
 <DontHeading />
 
@@ -59,4 +59,4 @@ A Back button can be used in place of [Breadcrumbs](/components/breadcrumbs) whe
 
 Back buttons should not be used on content pages as they do not show a user where they are in relation to the rest of a site structure. They allow a user to navigate up only one level whereas a breadcrumb allow navigation back through the entire site.
 
-When using Back buttons always use the label 'Back' rather than the name of the parent page. The label 'Back' is universal, can be understood in any context and does not require the user to remember the name of the parent page.
+When using Back buttons always use the label ‘Back’ rather than the name of the parent page. The label ‘Back’ is universal, can be understood in any context and does not require the user to remember the name of the parent page.

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -41,19 +41,19 @@ relatedPatterns: ['search-filters']
 
 - read the [Search filters pattern](/patterns/search-filters)
 - use a [Button group](/components/button#button-group) to display actions
-- include a "Close" button in the top right
-- include a meaningful title - e.g. "Filter by"
+- include a ‘Close’ button in the top right
+- include a meaningful title - e.g. ‘Filter by’
 - optionally close the Drawer when an action button is pressed
 
 <DontHeading />
 
-- remove the "Close" button
+- remove the ‘Close’ button
 - remove the overlay
 - change default behaviour
 
 ## Opening the Drawer
 
-The Drawer can be opened by pressing a button or a link. For example, pressing a 'Show filter' button opens a medium Drawer containing filters.
+The Drawer can be opened by pressing a button or a link. For example, pressing a ‘Show filter’ button opens a medium Drawer containing filters.
 
 When the Drawer is opened, an overlay is displayed over the main area of the page. This prevents the main area of the page from being interacted with, while still allowing users to maintain their context.
 
@@ -61,8 +61,8 @@ When the Drawer is opened, an overlay is displayed over the main area of the pag
 
 The Drawer can be closed by either:
 
-1. Pressing the "Close" button
-2. Pressing the "Escape" key
+1. Pressing the ‘Close’ button
+2. Pressing the ‘Escape’ key
 3. Pressing the overlay
 4. Pressing a button in the actions area (optional)
 

--- a/packages/react/src/dropdown-menu/docs/overview.mdx
+++ b/packages/react/src/dropdown-menu/docs/overview.mdx
@@ -23,7 +23,7 @@ relatedComponents: ['combobox', 'select']
 </DropdownMenu>
 ```
 
-A dropdown menu displays a list of actions when triggered by a `DropdownMenuButton`. Dropdown menu's float on top of the content they sit on. Consider using them when there isn't sufficient space to display actions.
+A dropdown menu displays a list of actions when triggered by a `DropdownMenuButton`. Dropdown menu’s float on top of the content they sit on. Consider using them when there isn’t sufficient space to display actions.
 
 Dropdown menus pose multiple usability problems which you should consider before using them:
 
@@ -33,8 +33,8 @@ Dropdown menus pose multiple usability problems which you should consider before
 
 <DoHeading />
 
-- ensure that actions in the dropdown can be accessed elsewhere on the same page, as some users won't be able to access them via the dropdown menu
-- only use a dropdown menu if there's insufficient space to display actions
+- ensure that actions in the dropdown can be accessed elsewhere on the same page, as some users won’t be able to access them via the dropdown menu
+- only use a dropdown menu if there’s insufficient space to display actions
 - trigger a dropdown menu on click of an element
 - keep the dropdown menu open until a user has made a selection or clicked outside the menu
 - organise actions in a logical way
@@ -44,14 +44,14 @@ Dropdown menus pose multiple usability problems which you should consider before
 
 <DontHeading />
 
-- use a dropdown menu if there's space to display actions
-- trigger a dropdown menu on hover of an element, ensure it's triggered on click
+- use a dropdown menu if there’s space to display actions
+- trigger a dropdown menu on hover of an element, ensure it’s triggered on click
 - use in the [Main nav](/components/main-nav) or other nav components
 - use a dropdown menu in a form where users need to select a single option - use a [Select](/components/select) component instead.
 
 ## Triggers
 
-Dropdown menu's can be triggered by a`DropdownMenuButton`, which can accept all of the same props as [Button](/components/button). This gives you flexibility in what your trigger looks like.
+Dropdown menu’s can be triggered by a`DropdownMenuButton`, which can accept all of the same props as [Button](/components/button). This gives you flexibility in what your trigger looks like.
 
 ```jsx live
 <Stack gap={1}>
@@ -76,7 +76,7 @@ Dropdown menu's can be triggered by a`DropdownMenuButton`, which can accept all 
 
 ## Placement
 
-By default the dropdown menu is aligned to the bottom left (`bottom-start`) of the `DropdownMenuButton` when opened. It can alternatively be aligned to the bottom right (`bottom-end`) or the bottom (`bottom`). If there's not enough space in the browser window to align the menu on the left, the dropdown menu will automatically be aligned to the right to help ensure it fits on the screen.
+By default the dropdown menu is aligned to the bottom left (`bottom-start`) of the `DropdownMenuButton` when opened. It can alternatively be aligned to the bottom right (`bottom-end`) or the bottom (`bottom`). If there’s not enough space in the browser window to align the menu on the left, the dropdown menu will automatically be aligned to the right to help ensure it fits on the screen.
 
 ```jsx live
 <Stack gap={2} alignItems="center">
@@ -114,7 +114,7 @@ The simplest dropdown menu contains text only list items. Use `DropdownMenuItem`
 </DropdownMenu>
 ```
 
-If you're opening links in a new tab, we recommend you use the `ExternalLinkIcon`.
+If you’re opening links in a new tab, we recommend you use the `ExternalLinkIcon`.
 
 ```jsx live
 <DropdownMenu>
@@ -162,7 +162,7 @@ Use the `endElement` prop to add elements such as an [Indicator dot](/components
 
 ## Divider
 
-Use a `DropdownMenuDivider` to separate destructive actions at the bottom of the list. This helps ensure they're not actioned by mistake.
+Use a `DropdownMenuDivider` to separate destructive actions at the bottom of the list. This helps ensure they’re not actioned by mistake.
 
 ```jsx live
 <DropdownMenu>

--- a/packages/react/src/field/docs/overview.mdx
+++ b/packages/react/src/field/docs/overview.mdx
@@ -25,9 +25,9 @@ Each field must be accompanied by a label. Effective form labeling helps users u
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like the required format of the input, how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <Field label="Email" hint="We will only use this to respond to your question">
@@ -53,11 +53,11 @@ Error messages are used to notify the user when a form field has not passed vali
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 
@@ -85,7 +85,7 @@ The usage of `hideOptionalLabel` should be reserved for inputs that filter data 
 
 `useScrollToField` is a hook that can be used to scroll and focus users to a form field on the same page.
 
-Because our labels or legends appear above the input, when using native browsers API's users will be presented with an input without any context, as the label or legend will be off the top of the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
+Because our labels or legends appear above the input, when using native browsers APIs users will be presented with an input without any context, as the label or legend will be off the top of the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
 
 Please refer to the [example site single-page form example](/example-site/single-page-form) to see an example of this hook in use.
 

--- a/packages/react/src/file-input/docs/overview.mdx
+++ b/packages/react/src/file-input/docs/overview.mdx
@@ -17,7 +17,7 @@ The File input component is a simple input for selecting and uploading files in 
 
 - use if only one file is being uploaded per form field
 - use to conserve vertical space
-- use when a drag and drop zone isn't required
+- use when a drag and drop zone isn’t required
 
 <DontHeading />
 
@@ -25,15 +25,15 @@ The File input component is a simple input for selecting and uploading files in 
 - use if you want the file to be uploaded immediately
 - use for uploading multiple files
 - use if the user might benefit from a drag and drop zone
-- use if it's the only form element on the page
+- use if it’s the only form element on the page
 
 ## Hint
 
-Use the `hint` prop to provide help that's relevant to the majority of users, like how their information will be used, or where to find it.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <FileInput label="Passport" hint="Hint text" />
@@ -43,11 +43,11 @@ Don't include links within hint text. While screen readers will read out the lin
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -28,8 +28,8 @@ File upload is used in forms to enable users to upload files they need. There ar
 - indicate file uploading state
 - indicate a successful file upload using a [Page alert](/components/page-alert), including file name
 - indicate unsuccessful file uploads using a [Page alert](/components/page-alert) with a meaningful error message, solution and support contact
-- Make use of the 'instant upload' pattern if your backend supports it
-- Consider the 'simple download' pattern for small screens
+- Make use of the ‘instant upload’ pattern if your backend supports it
+- Consider the ‘simple download’ pattern for small screens
 
 <DontHeading />
 
@@ -40,7 +40,7 @@ File upload is used in forms to enable users to upload files they need. There ar
 
 ## Indicating upload status
 
-When using FileUpload, you need to consider how to communicate to the user that the upload is in progress. Otherwise the page will appear "frozen" as the operation happens in the background.
+When using FileUpload, you need to consider how to communicate to the user that the upload is in progress. Otherwise the page will appear ‘frozen’ as the operation happens in the background.
 
 ### Uploading on submission
 
@@ -69,7 +69,7 @@ As normal, we indicate that the form is submitting by adding a `loading={true}` 
 
 ### Uploading files instantly
 
-In this example, the file is instantly uploaded to a file hosting service, and the URL of the uploaded asset would be added to the form for submission. This means the form should not be allowed to submit until all assets are uploaded, but that the submission should be very quick as it's only text content being submitted.
+In this example, the file is instantly uploaded to a file hosting service, and the URL of the uploaded asset would be added to the form for submission. This means the form should not be allowed to submit until all assets are uploaded, but that the submission should be very quick as it’s only text content being submitted.
 
 `FileUpload` component allows you to indicate the status of an upload via a `file.status` property.
 
@@ -129,7 +129,7 @@ For a complete list allowed file formats, please refer to [the source code](http
 
 ### Custom accepted file types
 
-If the file type you need to support isn't list of allowed file formats, you can pass in your own file type to the `accept` prop.
+If the file type you need to support isn’t list of allowed file formats, you can pass in your own file type to the `accept` prop.
 
 This can be done by passing an object instead of a string with `mimeType` and `extensions` as keys. Optionally, a `label` key can be used for the summary inside of the component. By default, the label will be generated using the file extension.
 

--- a/packages/react/src/filter-drawer/docs/overview.mdx
+++ b/packages/react/src/filter-drawer/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Filter drawer
-description: Filter drawer can be used to display 6+ filters for a data set. It is overlayed on top of the main area of the page to capture the users attention while keeping the context of the current task.
+description: Filter drawer can be used to display 6+ filters for a data set. It is overlayed on top of the main area of the page to capture the user’s attention while keeping the context of the current task.
 group: Layout
 deprecated: true
 ---

--- a/packages/react/src/flex/docs/overview.mdx
+++ b/packages/react/src/flex/docs/overview.mdx
@@ -12,7 +12,7 @@ The Flex component is a version of [Box](/components/box) which applies `display
 <Flex>A simple Flex</Flex>
 ```
 
-## The "as" prop
+## The ‘as’ prop
 
 By default, the Flex component renders a HTML `<div>` element. You can render it with a different HTML element tag by using the `as` prop.
 
@@ -30,7 +30,7 @@ Use the `inline` prop to apply `display: inline-flex` to the element.
 
 ## Wrapping
 
-`flexWrap` is an optional prop that makes the children wrap if they can't fit within the container.
+`flexWrap` is an optional prop that makes the children wrap if they can’t fit within the container.
 
 ```jsx live showCode
 <Flex flexWrap>A simple Flex with flex wrapping</Flex>

--- a/packages/react/src/global-alert/docs/overview.mdx
+++ b/packages/react/src/global-alert/docs/overview.mdx
@@ -33,7 +33,7 @@ Global alerts should be used sparingly due to their prominent nature and should 
 
 <DontHeading />
 
-- use for anything that's not system level
+- use for anything that’s not system level
 - let alert banners time out.
 
 ## Dismissable

--- a/packages/react/src/heading/docs/overview.mdx
+++ b/packages/react/src/heading/docs/overview.mdx
@@ -9,7 +9,7 @@ relatedComponents: ['text', 'list']
 
 Break content up with headings. Headings should clearly state what the user will find in paragraph that follows.
 
-The first heading (H1) should be unique to each page and contain keywords. Page headings should match users' search intent and should be 20 to 70 characters in length. See [How to create guidance in the Export Service](/guides/how-to-write-guidance) for more information.
+The first heading (H1) should be unique to each page and contain keywords. Page headings should match users’ search intent and should be 20 to 70 characters in length. See [How to create guidance in the Export Service](/guides/how-to-write-guidance) for more information.
 
 `Heading` uses the `fontGrid` function to make the font-size and line-height snap to grid.
 

--- a/packages/react/src/indicator-dot/docs/overview.mdx
+++ b/packages/react/src/indicator-dot/docs/overview.mdx
@@ -18,7 +18,7 @@ relatedComponents: ['notification-badge', 'status-badge', 'tags']
 <DontHeading />
 
 - change the colours or create new ones
-- use on it's own. It should be considered as part of a wider composition.
+- use on its own. It should be considered as part of a wider composition.
 
 ## Usage
 

--- a/packages/react/src/inpage-nav/docs/overview.mdx
+++ b/packages/react/src/inpage-nav/docs/overview.mdx
@@ -58,7 +58,7 @@ relatedComponents: ['direction-link', 'link-list', 'side-nav', 'sub-nav']
 
 The Inpage nav (or Page contents) is placed at the top of a page and consists of anchor links that guide users to page sections.
 
-The Inpage nav should be used in combination with 'Back to top' links using [Direction links](/components/direction-link) at the end of sections to help users return to the Inpage nav on long pages.
+The Inpage nav should be used in combination with ‘Back to top’ links using [Direction links](/components/direction-link) at the end of sections to help users return to the Inpage nav on long pages.
 
 The solid left-hand border visually separates the component from the page content.
 
@@ -68,7 +68,7 @@ The solid left-hand border visually separates the component from the page conten
 - ensure the anchor link text and section title are the same
 - use unique, accurate headings to describe section content
 - use for longer pages as a table of contents
-- use 'Back to top' links using [Direction links](/components/direction-link) at the end of sections to help users return to the Inpage nav on long pages.
+- use ‘Back to top’ links using [Direction links](/components/direction-link) at the end of sections to help users return to the Inpage nav on long pages.
 
 <DontHeading />
 

--- a/packages/react/src/loading/docs/overview.mdx
+++ b/packages/react/src/loading/docs/overview.mdx
@@ -34,7 +34,7 @@ Adding the `fullScreen` prop will position the component over the whole screen. 
 
 ## Loading Dots
 
-The `LoadingDots` component can be used on it's own, for example when fetching data from a remote source.
+The `LoadingDots` component can be used on its own, for example when fetching data from a remote source.
 
 ```jsx live
 <Stack gap={2} alignItems="center">

--- a/packages/react/src/page-alert/docs/rationale.mdx
+++ b/packages/react/src/page-alert/docs/rationale.mdx
@@ -7,7 +7,7 @@ Content should be easily understood at a glance.
 Use constructive, no-blame language, avoid vague descriptions and always provide a solution.
 
 <ExampleContent heading={<DoHeading />}>
-	<PageAlert tone="error" title="We can't find an account with those details">
+	<PageAlert tone="error" title="We can’t find an account with those details">
 		<Text as="p">Please check your information and try again</Text>
 	</PageAlert>
 </ExampleContent>
@@ -18,7 +18,7 @@ Use constructive, no-blame language, avoid vague descriptions and always provide
 	</PageAlert>
 </ExampleContent>
 
-## Don't repeat yourself
+## Don’t repeat yourself
 
 Avoid duplicating the title in the body copy. If the alert title is enough to conveys the message, body copy may not be necessary.
 

--- a/packages/react/src/pagination/docs/content.mdx
+++ b/packages/react/src/pagination/docs/content.mdx
@@ -2,13 +2,13 @@
 
 We use text to display the range of items currently displayed in the data. This text can be modified to suit your needs, but it must follow the guidelines below.
 
-- Show the range of items currently displayed in the data ("1 - 10")
+- Show the range of items currently displayed in the data (‘1 - 10’)
 - Show the total number of items in the data (125)
-- Use a word that describes the data being displayed. This word should be pluralized to match the total number of items in the data. For example, "certificates" or "applications". Otherwise use "results" or "items".
+- Use a word that describes the data being displayed. This word should be pluralized to match the total number of items in the data. For example, ‘certificates’ or ‘applications’. Otherwise use ‘results’ or ‘items’.
 
 For example:
 
-- "1 - 10 of 125 certificates"
-- "1 - 10 of 125 applications"
-- "1 - 10 of 125 results"
-- "1 - 10 of 125 items"
+- ‘1 - 10 of 125 certificates’
+- ‘1 - 10 of 125 applications’
+- ‘1 - 10 of 125 results’
+- ‘1 - 10 of 125 items’

--- a/packages/react/src/pagination/docs/overview.mdx
+++ b/packages/react/src/pagination/docs/overview.mdx
@@ -37,7 +37,7 @@ Use pagination to separate large lists of content, such as search results, into 
 
 By default, the `Pagination` component renders a link for each list item. We strongly recommend using wherever possible as it the most inclusive and accessible solution for users.
 
-This requires you to manage the state of the current page in the URL, which usually fine, but in scenarios where that isn't possible we offer a `PaginationButtons` component.
+This requires you to manage the state of the current page in the URL, which usually fine, but in scenarios where that isn’t possible we offer a `PaginationButtons` component.
 
 `PaginationButtons` renders a button element for each list item which makes it possible to manage the state outside of the URL, e.g. `React.useState`.
 

--- a/packages/react/src/password-input/docs/overview.mdx
+++ b/packages/react/src/password-input/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Password input
-description: The password input component allows users to securely enter a password. The text is obscured by default, but can be revealed by pressing the "Show password" checkbox.
+description: The password input component allows users to securely enter a password. The text is obscured by default, but can be revealed by pressing the ‘Show password’ checkbox.
 group: Forms
 storybookPath: /story/forms-passwordinput--basic
 figmaGalleryNodeId: 12444%3A100673
@@ -25,9 +25,9 @@ relatedComponents: ['text-input']
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <PasswordInput label="Password" hint="Hint text" required />
@@ -37,11 +37,11 @@ Don't include links within hint text. While screen readers will read out the lin
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/progress-indicator/docs/overview.mdx
+++ b/packages/react/src/progress-indicator/docs/overview.mdx
@@ -21,7 +21,7 @@ relatedComponents: ['task-list']
 
 Progress indicators are used to show users how many steps are needed to complete a form and where they are in the process of completing it. This helps users know how much is left to do and how far along they are.
 
-Progress indicators can be applied to larger tasks that can be completed in any order and returned to at a later date, like doing a tax return or applying for a driver's licence.
+Progress indicators can be applied to larger tasks that can be completed in any order and returned to at a later date, like doing a tax return or applying for a driver’s licence.
 
 Progress indicators can be applied to multi-step forms if the form has a known number of steps to be completed. <sup><a href="#cite-1">1</a></sup>
 

--- a/packages/react/src/prose/Prose.stories.tsx
+++ b/packages/react/src/prose/Prose.stories.tsx
@@ -242,6 +242,6 @@ const UnstyledContent = () => (
 
 		<hr />
 
-		<p>And that&apos;s a wrap.</p>
+		<p>And that’s a wrap.</p>
 	</Fragment>
 );

--- a/packages/react/src/prose/docs/overview.mdx
+++ b/packages/react/src/prose/docs/overview.mdx
@@ -146,13 +146,13 @@ The `Prose` component should only be used in the context of a page to format lon
 	<ul>
 		<li>
 			useful for marking up interesting things in quotations (without altering
-			the styling of text, eg to italic)
+			the styling of text, e.g. to italic)
 		</li>
 		<li>
-			drawing attention to specific parts of pre-formatted text (eg code
+			drawing attention to specific parts of pre-formatted text (e.g. code
 			snippets)
 		</li>
-		<li>for marking up search results (eg that match a given query)</li>
+		<li>for marking up search results (e.g. that match a given query)</li>
 	</ul>
 
 	<h6>Heading level 6</h6>

--- a/packages/react/src/prose/docs/overview.mdx
+++ b/packages/react/src/prose/docs/overview.mdx
@@ -219,7 +219,7 @@ The `Prose` component should only be used in the context of a page to format lon
 
 	<hr />
 
-	<p>And that&apos;s a wrap.</p>
+	<p>And that’s a wrap.</p>
 </Prose>
 ```
 

--- a/packages/react/src/radio/docs/overview.mdx
+++ b/packages/react/src/radio/docs/overview.mdx
@@ -69,11 +69,11 @@ Use the [Control group component](/components/control-group) to group multiple r
 
 ## Hint
 
-Use the `hint` prop to provide help that's relevant to the majority of users, like how their information will be used, or where to find it.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 () => {
@@ -131,11 +131,11 @@ Use the `invalid` prop to indicate if the user input is invalid (does not valida
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/search-input/docs/overview.mdx
+++ b/packages/react/src/search-input/docs/overview.mdx
@@ -33,9 +33,9 @@ By default, the `SearchInput` component does not expand to fill the available sp
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <SearchInput label="Search" hint="Hint text" />
@@ -45,11 +45,11 @@ Don't include links within hint text. While screen readers will read out the lin
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/select/docs/overview.mdx
+++ b/packages/react/src/select/docs/overview.mdx
@@ -42,9 +42,9 @@ By default, the `Select` component does not expand to fill the available space.
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <Select
@@ -63,11 +63,11 @@ Don't include links within hint text. While screen readers will read out the lin
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`SideNav renders correctly 1`] = `
                 href="/whats-new-for-individuals"
               >
                 <span>
-                  What's new for individuals
+                  What’s new for individuals
                 </span>
               </a>
             </li>

--- a/packages/react/src/side-nav/docs/overview.mdx
+++ b/packages/react/src/side-nav/docs/overview.mdx
@@ -34,7 +34,7 @@ relatedComponents: ['inpage-nav', 'link-list', 'sub-nav']
 		},
 		{
 			href: '#whats-new-for-individuals',
-			label: "What's new for individuals",
+			label: 'What’s new for individuals',
 		},
 		{
 			href: '#why-you-may-receive-a-tax-bill',
@@ -76,7 +76,7 @@ The side navigation allows users to find other pages which share a similar topic
 
 On mobile and smaller viewports, the side navigation uses functionality from the accordion component to collapse down to an expandable element.
 
-The background of the `SideNav` must match the background it is being placed on. For example, if `SideNav` is placed on a 'bodyAlt' background, please set the `background` prop to `bodyAlt`.
+The background of the `SideNav` must match the background it is being placed on. For example, if `SideNav` is placed on a `bodyAlt` background, please set the `background` prop to `'bodyAlt'`.
 
 <DoHeading />
 

--- a/packages/react/src/side-nav/test-utils.ts
+++ b/packages/react/src/side-nav/test-utils.ts
@@ -25,7 +25,7 @@ export const defaultTestingProps: SideNavProps = {
 		},
 		{
 			href: '/whats-new-for-individuals',
-			label: "What's new for individuals",
+			label: 'What’s new for individuals',
 		},
 		{
 			href: '/why-you-may-receive-a-tax-bill',

--- a/packages/react/src/stack/docs/overview.mdx
+++ b/packages/react/src/stack/docs/overview.mdx
@@ -14,7 +14,7 @@ relatedComponents: ['box', 'flex', 'form-stack']
 </Stack>
 ```
 
-## The "as" prop
+## The ‘as’ prop
 
 By default, the Stack component renders a HTML `<div>` element. You can render it with a different HTML element tag by using the `as` prop.
 

--- a/packages/react/src/status-badge/docs/overview.mdx
+++ b/packages/react/src/status-badge/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Status badge
-description: Status badges are visual indicators used to highlight an item's status for quick recognition.
+description: Status badges are visual indicators used to highlight an item’s status for quick recognition.
 group: Content
 storybookPath: /story/content-statusbadge--info
 figmaGalleryNodeId: 18568%3A86192
@@ -18,7 +18,7 @@ relatedComponents: ['notification-badge', 'indicator-dot', 'tags']
 - use status badge without an icon
 - change the colours or create new ones
 - use the `subtle` weight outside of tables or dense parent components
-- use when colour and icon don't convey meaning.
+- use when colour and icon don’t convey meaning.
 
 ## Tone
 

--- a/packages/react/src/table/docs/accessibility.mdx
+++ b/packages/react/src/table/docs/accessibility.mdx
@@ -8,7 +8,7 @@ You may need to add notes below the table to help users understand the informa
 
 Don’t rely on colour to convey information.
 
-Don’t leave cells empty. Use ‘zero’ or ‘nil’ or 'n/a' where there is no data. If it is numeric data, use zero (0). Only use zero if that is the true value.
+Don’t leave cells empty. Use ‘zero’ or ‘nil’ or ‘n/a’ where there is no data. If it is numeric data, use zero (0). Only use zero if that is the true value.
 
 Consider screen size and how much information you can include.
 
@@ -25,4 +25,4 @@ Using ARIA attributes can help users of assistive technology understand the purp
 
 The `aria-rowcount` attribute defines the total number of rows in a table, for users of assistive technology. This is useful for tables with pagination.
 
-The `aria-rowindex` attribute on `TableRow` defines it's position with respect to the total number of rows within a `Table`.
+The `aria-rowindex` attribute on `TableRow` defines its position with respect to the total number of rows within a `Table`.

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -89,10 +89,10 @@ For data tables with a small amount of rows use the default table. Align text co
 <DoHeading />
 
 - use for datasets with more than 2 columns
-- Use for tabular data - not layouts
+- use for tabular data - not layouts
 - provide a meaningful caption (heading), or use aria-labelledby to reference a heading
-- Keep row heights small.
-- Use a simple table structure - complex tables are difficult to navigate.
+- keep row heights small.
+- use a simple table structure - complex tables are difficult to navigate.
 - use Pagination to break up tables with many rows
 - align text left and numeric data right
 - only include text, tags, links and status badges as content
@@ -116,9 +116,7 @@ For data tables with a small amount of rows use the default table. Align text co
 Use tiger stripes for tables with complex information:
 
 - 4 or more rows
-
 - 3 or more columns
-
 - comparing important or similar information.
 
 You can enable tiger stripes by applying the `striped` prop.
@@ -441,7 +439,7 @@ A Table must have some form of caption or heading to describe the data it contai
 
 ## Actions
 
-The actions associated with each table row (e.g. "Edit", "Delete", "Download") should always be positioned in the last column beneath the table header labeled "Actions."
+The actions associated with each table row (e.g. ‘Edit’, ‘Delete’, ‘Download’) should always be positioned in the last column beneath the table header labeled ‘Actions’.
 
 If each table row can open a page to view more information, the cells in the first column should be displayed as bold clickable links under the table header labeled with the unique identifier.
 

--- a/packages/react/src/text-input/docs/overview.mdx
+++ b/packages/react/src/text-input/docs/overview.mdx
@@ -26,16 +26,16 @@ By default, the `TextInput` component does not expand to fill the available spac
 
 - use if a dropdown, select, or radio button can be used instead
 - use for passwords - use [Password input](/components/password-input) instead
-- hide the 'optional' label within a form
+- hide the ‘optional’ label within a form
 - use placeholder text as a substitute for a label.
 
 ## Hint
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <TextInput label="Name" hint="Hint text" />
@@ -45,11 +45,11 @@ Don't include links within hint text. While screen readers will read out the lin
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 

--- a/packages/react/src/textarea/docs/overview.mdx
+++ b/packages/react/src/textarea/docs/overview.mdx
@@ -33,9 +33,9 @@ By default, the `Textarea` component does not expand to fill the available space
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
 
-Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
 
-Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <Textarea label="Message" hint="Hint text" />
@@ -45,11 +45,11 @@ Don't include links within hint text. While screen readers will read out the lin
 
 The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
 
-Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+Using the `required` prop, this component will automatically append ‘(optional)’ to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
 
 ### Hide optional label
 
-The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don’t want to show the ‘(optional)’ label.
 
 The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
 


### PR DESCRIPTION
This updates all uses of quotes/apostrpohes in docs to a curly single quotes.

Also fixed incorrect uses of its/it’s and users/user’s

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1522)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets