### PR TITLE
progress-indicator: Add new `saved` and `error` status

### DIFF
--- a/.changeset/heavy-badgers-sit.md
+++ b/.changeset/heavy-badgers-sit.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': minor
 ---
 
-progress-indicator: Added two new statuses for items: `saved` and `error`.
+progress-indicator: Added two new statuses for items: `'saved'` and `'error'`.

--- a/.changeset/heavy-badgers-sit.md
+++ b/.changeset/heavy-badgers-sit.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+progress-indicator: Added two new statuses for items: `saved` and `error`.

--- a/packages/react/src/progress-indicator/ProgressIndicator.stories.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicator.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Box } from '../box';
-import { ProgressIndicator } from './index';
+import { ProgressIndicator, ProgressIndicatorItem } from './index';
 
 const meta: Meta<typeof ProgressIndicator> = {
 	title: 'forms/ProgressIndicator',
@@ -11,24 +11,24 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const exampleLinkItems = [
-	{ href: '#', label: 'Introduction', status: 'done' as const },
-	{ href: '#', label: 'Organisations', status: 'started' as const },
-	{ href: '#', label: 'Business contacts', status: 'doing' as const },
-	{ href: '#', label: 'Case studies', status: 'todo' as const },
-	{ href: '#', label: 'Attachments', status: 'blocked' as const },
+const exampleLinkItems: ProgressIndicatorItem[] = [
+	{ label: 'Introduction', status: 'done', href: '#' },
+	{ label: 'Submit evidence', status: 'saved', href: '#' },
+	{ label: 'Organisations', status: 'started', href: '#' },
+	{ label: 'Business contacts', status: 'error', href: '#' },
+	{ label: 'Case studies', status: 'todo', href: '#' },
+	{ label: 'Attachments', status: 'doing', href: '#' },
+	{ label: 'Review and submit', status: 'blocked', href: '#' },
 ];
 
-const exampleButtonItems = [
-	{ onClick: console.log, label: 'Introduction', status: 'done' as const },
-	{ onClick: console.log, label: 'Organisations', status: 'started' as const },
-	{
-		onClick: console.log,
-		label: 'Business contacts',
-		status: 'doing' as const,
-	},
-	{ onClick: console.log, label: 'Case studies', status: 'todo' as const },
-	{ onClick: console.log, label: 'Attachments', status: 'blocked' as const },
+const exampleButtonItems: ProgressIndicatorItem[] = [
+	{ label: 'Introduction', status: 'done', onClick: console.log },
+	{ label: 'Submit evidence', status: 'saved', onClick: console.log },
+	{ label: 'Organisations', status: 'started', onClick: console.log },
+	{ label: 'Business contacts', status: 'error', onClick: console.log },
+	{ label: 'Case studies', status: 'todo', onClick: console.log },
+	{ label: 'Attachments', status: 'doing', onClick: console.log },
+	{ label: 'Review and submit', status: 'blocked', onClick: console.log },
 ];
 
 export const Basic: Story = {

--- a/packages/react/src/progress-indicator/ProgressIndicator.test.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicator.test.tsx
@@ -14,11 +14,11 @@ function renderProgressIndicator(props: ProgressIndicatorProps) {
 
 describe('ProgressIndicator', () => {
 	describe('With anchors', () => {
-		const exampleProps = {
+		const exampleProps: ProgressIndicatorProps = {
 			items: [
-				{ href: '#', label: 'Introduction', status: 'done' as const },
-				{ href: '#', label: 'Business Contacts', status: 'doing' as const },
-				{ href: '#', label: 'Case Studies', status: 'todo' as const },
+				{ href: '#', label: 'Introduction', status: 'done' },
+				{ href: '#', label: 'Business Contacts', status: 'doing' },
+				{ href: '#', label: 'Case Studies', status: 'todo' },
 			],
 		};
 		it('renders correctly', () => {
@@ -39,22 +39,22 @@ describe('ProgressIndicator', () => {
 		});
 	});
 	describe('With buttons', () => {
-		const exampleProps = {
+		const exampleProps: ProgressIndicatorProps = {
 			items: [
 				{
 					onClick: console.log,
 					label: 'Introduction',
-					status: 'done' as const,
+					status: 'done',
 				},
 				{
 					onClick: console.log,
 					label: 'Business Contacts',
-					status: 'doing' as const,
+					status: 'doing',
 				},
 				{
 					onClick: console.log,
 					label: 'Case Studies',
-					status: 'todo' as const,
+					status: 'todo',
 				},
 			],
 		};

--- a/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
@@ -9,6 +9,8 @@ import {
 	ProgressDoingIcon,
 	SuccessFilledIcon,
 	ProgressTodoIcon,
+	SuccessIcon,
+	AlertIcon,
 } from '../icon';
 import { boxPalette, LinkProps, packs, tokens } from '../core';
 import { BaseButton } from '../button';
@@ -236,5 +238,15 @@ const statusMap = {
 		label: 'Completed',
 		icon: SuccessFilledIcon,
 		iconColor: 'success',
+	},
+	saved: {
+		label: 'Saved',
+		icon: SuccessIcon,
+		iconColor: 'success',
+	},
+	error: {
+		label: 'Error',
+		icon: AlertIcon,
+		iconColor: 'error',
 	},
 } as const;

--- a/packages/react/src/progress-indicator/docs/overview.mdx
+++ b/packages/react/src/progress-indicator/docs/overview.mdx
@@ -10,11 +10,13 @@ relatedComponents: ['task-list']
 ```jsx live
 <ProgressIndicator
 	items={[
-		{ href: '#', label: 'Introduction', status: 'done' },
-		{ href: '#', label: 'Organisations', status: 'started' },
-		{ href: '#', label: 'Business contacts', status: 'doing' },
-		{ href: '#', label: 'Case studies', status: 'todo' },
-		{ href: '#', label: 'Attachments', status: 'blocked' },
+		{ label: 'Introduction', status: 'done', href: '#' },
+		{ label: 'Submit evidence', status: 'saved', href: '#' },
+		{ label: 'Organisations', status: 'started', href: '#' },
+		{ label: 'Business contacts', status: 'error', href: '#' },
+		{ label: 'Case studies', status: 'todo', href: '#' },
+		{ label: 'Attachments', status: 'doing', href: '#' },
+		{ label: 'Review and submit', status: 'blocked', href: '#' },
 	]}
 />
 ```
@@ -107,6 +109,20 @@ The `status` prop can be used to indicate the status of each item. The following
 			<TableCell>Cannot start yet</TableCell>
 			<TableCell>The task is not available yet for the user to do</TableCell>
 		</TableRow>
+		<TableRow>
+			<TableCell>
+				<code>saved</code>
+			</TableCell>
+			<TableCell>Saved</TableCell>
+			<TableCell>The user has saved input</TableCell>
+		</TableRow>
+		<TableRow>
+			<TableCell>
+				<code>error</code>
+			</TableCell>
+			<TableCell>Error</TableCell>
+			<TableCell>There is an error that requires attention</TableCell>
+		</TableRow>
 	</TableBody>
 </Table>
 
@@ -117,11 +133,13 @@ If an item does not specify an `href` attribute, a `button` element will be rend
 ```jsx live
 <ProgressIndicator
 	items={[
-		{ onClick: console.log, label: 'Introduction', status: 'done' },
-		{ onClick: console.log, label: 'Organisations', status: 'started' },
-		{ onClick: console.log, label: 'Business contacts', status: 'doing' },
-		{ onClick: console.log, label: 'Case studies', status: 'todo' },
-		{ onClick: console.log, label: 'Attachments', status: 'blocked' },
+		{ label: 'Introduction', status: 'done', onClick: console.log },
+		{ label: 'Submit evidence', status: 'saved', onClick: console.log },
+		{ label: 'Organisations', status: 'started', onClick: console.log },
+		{ label: 'Business contacts', status: 'error', onClick: console.log },
+		{ label: 'Case studies', status: 'todo', onClick: console.log },
+		{ label: 'Attachments', status: 'doing', onClick: console.log },
+		{ label: 'Review and submit', status: 'blocked', onClick: console.log },
 	]}
 />
 ```


### PR DESCRIPTION
Added two new statuses for items: `saved` and `error`.

<img width="797" alt="Screenshot 2024-01-12 at 11 17 31 am" src="https://github.com/agriculturegovau/agds-next/assets/6265154/47660af8-a166-4fa0-a124-07c635bfcf9b">

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1548/components/progress-indicator)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
