### PR TITLE
app-layout: Improve hover styles of account name

### DIFF
--- a/packages/react/src/app-layout/AppLayoutHeaderAccount.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderAccount.tsx
@@ -1,6 +1,6 @@
 import { Avatar } from '../avatar';
 import { Flex } from '../flex';
-import { mq, packs, useLinkComponent } from '../core';
+import { boxPalette, mq, packs, useLinkComponent } from '../core';
 import { Text } from '../text';
 import type { AppLayoutHeaderProps } from './AppLayoutHeader';
 import { AppLayoutHeaderAccountDropdown } from './AppLayoutHeaderAccountDropdown';
@@ -34,6 +34,7 @@ export function AppLayoutHeaderAccount({
 			{...(hasLink && {
 				as: Link,
 				href,
+				link: true,
 				focus: true,
 			})}
 			alignItems="center"
@@ -45,16 +46,15 @@ export function AppLayoutHeaderAccount({
 				maxWidth: ['16rem', '18rem'],
 				...(hasLink && {
 					'&:hover': {
-						'& > span > span': {
-							textDecoration: 'underline',
-						},
+						color: boxPalette.foregroundText,
+						'& > span > span': packs.underline,
 					},
 				}),
 			})}
 		>
 			<Flex as="span" flexDirection="column" css={{ overflow: 'hidden' }}>
 				<Text
-					color="action"
+					color="inherit"
 					fontWeight="bold"
 					fontSize="xs"
 					css={packs.truncate}

--- a/packages/react/src/app-layout/AppLayoutHeaderAccountDropdown.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderAccountDropdown.tsx
@@ -64,6 +64,7 @@ function AppLayoutHeaderAccountDropdownButton({
 				overflow: 'hidden',
 				'&:hover': {
 					backgroundColor: boxPalette.backgroundShade,
+					color: boxPalette.foregroundText,
 					// Underline the name + secondary text
 					'& > span:last-of-type > span:last-of-type': packs.underline,
 				},
@@ -86,7 +87,7 @@ function AppLayoutHeaderAccountDropdownButton({
 					css={{ overflow: 'hidden' }}
 				>
 					<Text
-						color="action"
+						color="inherit"
 						fontWeight="bold"
 						fontSize="xs"
 						css={packs.truncate}

--- a/packages/react/src/app-layout/AppLayoutHeaderNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderNav.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from 'react';
 import { Flex } from '../flex';
-import { boxPalette, tokens } from '../core';
+import { boxPalette, packs, tokens } from '../core';
 import { MenuIcon } from '../icon';
 import { BaseButton } from '../button';
 import { AppLayoutHeaderProps } from './AppLayoutHeader';
@@ -58,8 +58,8 @@ function AppLayoutHeaderNavMenuButton({
 			focus
 			css={{
 				'&:hover': {
+					...packs.underline,
 					backgroundColor: boxPalette.backgroundShade,
-					textDecoration: 'underline',
 				},
 			}}
 		>

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`AppLayout renders correctly 1`] = `
             aria-controls="dropdown-menu-:r0:-panel"
             aria-expanded="false"
             aria-haspopup="true"
-            class="css-v49j9x-BaseButton-boxStyles-AppLayoutHeaderAccountDropdownButton"
+            class="css-1wn298b-BaseButton-boxStyles-AppLayoutHeaderAccountDropdownButton"
             id="dropdown-menu-:r0:-button"
             type="button"
           >
@@ -99,7 +99,7 @@ exports[`AppLayout renders correctly 1`] = `
                 class="css-hv1d8s-boxStyles-AppLayoutHeaderAccountDropdownButton"
               >
                 <span
-                  class="css-tr7opw-boxStyles-Text-AppLayoutHeaderAccountDropdownButton"
+                  class="css-uscra7-boxStyles-Text-AppLayoutHeaderAccountDropdownButton"
                 >
                   Toto Wolff
                 </span>
@@ -137,7 +137,7 @@ exports[`AppLayout renders correctly 1`] = `
         class="css-o9emw-boxStyles-AppLayoutHeaderNav"
       >
         <button
-          class="css-zbjn2b-BaseButton-boxStyles-AppLayoutHeaderNavMenuButton"
+          class="css-1orthae-BaseButton-boxStyles-AppLayoutHeaderNavMenuButton"
           type="button"
         >
           <svg
@@ -170,7 +170,7 @@ exports[`AppLayout renders correctly 1`] = `
           aria-controls="dropdown-menu-:r1:-panel"
           aria-expanded="false"
           aria-haspopup="true"
-          class="css-v49j9x-BaseButton-boxStyles-AppLayoutHeaderAccountDropdownButton"
+          class="css-1wn298b-BaseButton-boxStyles-AppLayoutHeaderAccountDropdownButton"
           id="dropdown-menu-:r1:-button"
           type="button"
         >
@@ -192,7 +192,7 @@ exports[`AppLayout renders correctly 1`] = `
               class="css-hv1d8s-boxStyles-AppLayoutHeaderAccountDropdownButton"
             >
               <span
-                class="css-tr7opw-boxStyles-Text-AppLayoutHeaderAccountDropdownButton"
+                class="css-uscra7-boxStyles-Text-AppLayoutHeaderAccountDropdownButton"
               >
                 Toto Wolff
               </span>


### PR DESCRIPTION
Updated the hover styles of the account name in the App layout header component, so that the account name transitions from the action colour to the text colour on hover.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1554/storybook/index.html?path=/story/layout-applayout--default)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

