### PR TITLE
date-picker: Days are standard buttons. Selected and range dates announced

### DIFF
--- a/.changeset/tall-gifts-heal.md
+++ b/.changeset/tall-gifts-heal.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+date-picker: Change day buttons from toggle buttons to normal buttons. Announce selected date upfront.
+
+date-range-picker: Change day buttons from toggle buttons to normal buttons. Announce selected dates upfront and dates within regions.

--- a/packages/react/src/date-picker/Calendar.tsx
+++ b/packages/react/src/date-picker/Calendar.tsx
@@ -193,20 +193,20 @@ const calendarComponents: CustomComponents = {
 	// Default: https://github.com/gpbl/react-day-picker/blob/main/src/components/Row/Row.tsx
 	Row: function Row(props: RowProps) {
 		const { styles, classNames, components } = useDayPicker();
+
+		// Will always have a DayComponent. To satisfy TypeScript only
 		const DayComponent = components?.Day;
+		if (!DayComponent) return null;
 
 		return (
 			<tr className={classNames.row} style={styles.row}>
-				{props.dates.map(
-					(date) =>
-						DayComponent ? (
-							<DayComponent
-								displayMonth={props.displayMonth}
-								date={date}
-								key={getUnixTime(date)}
-							/>
-						) : null // Will always have a DayComponent. To satisfy TypeScript only
-				)}
+				{props.dates.map((date) => (
+					<DayComponent
+						key={getUnixTime(date)}
+						displayMonth={props.displayMonth}
+						date={date}
+					/>
+				))}
 			</tr>
 		);
 	},

--- a/packages/react/src/date-picker/Calendar.tsx
+++ b/packages/react/src/date-picker/Calendar.tsx
@@ -194,20 +194,19 @@ const calendarComponents: CustomComponents = {
 	Row: function Row(props: RowProps) {
 		const { styles, classNames, components } = useDayPicker();
 		const DayComponent = components?.Day;
+
 		return (
 			<tr className={classNames.row} style={styles.row}>
-				{props.dates.map((date) => (
-					<td
-						key={getUnixTime(date)}
-						className={classNames.cell}
-						style={styles.cell}
-						role="gridcell"
-					>
-						{DayComponent ? (
-							<DayComponent displayMonth={props.displayMonth} date={date} />
-						) : null}
-					</td>
-				))}
+				{props.dates.map(
+					(date) =>
+						DayComponent ? (
+							<DayComponent
+								displayMonth={props.displayMonth}
+								date={date}
+								key={getUnixTime(date)}
+							/>
+						) : null // Will always have a DayComponent. To satisfy TypeScript only
+				)}
 			</tr>
 		);
 	},
@@ -215,35 +214,51 @@ const calendarComponents: CustomComponents = {
 	// Default: https://github.com/gpbl/react-day-picker/blob/main/src/components/Day/Day.tsx
 	Day: function Day(props: DayProps) {
 		const buttonRef = useRef<HTMLButtonElement>(null);
-		const dayRender = useDayRender(props.date, props.displayMonth, buttonRef);
-
-		if (dayRender.isHidden) {
-			return <VisuallyHidden>Blank</VisuallyHidden>;
-		}
-
-		if (!dayRender.isButton) {
-			return (
-				<div
-					{...dayRender.divProps}
-					// Remove `role` from `dayRender.divProps`
-					role={undefined}
-				/>
-			);
-		}
+		const { classNames, styles } = useDayPicker();
+		const { activeModifiers, buttonProps, divProps, isButton, isHidden } =
+			useDayRender(props.date, props.displayMonth, buttonRef);
 
 		return (
-			<ReactDayPickerButton
-				name="day"
-				ref={buttonRef}
-				{...dayRender.buttonProps}
-				// Remove `role` from `dayRender.buttonProps`
-				role={undefined}
-				// `aria-selected` is not valid on a button element, use `aria-pressed` instead
-				aria-selected={undefined}
-				aria-pressed={dayRender.buttonProps['aria-selected']}
-				// Improve the aria labels of each button
-				aria-label={formatHumanReadableDate(props.date)}
-			/>
+			<td
+				aria-selected={
+					// React Day Picker incorrectly marks ranges as selected
+					activeModifiers.range_middle ? undefined : activeModifiers.selected
+				}
+				className={classNames.cell}
+				role="gridcell"
+				style={styles.cell}
+			>
+				{isHidden ? (
+					// Announce Blank so SR screen reader virtual cursor appears
+					<VisuallyHidden>Blank</VisuallyHidden>
+				) : !isButton ? (
+					// This case should never happen, but catering for it as per the OOTB RDP
+					<div
+						{...divProps}
+						// Remove `role` from `divProps`
+						role={undefined}
+					/>
+				) : (
+					<ReactDayPickerButton
+						name="day"
+						ref={buttonRef}
+						{...buttonProps}
+						// Improve the aria labels of each button.
+						// Selected and dates within range are manually announced.
+						aria-label={`${
+							activeModifiers.selected && !activeModifiers.range_middle
+								? 'Selected. '
+								: ''
+						}${formatHumanReadableDate(props.date)}${
+							activeModifiers.range_middle ? '. Between selected dates' : ''
+						}`}
+						// Remove `aria-selected` from `buttonProps`. It's on the `<td>`
+						aria-selected={undefined}
+						// Remove `role` from `buttonProps`
+						role={undefined}
+					/>
+				)}
+			</td>
 		);
 	},
 };

--- a/packages/react/src/date-picker/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/Calendar.test.tsx.snap
@@ -440,12 +440,12 @@ exports[`Calendar Range renders correctly 1`] = `
                     </span>
                   </td>
                   <td
+                    aria-selected="true"
                     class="rdp-cell"
                     role="gridcell"
                   >
                     <button
-                      aria-label="1st June 2024 (Saturday)"
-                      aria-pressed="true"
+                      aria-label="Selected. 1st June 2024 (Saturday)"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_start"
                       name="day"
                       tabindex="0"
@@ -463,8 +463,7 @@ exports[`Calendar Range renders correctly 1`] = `
                     role="gridcell"
                   >
                     <button
-                      aria-label="2nd June 2024 (Sunday)"
-                      aria-pressed="true"
+                      aria-label="2nd June 2024 (Sunday). Between selected dates"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                       name="day"
                       tabindex="-1"
@@ -478,8 +477,7 @@ exports[`Calendar Range renders correctly 1`] = `
                     role="gridcell"
                   >
                     <button
-                      aria-label="3rd June 2024 (Monday)"
-                      aria-pressed="true"
+                      aria-label="3rd June 2024 (Monday). Between selected dates"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                       name="day"
                       tabindex="-1"
@@ -493,8 +491,7 @@ exports[`Calendar Range renders correctly 1`] = `
                     role="gridcell"
                   >
                     <button
-                      aria-label="4th June 2024 (Tuesday)"
-                      aria-pressed="true"
+                      aria-label="4th June 2024 (Tuesday). Between selected dates"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                       name="day"
                       tabindex="-1"
@@ -508,8 +505,7 @@ exports[`Calendar Range renders correctly 1`] = `
                     role="gridcell"
                   >
                     <button
-                      aria-label="5th June 2024 (Wednesday)"
-                      aria-pressed="true"
+                      aria-label="5th June 2024 (Wednesday). Between selected dates"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                       name="day"
                       tabindex="-1"
@@ -523,8 +519,7 @@ exports[`Calendar Range renders correctly 1`] = `
                     role="gridcell"
                   >
                     <button
-                      aria-label="6th June 2024 (Thursday)"
-                      aria-pressed="true"
+                      aria-label="6th June 2024 (Thursday). Between selected dates"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                       name="day"
                       tabindex="-1"
@@ -534,12 +529,12 @@ exports[`Calendar Range renders correctly 1`] = `
                     </button>
                   </td>
                   <td
+                    aria-selected="true"
                     class="rdp-cell"
                     role="gridcell"
                   >
                     <button
-                      aria-label="7th June 2024 (Friday)"
-                      aria-pressed="true"
+                      aria-label="Selected. 7th June 2024 (Friday)"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_end"
                       name="day"
                       tabindex="-1"
@@ -1402,12 +1397,12 @@ exports[`Calendar Single renders correctly 1`] = `
                     </span>
                   </td>
                   <td
+                    aria-selected="true"
                     class="rdp-cell"
                     role="gridcell"
                   >
                     <button
-                      aria-label="1st June 2024 (Saturday)"
-                      aria-pressed="true"
+                      aria-label="Selected. 1st June 2024 (Saturday)"
                       class="rdp-button_reset rdp-button rdp-day rdp-day_selected"
                       name="day"
                       tabindex="0"


### PR DESCRIPTION
- Update calendar days to be standard, not toggle buttons
- Manually prefix "Selected" to selected days
- Make days within selected region not selected, but manually announce that they're within the selected range.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-[PR_NUMBER])

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.