### PR TITLE
playroom: Add accountDetails to AppLayoutHeader. Fix whitespace

### DIFF
--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -1,3 +1,46 @@
+const boilerplateAppLayoutHeaderDropdown = `
+	<DropdownMenuPanel palette="light">
+		<DropdownMenuGroup label="Businesses">
+			{['Antfix', 'Produce Fresh', 'Organic Co'].map((businessName) => (
+				<DropdownMenuItemRadio
+					key={businessName}
+					checked={businessName === 'Antfix'}
+					secondaryText="ABN 00 000 000 000"
+					onClick={() => console.log(businessName)}
+				>
+					{businessName}
+				</DropdownMenuItemRadio>
+			))}
+			<DropdownMenuGroupLink href="#">View all</DropdownMenuGroupLink>
+		</DropdownMenuGroup>
+		<DropdownMenuDivider />
+		<DropdownMenuGroup label="My account">
+			<DropdownMenuItemLink href="/profile" icon={AvatarIcon}>
+				Profile
+			</DropdownMenuItemLink>
+			<DropdownMenuItemLink
+				href="/messages"
+				icon={EmailIcon}
+				endElement={
+					<span>
+						<NotificationBadge tone="action" value={6} max={99} aria-hidden />
+						<VisuallyHidden>, 6 unread</VisuallyHidden>
+					</span>
+				}
+			>
+				Messages
+			</DropdownMenuItemLink>
+			<DropdownMenuItemLink href="/account-settings" icon={SettingsIcon}>
+				Account settings
+			</DropdownMenuItemLink>
+		</DropdownMenuGroup>
+		<DropdownMenuDivider />
+		<DropdownMenuItem onClick={() => console.log('sign out')} icon={ExitIcon}>
+			Sign out
+		</DropdownMenuItem>
+	</DropdownMenuPanel>
+`;
+
 const boilerplateSiteTemplate = (content: string) => `
 	<Box dark><Header background="bodyAlt" logo={<Logo />} heading="Export Service" />
 		<MainNav items={[{ label: "Home", href: "/" }]} secondaryItems={[{ label: 'Sign in', endElement: <AvatarIcon />}]} />
@@ -27,9 +70,9 @@ const boilerplateAppTemplate = (content: string) => `
 		logo={<Logo />}
 		href="#"
 		accountDetails={{
-			"name": "Toto Wolff",
-			"secondaryText": "Antfix",
-			"href": "#",
+			name: 'Toto Wolff',
+			secondaryText: 'My account',
+			dropdown: ${boilerplateAppLayoutHeaderDropdown}
 		}}
 	/>
 	<AppLayoutSidebar
@@ -299,6 +342,58 @@ const snippets = [
 		</Footer></Box>`,
 	},
 	{
+		group: 'AppLayoutHeader',
+		name: 'Without Account',
+		code: `
+			<AppLayout>
+				<AppLayoutHeader
+					heading="Service name"
+					subLine="Service description that could be a little longer"
+					logo={<Logo />}
+					href="#"
+				/>
+			</AppLayout>
+		`,
+	},
+	{
+		group: 'AppLayoutHeader',
+		name: 'With Account Link',
+		code: `
+			<AppLayout>
+				<AppLayoutHeader
+					heading="Service name"
+					subLine="Service description that could be a little longer"
+					logo={<Logo />}
+					href="#"
+					accountDetails={{
+						name: 'Toto Wolff',
+						secondaryText: 'Antfix',
+						href: '#',
+					}}
+				/>
+			</AppLayout>
+		`,
+	},
+	{
+		group: 'AppLayoutHeader',
+		name: 'With Account Dropdown',
+		code: `
+			<AppLayout>
+				<AppLayoutHeader
+					heading="Service name"
+					subLine="Service description that could be a little longer"
+					logo={<Logo />}
+					href="#"
+					accountDetails={{
+						name: 'Toto Wolff',
+						secondaryText: 'My account',
+						dropdown: ${boilerplateAppLayoutHeaderDropdown}
+					}}
+				/>
+			</AppLayout>
+		`,
+	},
+	{
 		group: 'Footer',
 		name: 'Complex',
 		code: `<Box dark>
@@ -368,7 +463,7 @@ const snippets = [
 			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
 				&copy; 2022 Department of Agriculture, Fisheries and Forestry
 			</Text>
-	</Footer></Box>`,
+		</Footer></Box>`,
 	},
 	{
 		group: 'SideNav',

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -1,20 +1,23 @@
 const boilerplateSiteTemplate = (content: string) => `
 	<Box dark><Header background="bodyAlt" logo={<Logo />} heading="Export Service" />
-    <MainNav items={[{ label: "Home", href: "/" }]} secondaryItems={[{ label: 'Sign in', endElement: <AvatarIcon />}]} /></Box>
-		<PageContent as="main">${content}</PageContent>
-    <Box dark><Footer background="bodyAlt">
-    <nav aria-label="footer">
-      <LinkList
-        horizontal
-        links={[
-          { href: '#', label: 'Home' },
-          { href: '#', label: 'Terms and conditions' },
-          { href: '#', label: 'Privacy policy' },
-          { href: '#', label: 'A really long link title' },
-        ]}
-      />
-    </nav>
-    </Footer></Box>`;
+		<MainNav items={[{ label: "Home", href: "/" }]} secondaryItems={[{ label: 'Sign in', endElement: <AvatarIcon />}]} />
+	</Box>
+	<PageContent as="main">${content}</PageContent>
+	<Box dark>
+		<Footer background="bodyAlt">
+			<nav aria-label="footer">
+				<LinkList
+					horizontal
+					links={[
+						{ href: '#', label: 'Home' },
+						{ href: '#', label: 'Terms and conditions' },
+						{ href: '#', label: 'Privacy policy' },
+						{ href: '#', label: 'A really long link title' },
+					]}
+				/>
+			</nav>
+		</Footer>
+	</Box>`;
 
 const boilerplateAppTemplate = (content: string) => `
 <AppLayout>
@@ -23,6 +26,11 @@ const boilerplateAppTemplate = (content: string) => `
 		subLine="Service description that could be a little longer"
 		logo={<Logo />}
 		href="#"
+		accountDetails={{
+			"name": "Toto Wolff",
+			"secondaryText": "Antfix",
+			"href": "#",
+		}}
 	/>
 	<AppLayoutSidebar
 		items={[
@@ -55,9 +63,9 @@ const snippets = [
 		name: 'Basic',
 		code: boilerplateSiteTemplate(`
 		<Prose>
-      <h1>Page heading</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at arcu eleifend, varius enim non, eleifend nibh. Quisque ac lacinia elit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer scelerisque at ligula tempor eleifend. Vestibulum volutpat, dolor eu rutrum consequat, libero justo lacinia tortor, id varius tortor ante sit amet nisl. Aenean at dui diam. Cras a ligula a ante aliquam lacinia. Ut dolor quam, gravida eu dui quis, molestie lacinia dolor. Fusce lacus mi, pharetra molestie tortor eu, finibus lacinia libero.</p>
-  		<p>Suspendisse feugiat rhoncus magna eleifend aliquam. Morbi euismod ex convallis viverra eleifend. Nullam vel finibus libero. Maecenas leo sem, consectetur sit amet ipsum vel, commodo porttitor quam. Nullam libero nulla, cursus a turpis et, ullamcorper lobortis metus. Aliquam aliquam sodales malesuada. Phasellus sit amet libero ut nulla porta ornare. In elit lectus, iaculis et volutpat eget, tempor ornare eros. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse sodales metus quis vulputate convallis. Morbi congue lectus eget massa finibus luctus. Pellentesque tempus dui vel auctor ullamcorper.</p>
+			<h1>Page heading</h1>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at arcu eleifend, varius enim non, eleifend nibh. Quisque ac lacinia elit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer scelerisque at ligula tempor eleifend. Vestibulum volutpat, dolor eu rutrum consequat, libero justo lacinia tortor, id varius tortor ante sit amet nisl. Aenean at dui diam. Cras a ligula a ante aliquam lacinia. Ut dolor quam, gravida eu dui quis, molestie lacinia dolor. Fusce lacus mi, pharetra molestie tortor eu, finibus lacinia libero.</p>
+			<p>Suspendisse feugiat rhoncus magna eleifend aliquam. Morbi euismod ex convallis viverra eleifend. Nullam vel finibus libero. Maecenas leo sem, consectetur sit amet ipsum vel, commodo porttitor quam. Nullam libero nulla, cursus a turpis et, ullamcorper lobortis metus. Aliquam aliquam sodales malesuada. Phasellus sit amet libero ut nulla porta ornare. In elit lectus, iaculis et volutpat eget, tempor ornare eros. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse sodales metus quis vulputate convallis. Morbi congue lectus eget massa finibus luctus. Pellentesque tempus dui vel auctor ullamcorper.</p>
 		</Prose>`),
 	},
 	{
@@ -190,20 +198,21 @@ const snippets = [
 		name: 'AppLayout',
 		code: boilerplateAppTemplate(`
 		<Prose>
-      <h1>Page heading</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at arcu eleifend, varius enim non, eleifend nibh. Quisque ac lacinia elit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer scelerisque at ligula tempor eleifend. Vestibulum volutpat, dolor eu rutrum consequat, libero justo lacinia tortor, id varius tortor ante sit amet nisl. Aenean at dui diam. Cras a ligula a ante aliquam lacinia. Ut dolor quam, gravida eu dui quis, molestie lacinia dolor. Fusce lacus mi, pharetra molestie tortor eu, finibus lacinia libero.</p>
-  		<p>Suspendisse feugiat rhoncus magna eleifend aliquam. Morbi euismod ex convallis viverra eleifend. Nullam vel finibus libero. Maecenas leo sem, consectetur sit amet ipsum vel, commodo porttitor quam. Nullam libero nulla, cursus a turpis et, ullamcorper lobortis metus. Aliquam aliquam sodales malesuada. Phasellus sit amet libero ut nulla porta ornare. In elit lectus, iaculis et volutpat eget, tempor ornare eros. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse sodales metus quis vulputate convallis. Morbi congue lectus eget massa finibus luctus. Pellentesque tempus dui vel auctor ullamcorper.</p>
+			<h1>Page heading</h1>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at arcu eleifend, varius enim non, eleifend nibh. Quisque ac lacinia elit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer scelerisque at ligula tempor eleifend. Vestibulum volutpat, dolor eu rutrum consequat, libero justo lacinia tortor, id varius tortor ante sit amet nisl. Aenean at dui diam. Cras a ligula a ante aliquam lacinia. Ut dolor quam, gravida eu dui quis, molestie lacinia dolor. Fusce lacus mi, pharetra molestie tortor eu, finibus lacinia libero.</p>
+			<p>Suspendisse feugiat rhoncus magna eleifend aliquam. Morbi euismod ex convallis viverra eleifend. Nullam vel finibus libero. Maecenas leo sem, consectetur sit amet ipsum vel, commodo porttitor quam. Nullam libero nulla, cursus a turpis et, ullamcorper lobortis metus. Aliquam aliquam sodales malesuada. Phasellus sit amet libero ut nulla porta ornare. In elit lectus, iaculis et volutpat eget, tempor ornare eros. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse sodales metus quis vulputate convallis. Morbi congue lectus eget massa finibus luctus. Pellentesque tempus dui vel auctor ullamcorper.</p>
 		</Prose>`),
 	},
 	{
 		group: 'Prose',
 		name: 'Basic',
-		code: `<Prose>
-    <h1>Page heading</h1>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at arcu eleifend, varius enim non, eleifend nibh. Quisque ac lacinia elit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer scelerisque at ligula tempor eleifend. Vestibulum volutpat, dolor eu rutrum consequat, libero justo lacinia tortor, id varius tortor ante sit amet nisl. Aenean at dui diam. Cras a ligula a ante aliquam lacinia. Ut dolor quam, gravida eu dui quis, molestie lacinia dolor. Fusce lacus mi, pharetra molestie tortor eu, finibus lacinia libero.</p>
-    <p>Suspendisse feugiat rhoncus magna eleifend aliquam. Morbi euismod ex convallis viverra eleifend. Nullam vel finibus libero. Maecenas leo sem, consectetur sit amet ipsum vel, commodo porttitor quam. Nullam libero nulla, cursus a turpis et, ullamcorper lobortis metus. Aliquam aliquam sodales malesuada. Phasellus sit amet libero ut nulla porta ornare. In elit lectus, iaculis et volutpat eget, tempor ornare eros. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse sodales metus quis vulputate convallis. Morbi congue lectus eget massa finibus luctus. Pellentesque tempus dui vel auctor ullamcorper.</p>
-  	</Prose>
-    `,
+		code: `
+		<Prose>
+			<h1>Page heading</h1>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at arcu eleifend, varius enim non, eleifend nibh. Quisque ac lacinia elit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer scelerisque at ligula tempor eleifend. Vestibulum volutpat, dolor eu rutrum consequat, libero justo lacinia tortor, id varius tortor ante sit amet nisl. Aenean at dui diam. Cras a ligula a ante aliquam lacinia. Ut dolor quam, gravida eu dui quis, molestie lacinia dolor. Fusce lacus mi, pharetra molestie tortor eu, finibus lacinia libero.</p>
+			<p>Suspendisse feugiat rhoncus magna eleifend aliquam. Morbi euismod ex convallis viverra eleifend. Nullam vel finibus libero. Maecenas leo sem, consectetur sit amet ipsum vel, commodo porttitor quam. Nullam libero nulla, cursus a turpis et, ullamcorper lobortis metus. Aliquam aliquam sodales malesuada. Phasellus sit amet libero ut nulla porta ornare. In elit lectus, iaculis et volutpat eget, tempor ornare eros. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse sodales metus quis vulputate convallis. Morbi congue lectus eget massa finibus luctus. Pellentesque tempus dui vel auctor ullamcorper.</p>
+		</Prose>
+	`,
 	},
 	{
 		group: 'Text',
@@ -249,177 +258,177 @@ const snippets = [
 		group: 'LinkList',
 		name: 'Basic',
 		code: `<LinkList links={[
-      { href: '#', label: 'Home' },
-      { href: '#', label: 'Establishments' },
-      { href: '#', label: 'Applications' },
-    ]} />`,
+			{ href: '#', label: 'Home' },
+			{ href: '#', label: 'Establishments' },
+			{ href: '#', label: 'Applications' },
+		]} />`,
 	},
 	{
 		group: 'Breadcrumbs',
 		name: 'Basic',
 		code: `<Breadcrumbs links={[
-      { href: '#', label: 'Home' },
-      { href: '#', label: 'Establishments' },
-      { label: 'Applications' },
-    ]} />`,
+			{ href: '#', label: 'Home' },
+			{ href: '#', label: 'Establishments' },
+			{ label: 'Applications' },
+		]} />`,
 	},
 	{
 		group: 'Footer',
 		name: 'Basic',
-		code: `<Box dark><Footer background="bodyAlt">
-    <nav aria-label="footer">
-      <LinkList
-        horizontal
-        links={[
-          { href: '#', label: 'Home' },
-          { href: '#', label: 'Terms and conditions' },
-          { href: '#', label: 'Privacy policy' },
-          { href: '#', label: 'A really long link title' },
-        ]}
-      />
-    </nav>
-    <FooterDivider />
-    <Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-      We acknowledge the traditional owners of country throughout Australia and recognise their continuing connection to land, waters and culture.
-      We pay our respects to their Elders past, present and emerging.
-    </Text>
-    <Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-      &copy; 2022 Department of Agriculture, Fisheries and Forestry
-    </Text>
-  </Footer></Box>`,
+		code: `<Box dark>
+		<Footer background="bodyAlt">
+			<nav aria-label="footer">
+				<LinkList
+					horizontal
+					links={[
+						{ href: '#', label: 'Home' },
+						{ href: '#', label: 'Terms and conditions' },
+						{ href: '#', label: 'Privacy policy' },
+						{ href: '#', label: 'A really long link title' },
+					]}
+				/>
+			</nav>
+			<FooterDivider />
+			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+				We acknowledge the traditional owners of country throughout Australia and recognise their continuing connection to land, waters and culture.
+				We pay our respects to their Elders past, present and emerging.
+			</Text>
+			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+				&copy; 2022 Department of Agriculture, Fisheries and Forestry
+			</Text>
+		</Footer></Box>`,
 	},
 	{
 		group: 'Footer',
 		name: 'Complex',
-		code: `<Box dark><Footer background="bodyAlt">
-    <nav aria-label="footer">
-      <Columns>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3  }}>
-          <Stack gap={0.5}>
-            <Heading as="h2" type="h3">Section</Heading>
-            <LinkList
-              links={[
-                { href: "#", label: "Link 1" },
-                { href: "#", label: "Link 2" },
-                { href: "#", label: "Link 3" },
-              ]}
-            />
-          </Stack>
-        </Column>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
-          <Stack gap={0.5}>
-            <Heading as="h2" type="h3">Section</Heading>
-            <LinkList
-              links={[
-                { href: "#", label: "Link 1" },
-                { href: "#", label: "Link 2" },
-                { href: "#", label: "Link 3" },
-              ]}
-            />
-          </Stack>
-        </Column>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
-          <Stack gap={0.5}>
-            <Heading as="h2" type="h3">Section</Heading>
-            <LinkList
-              links={[
-                { href: "#", label: "Link 1" },
-                { href: "#", label: "Link 2" },
-                { href: "#", label: "Link 3" },
-              ]}
-            />
-          </Stack>
-        </Column>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
-          <Stack gap={0.5}>
-            <Heading as="h2" type="h3">Section</Heading>
-            <LinkList
-              links={[
-                { href: "#", label: "Link 1" },
-                { href: "#", label: "Link 2" },
-                { href: "#", label: "Link 3" },
-              ]}
-            />
-          </Stack>
-        </Column>
-      </Columns>
-    </nav>
-    <FooterDivider />
-    <Text as="p">Footer text</Text>
-    <Box maxWidth="240px">
-      <Logo />
-    </Box>
-    <FooterDivider />
-    <Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-      We acknowledge the traditional owners of country throughout Australia and recognise their continuing connection to land, waters and culture.
-      We pay our respects to their Elders past, present and emerging.
-    </Text>
-    <Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-      &copy; 2022 Department of Agriculture, Fisheries and Forestry
-    </Text>
-  </Footer></Box>
-  `,
+		code: `<Box dark>
+		<Footer background="bodyAlt">
+			<nav aria-label="footer">
+				<Columns>
+					<Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
+						<Stack gap={0.5}>
+							<Heading as="h2" type="h3">Section</Heading>
+							<LinkList
+								links={[
+									{ href: "#", label: "Link 1" },
+									{ href: "#", label: "Link 2" },
+									{ href: "#", label: "Link 3" },
+								]}
+							/>
+						</Stack>
+					</Column>
+					<Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
+						<Stack gap={0.5}>
+							<Heading as="h2" type="h3">Section</Heading>
+							<LinkList
+								links={[
+									{ href: "#", label: "Link 1" },
+									{ href: "#", label: "Link 2" },
+									{ href: "#", label: "Link 3" },
+								]}
+							/>
+						</Stack>
+					</Column>
+					<Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
+						<Stack gap={0.5}>
+							<Heading as="h2" type="h3">Section</Heading>
+							<LinkList
+								links={[
+									{ href: "#", label: "Link 1" },
+									{ href: "#", label: "Link 2" },
+									{ href: "#", label: "Link 3" },
+								]}
+							/>
+						</Stack>
+					</Column>
+					<Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
+						<Stack gap={0.5}>
+							<Heading as="h2" type="h3">Section</Heading>
+							<LinkList
+								links={[
+									{ href: "#", label: "Link 1" },
+									{ href: "#", label: "Link 2" },
+									{ href: "#", label: "Link 3" },
+								]}
+							/>
+						</Stack>
+					</Column>
+				</Columns>
+			</nav>
+			<FooterDivider />
+			<Text as="p">Footer text</Text>
+			<Box maxWidth="240px">
+				<Logo />
+			</Box>
+			<FooterDivider />
+			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+				We acknowledge the traditional owners of country throughout Australia and recognise their continuing connection to land, waters and culture.
+				We pay our respects to their Elders past, present and emerging.
+			</Text>
+			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+				&copy; 2022 Department of Agriculture, Fisheries and Forestry
+			</Text>
+	</Footer></Box>`,
 	},
 	{
 		group: 'SideNav',
 		name: 'Basic',
 		code: `<SideNav
-activePath="#welcome"
-title="SideNav"
-collapseTitle="In this section"
-titleLink="#"
-items={[
-  {
-    href: "#welcome",
-    label: "Welcome",
-  },
-  {
-    href: "#one",
-    label: "Item",
-    items: [
-      {
-        href: "#two",
-        label: "Sub-item",
-      },
-    ],
-  },
-  { href: "#three", label: "Item" },
-  {
-    href: "#four",
-    label: "Item",
-    items: [
-      {
-        href: "#five",
-        label: "Sub-item",
-        items: [
-          {
-            href: "#six",
-            label: "Sub-sub-item",
-          },
-          {
-            href: "#seven",
-            label: "Sub-sub-item",
-          },
-        ],
-      },
-      {
-        href: "#eight",
-        label: "Sub-item",
-      },
-    ],
-  },
-]}
-/>
-`,
+			activePath="#welcome"
+			title="SideNav"
+			collapseTitle="In this section"
+			titleLink="#"
+			items={[
+				{
+					href: "#welcome",
+					label: "Welcome",
+				},
+				{
+					href: "#one",
+					label: "Item",
+					items: [
+						{
+						href: "#two",
+						label: "Sub-item",
+						},
+					],
+				},
+				{ href: "#three", label: "Item" },
+				{
+					href: "#four",
+					label: "Item",
+					items: [
+						{
+						href: "#five",
+						label: "Sub-item",
+						items: [
+							{
+							href: "#six",
+								label: "Sub-sub-item",
+							},
+							{
+							href: "#seven",
+								label: "Sub-sub-item",
+							},
+						],
+						},
+						{
+						href: "#eight",
+						label: "Sub-item",
+						},
+					],
+				},
+			]}
+		/>`,
 	},
 	{
 		group: 'Button',
 		name: 'ButtonGroup',
 		code: `<ButtonGroup>
-    <Button variant="primary">Primary</Button>
-    <Button variant="secondary">Secondary</Button>
-    <Button variant="tertiary">Tertiary</Button>
-  </ButtonGroup>`,
+			<Button variant="primary">Primary</Button>
+			<Button variant="secondary">Secondary</Button>
+			<Button variant="tertiary">Tertiary</Button>
+		</ButtonGroup>`,
 	},
 	{
 		group: 'Button',
@@ -445,41 +454,41 @@ items={[
 		group: 'Columns',
 		name: 'Basic',
 		code: `<Columns gap={2}>
-      <Column columnSpan={[12, 6]} background="shade" padding={1}>
-        <Text>Left</Text>
-      </Column>
-      <Column columnSpan={[12, 6]} background="shade" padding={1}>
-        <Text>Right</Text>
-      </Column>
-    </Columns>`,
+			<Column columnSpan={[12, 6]} background="shade" padding={1}>
+				<Text>Left</Text>
+			</Column>
+			<Column columnSpan={[12, 6]} background="shade" padding={1}>
+				<Text>Right</Text>
+			</Column>
+		</Columns>`,
 	},
 	{
 		group: 'Callout',
 		name: 'Neutral',
 		code: `<Callout title="Callout heading">
-      <Text>Description of the callout.</Text>
-    </Callout>`,
+			<Text>Description of the callout.</Text>
+		</Callout>`,
 	},
 	{
 		group: 'Callout',
 		name: 'Info',
 		code: `<Callout title="Callout heading" tone="info">
-      <Text>Description of the callout.</Text>
-    </Callout>`,
+			<Text>Description of the callout.</Text>
+		</Callout>`,
 	},
 	{
 		group: 'Callout',
 		name: 'Compact',
 		code: `<Callout title="Callout heading" tone="info" variant="compact">
-      <Text>Description of the callout.</Text>
-    </Callout>`,
+			<Text>Description of the callout.</Text>
+		</Callout>`,
 	},
 	{
 		group: 'Callout',
 		name: 'Feature',
 		code: `<Callout title="Callout heading" tone="info" variant="feature">
-      <Text>Description of the callout.</Text>
-    </Callout>`,
+			<Text>Description of the callout.</Text>
+		</Callout>`,
 	},
 	{
 		group: 'TextInput',
@@ -494,43 +503,49 @@ items={[
 	{
 		group: 'Select',
 		name: 'Basic',
-		code: `<Select 	label="What option?"
-    placeholder="Please select"
-    options={[
-      { value: 'a', label: 'Option A' },
-      { value: 'b', label: 'Option B' },
-      { value: 'c', label: 'Option C' },
-    ]} />`,
+		code: `<Select
+			label="What option?"
+			placeholder="Please select"
+			options={[
+				{ value: 'a', label: 'Option A' },
+				{ value: 'b', label: 'Option B' },
+				{ value: 'c', label: 'Option C' },
+			]}
+		/>`,
 	},
 	{
 		group: 'Fieldset',
 		name: 'Basic',
 		code: `<Fieldset legend="What is your address?">
-    <FormStack>
-			<TextInput label="Street and number" required maxWidth="xl" />
-			<TextInput label="Suburb" required maxWidth="xl" />
-			<TextInput label="Country" required maxWidth="xl" />
-			<TextInput label="Postcode" required maxWidth="sm" />
-		</FormStack>
-	</Fieldset>`,
+			<FormStack>
+					<TextInput label="Street and number" required maxWidth="xl" />
+					<TextInput label="Suburb" required maxWidth="xl" />
+					<TextInput label="Country" required maxWidth="xl" />
+					<TextInput label="Postcode" required maxWidth="sm" />
+				</FormStack>
+			</Fieldset>`,
 	},
 	{
 		group: 'Accordion',
 		name: 'Basic',
-		code: `<Accordion><AccordionItem title="Accordion">
-    <AccordionItemContent><Text as="p">This is some text inside an Accordion</Text></AccordionItemContent>
-  </AccordionItem></Accordion>`,
+		code: `<Accordion>
+			<AccordionItem title="Accordion">
+				<AccordionItemContent>
+					<Text as="p">This is some text inside an Accordion</Text>
+				</AccordionItemContent>
+			</AccordionItem>
+		</Accordion>`,
 	},
 	{
 		group: 'ProgressIndicator',
 		name: 'Basic',
 		code: `<ProgressIndicator
-    items={[
-      { href: '#', label: 'Introduction', status: 'doing' },
-      { href: '#', label: 'Business Contacts', status: 'todo' },
-      { href: '#', label: 'Case Studies', status: 'done' },
-    ]}
-  />`,
+			items={[
+				{ href: '#', label: 'Introduction', status: 'doing' },
+				{ href: '#', label: 'Business Contacts', status: 'todo' },
+				{ href: '#', label: 'Case Studies', status: 'done' },
+			]}
+		/>`,
 	},
 	{
 		group: 'Checkbox',
@@ -550,10 +565,10 @@ items={[
 		group: 'Radio',
 		name: 'Basic',
 		code: `<ControlGroup>
-    <Radio checked={false}>Phone</Radio>
-    <Radio checked={false}>Tablet</Radio>
-    <Radio checked={true}>Laptop</Radio>
-  </ControlGroup>`,
+			<Radio checked={false}>Phone</Radio>
+			<Radio checked={false}>Tablet</Radio>
+			<Radio checked={true}>Laptop</Radio>
+		</ControlGroup>`,
 	},
 	{
 		group: 'ControlGroup',
@@ -568,10 +583,10 @@ items={[
 		group: 'ControlGroup',
 		name: 'Radio',
 		code: `<ControlGroup>
-    <Radio checked={false}>Phone</Radio>
-    <Radio checked={false}>Tablet</Radio>
-    <Radio checked={true}>Laptop</Radio>
-  </ControlGroup>`,
+			<Radio checked={false}>Phone</Radio>
+			<Radio checked={false}>Tablet</Radio>
+			<Radio checked={true}>Laptop</Radio>
+		</ControlGroup>`,
 	},
 	{
 		group: 'Switch',
@@ -582,30 +597,30 @@ items={[
 		group: 'Searchbox',
 		name: 'Basic',
 		code: `<SearchBox onSubmit={console.log}>
-    <SearchBoxInput label="Search this website" />
-    <SearchBoxButton>Search</SearchBoxButton>
-  </SearchBox>`,
+			<SearchBoxInput label="Search this website" />
+			<SearchBoxButton>Search</SearchBoxButton>
+		</SearchBox>`,
 	},
 	{
 		group: 'SkipLinks',
 		name: 'Basic',
 		code: `<SkipLinks
-    links={[
-      { href: '#main-content', label: 'Skip to main content' },
-      { href: '#main-nav', label: 'Skip to main navigation' },
-    ]}
-  />`,
+			links={[
+				{ href: '#main-content', label: 'Skip to main content' },
+				{ href: '#main-nav', label: 'Skip to main navigation' },
+			]}
+		/>`,
 	},
 	{
 		group: 'InpageNav',
 		name: 'Basic',
 		code: `<InpageNav
-		title="On this page"
-		links={[
-			{ href: '#section-1', label: 'Section 1' },
-			{ href: '#section-2', label: 'Section 2' },
-		]}
-	/>`,
+			title="On this page"
+			links={[
+				{ href: '#section-1', label: 'Section 1' },
+				{ href: '#section-2', label: 'Section 2' },
+			]}
+		/>`,
 	},
 	{
 		group: 'DirectionLink',
@@ -626,25 +641,25 @@ items={[
 		group: 'Tags',
 		name: 'Basic',
 		code: `<Tags
-    heading={<Text as="h2" fontWeight="bold">Tags:</Text>}
-    items={[
-      { href: '#', label: 'Foo' },
-      { href: '#', label: 'Bar' },
-      { href: '#', label: 'Baz' },
-    ]}
-    />`,
+			heading={<Text as="h2" fontWeight="bold">Tags:</Text>}
+			items={[
+				{ href: '#', label: 'Foo' },
+				{ href: '#', label: 'Bar' },
+				{ href: '#', label: 'Baz' },
+			]}
+		/>`,
 	},
 	{
 		group: 'Tags',
 		name: 'Removable',
 		code: `<Tags
-    heading={<Text as="h2" fontWeight="bold">Tags:</Text>}
-    items={[
-      { href: '#', label: 'Foo', onRemove: console.log },
-      { href: '#', label: 'Bar', onRemove: console.log },
-      { href: '#', label: 'Baz', onRemove: console.log },
-    ]}
-    />`,
+			heading={<Text as="h2" fontWeight="bold">Tags:</Text>}
+			items={[
+				{ href: '#', label: 'Foo', onRemove: console.log },
+				{ href: '#', label: 'Bar', onRemove: console.log },
+				{ href: '#', label: 'Baz', onRemove: console.log },
+			]}
+		/>`,
 	},
 	{
 		group: 'Tag',
@@ -655,17 +670,17 @@ items={[
 		group: 'Form',
 		name: 'Sign in',
 		code: `<form>
-    <FormStack>
-      <TextInput label="Email" type="email" maxWidth="xl" />
-      <TextInput label="Password" type="password" maxWidth="xl" />
-      <ButtonGroup>
-        <Button type="submit">Submit</Button>
-        <Button type="button" variant="secondary">
-          Cancel
-        </Button>
-      </ButtonGroup>
-    </FormStack>
-  </form>`,
+			<FormStack>
+				<TextInput label="Email" type="email" maxWidth="xl" />
+				<TextInput label="Password" type="password" maxWidth="xl" />
+				<ButtonGroup>
+				<Button type="submit">Submit</Button>
+				<Button type="button" variant="secondary">
+					Cancel
+				</Button>
+				</ButtonGroup>
+			</FormStack>
+		</form>`,
 	},
 	{
 		group: 'FileUpload',
@@ -676,30 +691,30 @@ items={[
 		group: 'TaskList',
 		name: 'Basic',
 		code: `<TaskList
-    items={[
-      {
-        href: '#',
-        label: 'Check eligibility',
-        status: 'done',
-      },
-      {
-        href: '#',
-        label: 'Lorem ipsum dolor sit amet',
-        status: 'done',
-      },
-      {
-        href: '#',
-        label: 'Case Studies',
-        status: 'todo',
-      },
-      {
-        href: '#',
-        label: 'Review and submit',
-        message: 'Not available until previous tasks are done',
-        status: 'todo',
-      },
-    ]}
-  />`,
+			items={[
+				{
+					href: '#',
+					label: 'Check eligibility',
+					status: 'done',
+				},
+				{
+					href: '#',
+					label: 'Lorem ipsum dolor sit amet',
+					status: 'done',
+				},
+				{
+					href: '#',
+					label: 'Case Studies',
+					status: 'todo',
+				},
+				{
+					href: '#',
+					label: 'Review and submit',
+					message: 'Not available until previous tasks are done',
+					status: 'todo',
+				},
+			]}
+		/>`,
 	},
 	{
 		group: 'PageAlert',
@@ -724,7 +739,7 @@ items={[
 				<ListItem><TextLink href="#">Email must not be empty</TextLink></ListItem>
 				<ListItem><TextLink href="#">Description must not be empty</TextLink></ListItem>
 			</UnorderedList>
-    </PageAlert>`,
+		</PageAlert>`,
 	},
 	{
 		group: 'PageAlert',
@@ -737,79 +752,78 @@ items={[
 		group: 'Table',
 		name: 'Basic',
 		code: `<TableWrapper>
-    <Table>
-      <TableCaption>
-        Population of Australian states and territories, December 2015
-      </TableCaption>
-      <TableHead>
-        <TableRow>
-          <TableHeader width="50%" scope="col">
-            Location
-          </TableHeader>
-          <TableHeader textAlign="right" scope="col">
-            Population
-          </TableHeader>
-          <TableHeader textAlign="right" scope="col">
-            Change over previous year %
-          </TableHeader>
-          <TableHeader textAlign="right" scope="col">
-            Change over previous decade %
-          </TableHeader>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <TableCell>New South Wales</TableCell>
-          <TableCell textAlign="right">7,670,700</TableCell>
-          <TableCell textAlign="right">3.1%</TableCell>
-          <TableCell textAlign="right">12.9%</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Victoria</TableCell>
-          <TableCell textAlign="right">5,996,400</TableCell>
-          <TableCell textAlign="right">2.5%</TableCell>
-          <TableCell textAlign="right">9.3%</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Queensland</TableCell>
-          <TableCell textAlign="right">4,808,800</TableCell>
-          <TableCell textAlign="right">1.7%</TableCell>
-          <TableCell textAlign="right">13.3%</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Western Australia</TableCell>
-          <TableCell textAlign="right">2,603,900</TableCell>
-          <TableCell textAlign="right">2.3%</TableCell>
-          <TableCell textAlign="right">11.6%</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>South Australia</TableCell>
-          <TableCell textAlign="right">1,702,800</TableCell>
-          <TableCell textAlign="right">2.0%</TableCell>
-          <TableCell textAlign="right">6.8%</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Tasmania</TableCell>
-          <TableCell textAlign="right">517,400</TableCell>
-          <TableCell textAlign="right">4%</TableCell>
-          <TableCell textAlign="right">5.3%</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Northern Territory</TableCell>
-          <TableCell textAlign="right">244,400</TableCell>
-          <TableCell textAlign="right">1.2%</TableCell>
-          <TableCell textAlign="right">4.5%</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Australian Capital Territory</TableCell>
-          <TableCell textAlign="right">393,000</TableCell>
-          <TableCell textAlign="right">2.4%</TableCell>
-          <TableCell textAlign="right">9.6%</TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
-  </TableWrapper>
-  `,
+			<Table>
+				<TableCaption>
+				Population of Australian states and territories, December 2015
+				</TableCaption>
+				<TableHead>
+				<TableRow>
+					<TableHeader width="50%" scope="col">
+						Location
+					</TableHeader>
+					<TableHeader textAlign="right" scope="col">
+						Population
+					</TableHeader>
+					<TableHeader textAlign="right" scope="col">
+						Change over previous year %
+					</TableHeader>
+					<TableHeader textAlign="right" scope="col">
+						Change over previous decade %
+					</TableHeader>
+				</TableRow>
+				</TableHead>
+				<TableBody>
+				<TableRow>
+					<TableCell>New South Wales</TableCell>
+					<TableCell textAlign="right">7,670,700</TableCell>
+					<TableCell textAlign="right">3.1%</TableCell>
+					<TableCell textAlign="right">12.9%</TableCell>
+				</TableRow>
+				<TableRow>
+					<TableCell>Victoria</TableCell>
+					<TableCell textAlign="right">5,996,400</TableCell>
+					<TableCell textAlign="right">2.5%</TableCell>
+					<TableCell textAlign="right">9.3%</TableCell>
+				</TableRow>
+				<TableRow>
+					<TableCell>Queensland</TableCell>
+					<TableCell textAlign="right">4,808,800</TableCell>
+					<TableCell textAlign="right">1.7%</TableCell>
+					<TableCell textAlign="right">13.3%</TableCell>
+				</TableRow>
+				<TableRow>
+					<TableCell>Western Australia</TableCell>
+					<TableCell textAlign="right">2,603,900</TableCell>
+					<TableCell textAlign="right">2.3%</TableCell>
+					<TableCell textAlign="right">11.6%</TableCell>
+				</TableRow>
+				<TableRow>
+					<TableCell>South Australia</TableCell>
+					<TableCell textAlign="right">1,702,800</TableCell>
+					<TableCell textAlign="right">2.0%</TableCell>
+					<TableCell textAlign="right">6.8%</TableCell>
+				</TableRow>
+				<TableRow>
+					<TableCell>Tasmania</TableCell>
+					<TableCell textAlign="right">517,400</TableCell>
+					<TableCell textAlign="right">4%</TableCell>
+					<TableCell textAlign="right">5.3%</TableCell>
+				</TableRow>
+				<TableRow>
+					<TableCell>Northern Territory</TableCell>
+					<TableCell textAlign="right">244,400</TableCell>
+					<TableCell textAlign="right">1.2%</TableCell>
+					<TableCell textAlign="right">4.5%</TableCell>
+				</TableRow>
+				<TableRow>
+					<TableCell>Australian Capital Territory</TableCell>
+					<TableCell textAlign="right">393,000</TableCell>
+					<TableCell textAlign="right">2.4%</TableCell>
+					<TableCell textAlign="right">9.6%</TableCell>
+				</TableRow>
+				</TableBody>
+			</Table>
+		</TableWrapper>`,
 	},
 	{
 		group: 'DatePicker',
@@ -830,79 +844,79 @@ items={[
 		group: 'LoadingBlanket',
 		name: 'Basic',
 		code: `<Box background="body" height="300px" width="100%" padding={1} border rounded style={{ position: 'relative' }}>
-      <LoadingBlanket label="Component loading state" />
-    </Box>`,
+			<LoadingBlanket label="Component loading state" />
+		</Box>`,
 	},
 	{
 		group: 'HeroBanner',
 		name: 'Basic',
 		code: `<HeroBanner
-    image={
-      <img
-        src="/img/placeholder/hero-banner.jpeg"
-        role="presentation"
-        alt=""
-      />
-    }
->
-    <HeroBannerTitleContainer>
-        <HeroBannerTitle>Website hero banner title - xxxl/display (H1)</HeroBannerTitle>
-        <HeroBannerSubtitle>Hero banner paragraph text (P)</HeroBannerSubtitle>
-    </HeroBannerTitleContainer>
-    <SearchBox onSubmit={() => {}}>
-        <SearchBoxInput label="Search this website" />
-        <SearchBoxButton iconOnly={{ xs: true, md: false }}>Search</SearchBoxButton>
-    </SearchBox>
-  </HeroBanner>`,
+			image={
+				<img
+				src="/img/placeholder/hero-banner.jpeg"
+				role="presentation"
+				alt=""
+				/>
+			}
+		>
+			<HeroBannerTitleContainer>
+				<HeroBannerTitle>Website hero banner title - xxxl/display (H1)</HeroBannerTitle>
+				<HeroBannerSubtitle>Hero banner paragraph text (P)</HeroBannerSubtitle>
+			</HeroBannerTitleContainer>
+			<SearchBox onSubmit={() => {}}>
+				<SearchBoxInput label="Search this website" />
+				<SearchBoxButton iconOnly={{ xs: true, md: false }}>Search</SearchBoxButton>
+			</SearchBox>
+		</HeroBanner>`,
 	},
 	{
 		group: 'HeroCategoryBanner',
 		name: 'Basic',
 		code: `<HeroCategoryBanner
-    image={
-      <img
-        src="/img/placeholder/hero-banner.jpeg"
-        role="presentation"
-        alt=""
-      />
-    }
-  >
-    <HeroCategoryBannerTitle>
-      Website hero banner title - xxl/display (H1)
-    </HeroCategoryBannerTitle>
-    <HeroCategoryBannerSubtitle>
-      Hero banner sub title (P).
-    </HeroCategoryBannerSubtitle>
-  </HeroCategoryBanner>`,
+			image={
+				<img
+				src="/img/placeholder/hero-banner.jpeg"
+				role="presentation"
+				alt=""
+				/>
+			}
+		>
+			<HeroCategoryBannerTitle>
+				Website hero banner title - xxl/display (H1)
+			</HeroCategoryBannerTitle>
+			<HeroCategoryBannerSubtitle>
+				Hero banner sub title (P).
+			</HeroCategoryBannerSubtitle>
+		</HeroCategoryBanner>`,
 	},
 	{
 		group: 'HeroSubcategoryBanner',
 		name: 'Basic',
 		code: `<HeroSubcategoryBanner>
-    <Breadcrumbs
-      links={[
-        { href: '#', label: 'Section 1' },
-        { href: '#', label: 'Category page' },
-        { label: 'Subcategory page' },
-      ]}
-    />
-    <HeroSubcategoryBannerTitle>
-      Subcategory banner title - xxl/display (H1)
-    </HeroSubcategoryBannerTitle>
-  </HeroSubcategoryBanner>`,
+			<Breadcrumbs
+				links={[
+				{ href: '#', label: 'Section 1' },
+				{ href: '#', label: 'Category page' },
+				{ label: 'Subcategory page' },
+				]}
+			/>
+			<HeroSubcategoryBannerTitle>
+				Subcategory banner title - xxl/display (H1)
+			</HeroSubcategoryBannerTitle>
+		</HeroSubcategoryBanner>`,
 	},
 	{
 		group: 'SubNav',
 		name: 'Basic',
 		code: `<SubNav
-    activePath="#code"
-    links={[
-      { href: '#usage', label: 'Usage' },
-      { href: '#code', label: 'Code' },
-      { href: '#content', label: 'Content' },
-      { href: '#accessibility', label: 'Accessibility' },
-    ]}
-  />`,
+			activePath="#code"
+			links={[
+				{ href: '#usage', label: 'Usage' },
+				{ href: '#code', label: 'Code' },
+				{ href: '#content', label: 'Content' },
+				{ href: '#accessibility', label: 'Accessibility' },
+			]}
+		/>`,
 	},
 	{
 		group: 'TextLink',
@@ -985,18 +999,18 @@ items={[
 		group: 'Card',
 		name: 'Basic',
 		code: `<Card shadow clickable>
-    <CardInner>
-      <Stack gap={1}>
-        <H3>
-          <CardLink href="#">Card heading</CardLink>
-        </H3>
-        <Text as="p">
-          Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
-          voluptat
-        </Text>
-      </Stack>
-    </CardInner>
-  </Card>`,
+			<CardInner>
+				<Stack gap={1}>
+				<H3>
+					<CardLink href="#">Card heading</CardLink>
+				</H3>
+				<Text as="p">
+					Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+					voluptat
+				</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
 	},
 	{
 		group: 'Autocomplete',
@@ -1023,68 +1037,68 @@ items={[
 		group: 'SummaryList',
 		name: 'Basic',
 		code: `<Stack gap={1.5}>
-      <SummaryList>
-        <SummaryListItem>
-          <SummaryListItemTerm>First name</SummaryListItemTerm>
-          <SummaryListItemDescription>Will</SummaryListItemDescription>
-        </SummaryListItem>
-        <SummaryListItem>
-          <SummaryListItemTerm>Last name</SummaryListItemTerm>
-          <SummaryListItemDescription>Power</SummaryListItemDescription>
-        </SummaryListItem>
-        <SummaryListItem>
-          <SummaryListItemTerm>Contact information</SummaryListItemTerm>
-          <SummaryListItemDescription>
-            +61 9912 3456
-					  <br />
-					  will.power@example.com
-          </SummaryListItemDescription>
-        </SummaryListItem>
-        <SummaryListItem>
-          <SummaryListItemTerm>Date of birth</SummaryListItemTerm>
-          <SummaryListItemDescription>09/06/1995</SummaryListItemDescription>
-        </SummaryListItem>
-      </SummaryList>
-      <TextLink href="#">Change all</TextLink>
-    </Stack>`,
+			<SummaryList>
+			<SummaryListItem>
+				<SummaryListItemTerm>First name</SummaryListItemTerm>
+				<SummaryListItemDescription>Will</SummaryListItemDescription>
+			</SummaryListItem>
+			<SummaryListItem>
+				<SummaryListItemTerm>Last name</SummaryListItemTerm>
+				<SummaryListItemDescription>Power</SummaryListItemDescription>
+			</SummaryListItem>
+			<SummaryListItem>
+				<SummaryListItemTerm>Contact information</SummaryListItemTerm>
+				<SummaryListItemDescription>
+					+61 9912 3456
+					<br />
+					will.power@example.com
+				</SummaryListItemDescription>
+			</SummaryListItem>
+			<SummaryListItem>
+				<SummaryListItemTerm>Date of birth</SummaryListItemTerm>
+				<SummaryListItemDescription>09/06/1995</SummaryListItemDescription>
+			</SummaryListItem>
+			</SummaryList>
+			<TextLink href="#">Change all</TextLink>
+		</Stack>`,
 	},
 	{
 		group: 'SummaryList',
 		name: 'With actions',
 		code: `<SummaryList>
-      <SummaryListItem>
-          <SummaryListItemTerm>First name</SummaryListItemTerm>
-          <SummaryListItemDescription>Will</SummaryListItemDescription>
-          <SummaryListItemAction>
-              <TextLink href="#">Change</TextLink>
-          </SummaryListItemAction>
-      </SummaryListItem>
-      <SummaryListItem>
-          <SummaryListItemTerm>Last name</SummaryListItemTerm>
-          <SummaryListItemDescription>Power</SummaryListItemDescription>
-          <SummaryListItemAction>
-              <TextLink href="#">Change</TextLink>
-          </SummaryListItemAction>
-      </SummaryListItem>
-      <SummaryListItem>
-          <SummaryListItemTerm>Contact information</SummaryListItemTerm>
-          <SummaryListItemDescription>
-            +61 9912 3456
-					  <br />
-					  will.power@example.com
-          </SummaryListItemDescription>
-          <SummaryListItemAction>
-              <TextLink href="#">Change</TextLink>
-          </SummaryListItemAction>
-      </SummaryListItem>
-      <SummaryListItem>
-          <SummaryListItemTerm>Date of birth</SummaryListItemTerm>
-          <SummaryListItemDescription>09/06/1995</SummaryListItemDescription>
-          <SummaryListItemAction>
-              <TextLink href="#">Change</TextLink>
-          </SummaryListItemAction>
-      </SummaryListItem>
-    </SummaryList>`,
+			<SummaryListItem>
+				<SummaryListItemTerm>First name</SummaryListItemTerm>
+				<SummaryListItemDescription>Will</SummaryListItemDescription>
+				<SummaryListItemAction>
+					<TextLink href="#">Change</TextLink>
+				</SummaryListItemAction>
+			</SummaryListItem>
+			<SummaryListItem>
+				<SummaryListItemTerm>Last name</SummaryListItemTerm>
+				<SummaryListItemDescription>Power</SummaryListItemDescription>
+				<SummaryListItemAction>
+					<TextLink href="#">Change</TextLink>
+				</SummaryListItemAction>
+			</SummaryListItem>
+			<SummaryListItem>
+				<SummaryListItemTerm>Contact information</SummaryListItemTerm>
+				<SummaryListItemDescription>
+					+61 9912 3456
+					<br />
+					will.power@example.com
+				</SummaryListItemDescription>
+				<SummaryListItemAction>
+					<TextLink href="#">Change</TextLink>
+				</SummaryListItemAction>
+			</SummaryListItem>
+			<SummaryListItem>
+				<SummaryListItemTerm>Date of birth</SummaryListItemTerm>
+				<SummaryListItemDescription>09/06/1995</SummaryListItemDescription>
+				<SummaryListItemAction>
+					<TextLink href="#">Change</TextLink>
+				</SummaryListItemAction>
+			</SummaryListItem>
+		</SummaryList>`,
 	},
 	{
 		group: 'SearchInput',


### PR DESCRIPTION
Adds the `accountDetails` prop to `AppLayoutHeader` in `boilerplateAppTemplate`.

Makes all whitespace consistent to use tabs, and not a mixture of tabs and spaces.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1525/playroom)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets