### PR TITLE
date-range-picker: Correctly associate error message to appropriate date inputs

### DIFF
--- a/.changeset/dull-keys-tap.md
+++ b/.changeset/dull-keys-tap.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+date-range-picker: Correctly associate error message to appropriate date inputs.

--- a/packages/react/src/date-range-picker/DateRangePicker.stories.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.stories.tsx
@@ -99,6 +99,15 @@ export const ToInvalid: Story = {
 	},
 };
 
+export const ToInvalidWithHint: Story = {
+	args: {
+		legend: 'Date range',
+		toInvalid: true,
+		message: 'Enter a valid date',
+		hint: 'Hint text',
+	},
+};
+
 export const Required: Story = {
 	args: {
 		legend: 'Date range',

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -276,13 +276,24 @@ export const DateRangePicker = ({
 	const invalid = fromInvalid || toInvalid;
 
 	const { fieldsetId, hintId, messageId } = useDateRangePickerIds(id);
+	const fromDescribedByIds = [
+		fromInvalid && message ? messageId : null,
+		hint ? hintId : null,
+	]
+		.filter(Boolean)
+		.join(' ');
+	const toDescribedByIds = [
+		toInvalid && message ? messageId : null,
+		hint ? hintId : null,
+	]
+		.filter(Boolean)
+		.join(' ');
 
 	return (
 		<FieldContainer invalid={invalid} id={fieldsetId}>
 			<fieldset css={{ padding: 0, margin: 0, border: 'none' }}>
 				{/* Legend needs to be the first element, so if none is supplied render a visually hidden element. */}
 				<FieldLabel
-					aria-describedby={hint ? hintId : null}
 					as="legend"
 					required={required}
 					hideOptionalLabel={hideOptionalLabel}
@@ -300,7 +311,9 @@ export const DateRangePicker = ({
 					) : null}
 					<Flex {...popover.getReferenceProps()} flexWrap="wrap" inline gap={1}>
 						<DateInput
-							aria-describedby={message && fromInvalid ? messageId : null}
+							aria-describedby={
+								fromDescribedByIds.length > 0 ? fromDescribedByIds : null
+							}
 							ref={fromInputRef}
 							label={fromLabel}
 							hideOptionalLabel={hideOptionalLabel || Boolean(legend)}
@@ -313,7 +326,9 @@ export const DateRangePicker = ({
 							invalid={{ field: false, input: fromInvalid }}
 						/>
 						<DateInput
-							aria-describedby={message && toInvalid ? messageId : null}
+							aria-describedby={
+								toDescribedByIds.length > 0 ? toDescribedByIds : null
+							}
 							ref={toInputRef}
 							label={toLabel}
 							hideOptionalLabel={hideOptionalLabel || Boolean(legend)}

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -276,22 +276,13 @@ export const DateRangePicker = ({
 	const invalid = fromInvalid || toInvalid;
 
 	const { fieldsetId, hintId, messageId } = useDateRangePickerIds(id);
-	const describedByIds = [
-		invalid && message ? messageId : null,
-		hint ? hintId : null,
-	].filter(Boolean);
-	const describedBy = describedByIds.length
-		? describedByIds.join(' ')
-		: undefined;
 
 	return (
 		<FieldContainer invalid={invalid} id={fieldsetId}>
-			<fieldset
-				aria-describedby={describedBy}
-				css={{ padding: 0, margin: 0, border: 'none' }}
-			>
+			<fieldset css={{ padding: 0, margin: 0, border: 'none' }}>
 				{/* Legend needs to be the first element, so if none is supplied render a visually hidden element. */}
 				<FieldLabel
+					aria-describedby={hint ? hintId : null}
 					as="legend"
 					required={required}
 					hideOptionalLabel={hideOptionalLabel}
@@ -309,6 +300,7 @@ export const DateRangePicker = ({
 					) : null}
 					<Flex {...popover.getReferenceProps()} flexWrap="wrap" inline gap={1}>
 						<DateInput
+							aria-describedby={message && fromInvalid ? messageId : null}
 							ref={fromInputRef}
 							label={fromLabel}
 							hideOptionalLabel={hideOptionalLabel || Boolean(legend)}
@@ -321,6 +313,7 @@ export const DateRangePicker = ({
 							invalid={{ field: false, input: fromInvalid }}
 						/>
 						<DateInput
+							aria-describedby={message && toInvalid ? messageId : null}
 							ref={toInputRef}
 							label={toLabel}
 							hideOptionalLabel={hideOptionalLabel || Boolean(legend)}


### PR DESCRIPTION
## Invalid: 

<img width="1040" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/acbd61ac-7581-4cc3-af22-00dd04d2e47f">


## Valid: 

<img width="1038" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/72e93675-a109-4b44-bbec-f75f78594f94">

The error message wasn't associated to the inputs, so this fixes that.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1534)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.