### PR TITLE
date-picker/date-range-picker: Add new `dateFormat` prop

### DIFF
--- a/.changeset/nice-bees-sleep.md
+++ b/.changeset/nice-bees-sleep.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+date-picker: Add new prop `dateFormat`, which can be used to adjust the date format displayed in the text input and secondary label.
+
+date-range-picker: Add new prop `dateFormat`, which can be used to adjust the date format displayed in the text input and secondary label.

--- a/packages/react/src/date-picker/DatePicker.stories.tsx
+++ b/packages/react/src/date-picker/DatePicker.stories.tsx
@@ -73,6 +73,12 @@ export const Block: Story = {
 	},
 };
 
+export const AlternativeDateFormat: Story = {
+	args: {
+		dateFormat: 'd MMM yyyy',
+	},
+};
+
 export const ScrollExample: Story = {
 	render: (props) => (
 		<Box>

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -45,8 +45,8 @@ function renderDatePicker(props: ControlledDatePickerProps) {
 }
 
 function ControlledDatePicker({
-	onChange: onChangeProp,
 	initialValue: initialValueProp,
+	onChange: onChangeProp,
 	...props
 }: ControlledDatePickerProps) {
 	const [value, setValue] = useState<Date | string | undefined>(

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -24,6 +24,17 @@ jest.mock('use-debounce', () => ({
 	}),
 }));
 
+// Mock the current date so snapshot outputs are always consistent
+const mockSystemTime = new Date(2015, 7, 5);
+beforeAll(() => {
+	jest.useFakeTimers({ advanceTimers: true });
+	jest.setSystemTime(mockSystemTime);
+});
+
+afterAll(() => {
+	jest.useRealTimers();
+});
+
 function renderDatePicker(props: DatePickerProps) {
 	return render(<DatePicker {...props} />);
 }
@@ -116,18 +127,12 @@ async function getSubmitButton() {
 
 describe('DatePicker', () => {
 	it('renders correctly', () => {
-		// Mock the current date so snapshot outputs are always consistent
-		jest.useFakeTimers().setSystemTime(new Date(2020, 5, 20));
-
 		const { container } = renderDatePicker({
 			label: 'Example',
 			value: new Date(2000, 0, 1),
 			onChange: console.log,
 		});
 		expect(container).toMatchSnapshot();
-
-		// Reset mock timers
-		jest.useRealTimers();
 	});
 
 	it('renders valid HTML with no a11y violations', async () => {

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -36,7 +36,7 @@ afterAll(() => {
 });
 
 type ControlledDatePickerProps = Omit<DatePickerProps, 'value' | 'onChange'> & {
-	initialValue?: DatePickerProps['value']; // value is not allowed as it is controlled, but a `initialValue` can be passed in
+	initialValue?: DatePickerProps['value']; // value is not allowed as it is controlled, but an `initialValue` can be passed in
 	onChange?: DatePickerProps['onChange']; // onChange is optional
 };
 

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -252,13 +252,13 @@ describe('DatePicker', () => {
 		);
 	});
 
-	it('formats valid dates to the default date format (`dd/mm/yyyy`)', async () => {
+	it('formats valid dates to the default date format (dd/MM/yyyy)', async () => {
 		renderDatePicker({ label: 'Example' });
 
 		// Type a valid date in the input field that isn't in the display format
 		await userEvent.type(await getInput(), 'June 5th 2023');
 
-		// The input should be formatted to dd/mm/yyyy
+		// The input should be formatted to dd/MM/yyyy
 		expect(await getInput()).toHaveValue('05/06/2023');
 	});
 

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -116,12 +116,18 @@ async function getSubmitButton() {
 
 describe('DatePicker', () => {
 	it('renders correctly', () => {
+		// Mock the current date so snapshot outputs are always consistent
+		jest.useFakeTimers().setSystemTime(new Date(2020, 5, 20));
+
 		const { container } = renderDatePicker({
 			label: 'Example',
 			value: new Date(2000, 0, 1),
 			onChange: console.log,
 		});
 		expect(container).toMatchSnapshot();
+
+		// Reset mock timers
+		jest.useRealTimers();
 	});
 
 	it('renders valid HTML with no a11y violations', async () => {

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -22,6 +22,7 @@ import {
 	transformValuePropToInputValue,
 	getCalendarDefaultMonth,
 	getDateInputButtonAriaLabel,
+	AcceptedDateFormat,
 } from './utils';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -75,6 +76,8 @@ type DatePickerBaseProps = {
 	onInputChange?: (inputValue: string) => void;
 	/** Ref to the input element. */
 	inputRef?: Ref<HTMLInputElement>;
+	/** The date format for dates. */
+	dateFormat?: AcceptedDateFormat;
 };
 
 export type DatePickerProps = DatePickerInputProps &
@@ -92,6 +95,7 @@ export const DatePicker = ({
 	inputRef,
 	invalid = false,
 	maxWidth = 'md',
+	dateFormat = 'dd/MM/yyyy',
 	...props
 }: DatePickerProps) => {
 	const triggerRef = useRef<HTMLButtonElement>(null);
@@ -106,17 +110,17 @@ export const DatePicker = ({
 			// If the day is disabled, do nothing
 			if (modifiers.disabled) return;
 			// Update the input field with the selected day
-			setInputValue(formatDate(selectedDay));
+			setInputValue(formatDate(selectedDay, dateFormat));
 			// Trigger the callback
 			onChange(selectedDay);
 			// Close the calendar and focus the calendar icon
 			closeCalendar();
 		},
-		[onChange, closeCalendar]
+		[onChange, closeCalendar, dateFormat]
 	);
 
 	const [inputValue, setInputValue] = useState(
-		transformValuePropToInputValue(value)
+		transformValuePropToInputValue(value, dateFormat)
 	);
 
 	const debouncedAttemptDateParse = useDebouncedCallback(
@@ -149,8 +153,8 @@ export const DatePicker = ({
 
 	// Update the text input when the value updates
 	useEffect(() => {
-		setInputValue(transformValuePropToInputValue(value));
-	}, [value]);
+		setInputValue(transformValuePropToInputValue(value, dateFormat));
+	}, [value, dateFormat]);
 
 	// Close the calendar when the user clicks outside
 	const handleClickOutside = useCallback(() => {
@@ -193,6 +197,7 @@ export const DatePicker = ({
 		<div {...popover.getReferenceProps()}>
 			<DateInput
 				{...props}
+				dateFormat={dateFormat}
 				maxWidth={maxWidth}
 				invalid={{ field: invalid, input: invalid }}
 				ref={inputRef}

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -22,7 +22,7 @@ import {
 	transformValuePropToInputValue,
 	getCalendarDefaultMonth,
 	getDateInputButtonAriaLabel,
-	AcceptedDateFormat,
+	AcceptedDateFormats,
 } from './utils';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -76,8 +76,8 @@ type DatePickerBaseProps = {
 	onInputChange?: (inputValue: string) => void;
 	/** Ref to the input element. */
 	inputRef?: Ref<HTMLInputElement>;
-	/** The date format for dates. */
-	dateFormat?: AcceptedDateFormat;
+	/** Used to adjust the date format displayed in the text input and secondary label. */
+	dateFormat?: AcceptedDateFormats;
 };
 
 export type DatePickerProps = DatePickerInputProps &

--- a/packages/react/src/date-picker/DatePickerInput.tsx
+++ b/packages/react/src/date-picker/DatePickerInput.tsx
@@ -1,10 +1,12 @@
-import { forwardRef, MouseEventHandler, RefObject } from 'react';
+import { forwardRef, MouseEventHandler, RefObject, useMemo } from 'react';
+import { format } from 'date-fns';
 import { Flex } from '../flex';
 import { CalendarIcon } from '../icon';
 import { TextInputProps, textInputStyles } from '../text-input';
 import { mapSpacing } from '../core';
 import { Button } from '../button';
 import { Field } from '../field';
+import { acceptedDateFormats, AcceptedDateFormat } from './utils';
 
 export type DateInputProps = Omit<TextInputProps, 'invalid'> & {
 	invalid: {
@@ -13,6 +15,7 @@ export type DateInputProps = Omit<TextInputProps, 'invalid'> & {
 		/** If true, only the input element will be rendered in an invalids state. */
 		input: boolean;
 	};
+	dateFormat: AcceptedDateFormat;
 	buttonRef: RefObject<HTMLButtonElement>;
 	buttonOnClick: MouseEventHandler<HTMLButtonElement>;
 	buttonAriaLabel: string;
@@ -35,6 +38,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 			buttonAriaLabel,
 			disabled,
 			value,
+			dateFormat: dateFormatProp,
 			...props
 		},
 		ref
@@ -51,10 +55,20 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 			borderBottomRightRadius: 0,
 		};
 
+		// The secondary label should show todays date in the supplied date format
+		// Fallback to our default date format of `dd/MM/yyyy` if the provided format is not supported
+		// Typescript will complain about incorrect usage, but not everyone relies on typescript
+		const secondaryLabel = useMemo(() => {
+			const dateFormat = acceptedDateFormats.includes(dateFormatProp)
+				? dateFormatProp
+				: 'dd/MM/yyyy';
+			return '(e.g. ' + format(new Date(), dateFormat) + ')';
+		}, [dateFormatProp]);
+
 		return (
 			<Field
 				label={label}
-				secondaryLabel="(dd/mm/yyyy)"
+				secondaryLabel={secondaryLabel}
 				hideOptionalLabel={hideOptionalLabel}
 				required={Boolean(required)}
 				hint={hint}

--- a/packages/react/src/date-picker/DatePickerInput.tsx
+++ b/packages/react/src/date-picker/DatePickerInput.tsx
@@ -6,7 +6,7 @@ import { TextInputProps, textInputStyles } from '../text-input';
 import { mapSpacing } from '../core';
 import { Button } from '../button';
 import { Field } from '../field';
-import { acceptedDateFormats, AcceptedDateFormat } from './utils';
+import { acceptedDateFormats, AcceptedDateFormats } from './utils';
 
 export type DateInputProps = Omit<TextInputProps, 'invalid'> & {
 	invalid: {
@@ -15,7 +15,7 @@ export type DateInputProps = Omit<TextInputProps, 'invalid'> & {
 		/** If true, only the input element will be rendered in an invalids state. */
 		input: boolean;
 	};
-	dateFormat: AcceptedDateFormat;
+	dateFormat: AcceptedDateFormats;
 	buttonRef: RefObject<HTMLButtonElement>;
 	buttonOnClick: MouseEventHandler<HTMLButtonElement>;
 	buttonAriaLabel: string;

--- a/packages/react/src/date-picker/DatePickerInput.tsx
+++ b/packages/react/src/date-picker/DatePickerInput.tsx
@@ -55,9 +55,9 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 			borderBottomRightRadius: 0,
 		};
 
-		// The secondary label should show today's date in the supplied date format
-		// Fallback to our default date format of `dd/MM/yyyy` if the provided format is not supported
-		// Typescript will complain about incorrect usage, but not everyone relies on typescript
+		// The secondary label should show todays date in the supplied date format (via the `dateFormat` prop)
+		// If the supplied date format is not an accepted format, fallback to the default date format of `dd/MM/yyyy`
+		// Note: Typescript will complain about incorrect values passed into the `dateFormat` prop, but not everyone relies on Typescript
 		const secondaryLabel = useMemo(() => {
 			const dateFormat = acceptedDateFormats.includes(dateFormatProp)
 				? dateFormatProp

--- a/packages/react/src/date-picker/DatePickerInput.tsx
+++ b/packages/react/src/date-picker/DatePickerInput.tsx
@@ -55,7 +55,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 			borderBottomRightRadius: 0,
 		};
 
-		// The secondary label should show todays date in the supplied date format
+		// The secondary label should show today's date in the supplied date format
 		// Fallback to our default date format of `dd/MM/yyyy` if the provided format is not supported
 		// Typescript will complain about incorrect usage, but not everyone relies on typescript
 		const secondaryLabel = useMemo(() => {

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DatePicker renders correctly 1`] = `
           class="css-1rpt3h8-boxStyles-Text"
         >
            
-          (dd/mm/yyyy) (optional)
+          (e.g. 20/06/2020) (optional)
         </span>
       </label>
       <div

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DatePicker renders correctly 1`] = `
           class="css-1rpt3h8-boxStyles-Text"
         >
            
-          (e.g. 20/06/2020) (optional)
+          (e.g. 05/08/2015) (optional)
         </span>
       </label>
       <div

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -235,7 +235,7 @@ While the Date picker component prefers the `dd/mm/yyyy` date format, any of the
 			label="Select date"
 			value={value}
 			onChange={setValue}
-			dateFormat="do MMMM yyyy"
+			dateFormat="d MMM yyyy"
 		/>
 	);
 };

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -82,6 +82,47 @@ To fix this issue, you can use the `onInputChange` prop to keep track of the use
 };
 ```
 
+## Changing the date format
+
+The Date picker component allows users to enter dates in various formats. To select the 18th February 2023, a user could input '18/02/2023', '18 Feb 2023', '18th February 2023', or any other supported date format.
+
+When a valid date is typed, the date will be formatted using the `dateFormat` prop, which is set to `dd/MM/yyyy` by default.
+
+To modify the date format, you can change the `dateFormat` prop to one of the supported date formats:
+
+- `dd/MM/yyyy` (e.g. 18/02/2023)
+- `dd-MM-yyyy` (e.g. 18-02-2023)
+- `dd MM yyyy` (e.g. 18 02 2023)
+- `MM/dd/yyyy` (e.g. 02/18/2023)
+- `MM-dd-yyyy` (e.g. 02-18-2023)
+- `MM dd yyyy` (e.g. 02 18 2023)
+- `do MMMM yyyy` (e.g. 8th February 2023)
+- `do MMM yyyy` (e.g. 8th Feb 2023)
+- `MMMM do yyyy` (e.g. February 8th 2023)
+- `MMM do yyyy` (e.g. Feb 8th 2023)
+- `d MMMM yyyy` (e.g. 8 February 2023)
+- `d MMM yyyy` (e.g. 8 Feb 2023)
+- `MMMM d yyyy` (e.g. February 8 2023)
+- `MMM d yyyy` (e.g. Feb 8 2023)
+- `dd MMMM yyyy` (e.g. 08 February 2023)
+- `dd MMM yyyy` (e.g. 08 Feb 2023)
+- `MMMM dd yyyy` (e.g. February 08 2023)
+- `MMM dd yyyy` (e.g. Feb 08 2023)
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker
+			label="Select date"
+			value={value}
+			onChange={setValue}
+			dateFormat="d MMM yyyy"
+		/>
+	);
+};
+```
+
 ## Hint
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
@@ -197,45 +238,6 @@ The `yearRange` prop can be used to change the range of options to display in ca
 			yearRange={yearRange}
 			value={value}
 			onChange={setValue}
-		/>
-	);
-};
-```
-
-## Alternative date formats
-
-Use the `dateFormat` prop to change the format of the date displayed in the text input and secondary label.
-
-While the Date picker component prefers the `dd/mm/yyyy` date format, any of the current dates are accepted:
-
-- `dd/MM/yyyy` (e.g. 18/02/2023)
-- `dd-MM-yyyy` (e.g. 18-02-2023)
-- `dd MM yyyy` (e.g. 18 02 2023)
-- `MM/dd/yyyy` (e.g. 02/18/2023)
-- `MM-dd-yyyy` (e.g. 02-18-2023)
-- `MM dd yyyy` (e.g. 02 18 2023)
-- `do MMMM yyyy` (e.g. 8th February 2023)
-- `do MMM yyyy` (e.g. 8th Feb 2023)
-- `MMMM do yyyy` (e.g. February 8th 2023)
-- `MMM do yyyy` (e.g. Feb 8th 2023)
-- `d MMMM yyyy` (e.g. 8 February 2023)
-- `d MMM yyyy` (e.g. 8 Feb 2023)
-- `MMMM d yyyy` (e.g. February 8 2023)
-- `MMM d yyyy` (e.g. Feb 8 2023)
-- `dd MMMM yyyy` (e.g. 08 February 2023)
-- `dd MMM yyyy` (e.g. 08 Feb 2023)
-- `MMMM dd yyyy` (e.g. February 08 2023)
-- `MMM dd yyyy` (e.g. Feb 08 2023)
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker
-			label="Select date"
-			value={value}
-			onChange={setValue}
-			dateFormat="d MMM yyyy"
 		/>
 	);
 };

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -21,7 +21,7 @@ For an example of using this component in a form built with [react-hook-form](ht
 <DoHeading />
 
 - always display the date format above the text input
-- use Australian date format 'dd/mm/yyyy'
+- prefer Australian date format 'dd/mm/yyyy'
 - allow users to navigate dates via the calendar
 - ensure users can enter dates via the calendar or text input
 - Make sure error messages are specific about what input is required.

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -201,3 +201,42 @@ The `yearRange` prop can be used to change the range of options to display in ca
 	);
 };
 ```
+
+## Alternative date formats
+
+Use the `dateFormat` prop to change the format of the date displayed in the text input and secondary label.
+
+While the Date picker component prefers the `dd/mm/yyyy` date format, any of the current dates are accepted:
+
+- `dd/MM/yyyy` (e.g. 18/02/2023)
+- `dd-MM-yyyy` (e.g. 18-02-2023)
+- `dd MM yyyy` (e.g. 18 02 2023)
+- `MM/dd/yyyy` (e.g. 02/18/2023)
+- `MM-dd-yyyy` (e.g. 02-18-2023)
+- `MM dd yyyy` (e.g. 02 18 2023)
+- `do MMMM yyyy` (e.g. 8th February 2023)
+- `do MMM yyyy` (e.g. 8th Feb 2023)
+- `MMMM do yyyy` (e.g. February 8th 2023)
+- `MMM do yyyy` (e.g. Feb 8th 2023)
+- `d MMMM yyyy` (e.g. 8 February 2023)
+- `d MMM yyyy` (e.g. 8 Feb 2023)
+- `MMMM d yyyy` (e.g. February 8 2023)
+- `MMM d yyyy` (e.g. Feb 8 2023)
+- `dd MMMM yyyy` (e.g. 08 February 2023)
+- `dd MMM yyyy` (e.g. 08 Feb 2023)
+- `MMMM dd yyyy` (e.g. February 08 2023)
+- `MMM dd yyyy` (e.g. Feb 08 2023)
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker
+			label="Select date"
+			value={value}
+			onChange={setValue}
+			dateFormat="do MMMM yyyy"
+		/>
+	);
+};
+```

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -82,47 +82,6 @@ To fix this issue, you can use the `onInputChange` prop to keep track of the use
 };
 ```
 
-## Changing the date format
-
-The Date picker component allows users to enter dates in various formats. To select the 18th February 2023, a user could input '18/02/2023', '18 Feb 2023', '18th February 2023', or any other supported date format.
-
-When a valid date is typed, the date will be formatted using the `dateFormat` prop, which is set to `dd/MM/yyyy` by default.
-
-To modify the date format, you can change the `dateFormat` prop to one of the supported date formats:
-
-- `dd/MM/yyyy` (e.g. 18/02/2023)
-- `dd-MM-yyyy` (e.g. 18-02-2023)
-- `dd MM yyyy` (e.g. 18 02 2023)
-- `MM/dd/yyyy` (e.g. 02/18/2023)
-- `MM-dd-yyyy` (e.g. 02-18-2023)
-- `MM dd yyyy` (e.g. 02 18 2023)
-- `do MMMM yyyy` (e.g. 8th February 2023)
-- `do MMM yyyy` (e.g. 8th Feb 2023)
-- `MMMM do yyyy` (e.g. February 8th 2023)
-- `MMM do yyyy` (e.g. Feb 8th 2023)
-- `d MMMM yyyy` (e.g. 8 February 2023)
-- `d MMM yyyy` (e.g. 8 Feb 2023)
-- `MMMM d yyyy` (e.g. February 8 2023)
-- `MMM d yyyy` (e.g. Feb 8 2023)
-- `dd MMMM yyyy` (e.g. 08 February 2023)
-- `dd MMM yyyy` (e.g. 08 Feb 2023)
-- `MMMM dd yyyy` (e.g. February 08 2023)
-- `MMM dd yyyy` (e.g. Feb 08 2023)
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker
-			label="Select date"
-			value={value}
-			onChange={setValue}
-			dateFormat="d MMM yyyy"
-		/>
-	);
-};
-```
-
 ## Hint
 
 Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
@@ -238,6 +197,47 @@ The `yearRange` prop can be used to change the range of options to display in ca
 			yearRange={yearRange}
 			value={value}
 			onChange={setValue}
+		/>
+	);
+};
+```
+
+## Changing the date format
+
+The Date picker component allows users to enter dates in various formats. To select the 18th February 2023, a user could input '18/02/2023', '18 Feb 2023', '18th February 2023', or any other supported date format.
+
+When a valid date is typed, the date will be formatted using the `dateFormat` prop, which is set to `dd/MM/yyyy` by default.
+
+To modify the date format, you can change the `dateFormat` prop to one of the supported date formats:
+
+- `dd/MM/yyyy` (e.g. 18/02/2023)
+- `dd-MM-yyyy` (e.g. 18-02-2023)
+- `dd MM yyyy` (e.g. 18 02 2023)
+- `MM/dd/yyyy` (e.g. 02/18/2023)
+- `MM-dd-yyyy` (e.g. 02-18-2023)
+- `MM dd yyyy` (e.g. 02 18 2023)
+- `do MMMM yyyy` (e.g. 8th February 2023)
+- `do MMM yyyy` (e.g. 8th Feb 2023)
+- `MMMM do yyyy` (e.g. February 8th 2023)
+- `MMM do yyyy` (e.g. Feb 8th 2023)
+- `d MMMM yyyy` (e.g. 8 February 2023)
+- `d MMM yyyy` (e.g. 8 Feb 2023)
+- `MMMM d yyyy` (e.g. February 8 2023)
+- `MMM d yyyy` (e.g. Feb 8 2023)
+- `dd MMMM yyyy` (e.g. 08 February 2023)
+- `dd MMM yyyy` (e.g. 08 Feb 2023)
+- `MMMM dd yyyy` (e.g. February 08 2023)
+- `MMM dd yyyy` (e.g. Feb 08 2023)
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker
+			label="Select date"
+			value={value}
+			onChange={setValue}
+			dateFormat="d MMM yyyy"
 		/>
 	);
 };

--- a/packages/react/src/date-picker/utils.test.ts
+++ b/packages/react/src/date-picker/utils.test.ts
@@ -110,8 +110,8 @@ describe('constrainDate', () => {
 });
 
 describe('formatDate', () => {
-	expect(formatDate(new Date(2020, 0, 31))).toEqual('31/01/2020');
-	expect(formatDate(new Date(2020, 11, 6))).toEqual('06/12/2020');
+	expect(formatDate(new Date(2020, 0, 31), 'dd/MM/yyyy')).toEqual('31/01/2020');
+	expect(formatDate(new Date(2020, 11, 6), 'dd/MM/yyyy')).toEqual('06/12/2020');
 });
 
 describe('formatHumanReadableDate', () => {
@@ -125,19 +125,21 @@ describe('formatHumanReadableDate', () => {
 
 describe('transformValuePropToInputValue', () => {
 	test('works with undefined', () => {
-		expect(transformValuePropToInputValue(undefined)).toEqual('');
+		expect(transformValuePropToInputValue(undefined, 'dd/MM/yyyy')).toEqual('');
 	});
 
 	test('works with strings', () => {
-		expect(transformValuePropToInputValue('')).toEqual('');
-		expect(transformValuePropToInputValue('abc')).toEqual('abc');
-		expect(transformValuePropToInputValue('aa/bb/cccc')).toEqual('aa/bb/cccc');
+		expect(transformValuePropToInputValue('', 'dd/MM/yyyy')).toEqual('');
+		expect(transformValuePropToInputValue('abc', 'dd/MM/yyyy')).toEqual('abc');
+		expect(transformValuePropToInputValue('aa/bb/cccc', 'dd/MM/yyyy')).toEqual(
+			'aa/bb/cccc'
+		);
 	});
 
 	test('works with dates', () => {
 		const exampleDate = new Date(1999, 11, 10);
-		expect(transformValuePropToInputValue(exampleDate)).toEqual(
-			formatDate(exampleDate)
+		expect(transformValuePropToInputValue(exampleDate, 'dd/MM/yyyy')).toEqual(
+			formatDate(exampleDate, 'dd/MM/yyyy')
 		);
 	});
 });

--- a/packages/react/src/date-picker/utils.ts
+++ b/packages/react/src/date-picker/utils.ts
@@ -9,11 +9,8 @@ import {
 	isMatch,
 } from 'date-fns';
 
-// Date format is not configurable
-const displayDateFormat = 'dd/MM/yyyy';
-
-const acceptedDateFormats = [
-	displayDateFormat, // 18/02/2023
+export const acceptedDateFormats = [
+	'dd/MM/yyyy', // 18/02/2023
 	'dd-MM-yyyy', // 18-02-2023
 	'dd MM yyyy', // 18 02 2023
 	'MM/dd/yyyy', // 02/18/2023
@@ -31,9 +28,12 @@ const acceptedDateFormats = [
 	'dd MMM yyyy', // 08 Feb 2023
 	'MMMM dd yyyy', // February 08 2023
 	'MMM dd yyyy', // Feb 08 2023
-];
+] as const;
 
-export const formatDate = (date: Date) => format(date, displayDateFormat);
+export type AcceptedDateFormat = (typeof acceptedDateFormats)[number];
+
+export const formatDate = (date: Date, dateformat: AcceptedDateFormat) =>
+	format(date, dateformat);
 
 export const formatHumanReadableDate = (date: Date) =>
 	format(date, 'do MMMM yyyy (EEEE)');
@@ -84,11 +84,12 @@ export function constrainDate(
 // For example, if a `Date` object is passed we need to convert to to formatted date string (dd/mm/yyyy)
 // If `undefined` if passed, we need to convert to an empty string
 export function transformValuePropToInputValue(
-	valueProp: Date | string | undefined
+	valueProp: Date | string | undefined,
+	dateFormat: AcceptedDateFormat
 ): string {
 	if (typeof valueProp === 'string') return valueProp;
 	if (typeof valueProp === 'undefined') return '';
-	if (isValidDate(valueProp)) return formatDate(valueProp);
+	if (isValidDate(valueProp)) return formatDate(valueProp, dateFormat);
 	return '';
 }
 

--- a/packages/react/src/date-picker/utils.ts
+++ b/packages/react/src/date-picker/utils.ts
@@ -10,29 +10,29 @@ import {
 } from 'date-fns';
 
 export const acceptedDateFormats = [
-	'dd/MM/yyyy', // 18/02/2023
-	'dd-MM-yyyy', // 18-02-2023
-	'dd MM yyyy', // 18 02 2023
-	'MM/dd/yyyy', // 02/18/2023
-	'MM-dd-yyyy', // 02-18-2023
-	'MM dd yyyy', // 02 18 2023
-	'do MMMM yyyy', // 8th February 2023
-	'do MMM yyyy', // 8th Feb 2023
-	'MMMM do yyyy', // February 8th 2023
-	'MMM do yyyy', // Feb 8th 2023
-	'd MMMM yyyy', // 8 February 2023
-	'd MMM yyyy', // 8 Feb 2023
-	'MMMM d yyyy', // February 8 2023
-	'MMM d yyyy', // Feb 8 2023
-	'dd MMMM yyyy', // 08 February 2023
-	'dd MMM yyyy', // 08 Feb 2023
-	'MMMM dd yyyy', // February 08 2023
-	'MMM dd yyyy', // Feb 08 2023
+	'dd/MM/yyyy', // e.g. 18/02/2023
+	'dd-MM-yyyy', // e.g. 18-02-2023
+	'dd MM yyyy', // e.g. 18 02 2023
+	'MM/dd/yyyy', // e.g. 02/18/2023
+	'MM-dd-yyyy', // e.g. 02-18-2023
+	'MM dd yyyy', // e.g. 02 18 2023
+	'do MMMM yyyy', // e.g. 8th February 2023
+	'do MMM yyyy', // e.g. 8th Feb 2023
+	'MMMM do yyyy', // e.g. February 8th 2023
+	'MMM do yyyy', // e.g. Feb 8th 2023
+	'd MMMM yyyy', // e.g. 8 February 2023
+	'd MMM yyyy', // e.g. 8 Feb 2023
+	'MMMM d yyyy', // e.g. February 8 2023
+	'MMM d yyyy', // e.g. Feb 8 2023
+	'dd MMMM yyyy', // e.g. 08 February 2023
+	'dd MMM yyyy', // e.g. 08 Feb 2023
+	'MMMM dd yyyy', // e.g. February 08 2023
+	'MMM dd yyyy', // e.g. Feb 08 2023
 ] as const;
 
-export type AcceptedDateFormat = (typeof acceptedDateFormats)[number];
+export type AcceptedDateFormats = (typeof acceptedDateFormats)[number];
 
-export const formatDate = (date: Date, dateformat: AcceptedDateFormat) =>
+export const formatDate = (date: Date, dateformat: AcceptedDateFormats) =>
 	format(date, dateformat);
 
 export const formatHumanReadableDate = (date: Date) =>
@@ -85,7 +85,7 @@ export function constrainDate(
 // If `undefined` if passed, we need to convert to an empty string
 export function transformValuePropToInputValue(
 	valueProp: Date | string | undefined,
-	dateFormat: AcceptedDateFormat
+	dateFormat: AcceptedDateFormats
 ): string {
 	if (typeof valueProp === 'string') return valueProp;
 	if (typeof valueProp === 'undefined') return '';

--- a/packages/react/src/date-range-picker/DateRangePicker.stories.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.stories.tsx
@@ -122,6 +122,12 @@ export const Labels: Story = {
 	},
 };
 
+export const AlternativeDateFormat: Story = {
+	args: {
+		dateFormat: 'd MMM yyyy',
+	},
+};
+
 export const ScrollExample: Story = {
 	render: (props) => (
 		<Box>

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -361,8 +361,7 @@ describe('DateRangePicker', () => {
 		const defaultLegend = 'Date range';
 
 		renderDateRangePicker({
-			value: { from: new Date(2000, 1, 1), to: new Date(2000, 1, 2) },
-			onChange: console.log,
+			initialValue: { from: new Date(2000, 1, 1), to: new Date(2000, 1, 2) },
 			required: false,
 		});
 		expect(await await (await getLegend(defaultLegend)).textContent).toEqual(
@@ -374,8 +373,7 @@ describe('DateRangePicker', () => {
 		const defaultLegend = 'Date range';
 
 		renderDateRangePicker({
-			value: { from: new Date(2000, 1, 1), to: new Date(2000, 1, 2) },
-			onChange: console.log,
+			initialValue: { from: new Date(2000, 1, 1), to: new Date(2000, 1, 2) },
 			required: true,
 		});
 		expect(await (await getLegend(defaultLegend)).textContent).toEqual(
@@ -388,8 +386,7 @@ describe('DateRangePicker', () => {
 
 		renderDateRangePicker({
 			legend,
-			value: { from: new Date(2000, 1, 1), to: new Date(2000, 1, 2) },
-			onChange: console.log,
+			initialValue: { from: new Date(2000, 1, 1), to: new Date(2000, 1, 2) },
 		});
 		expect(await (await getLegend(legend)).textContent).toEqual(
 			`${legend} (optional)`
@@ -471,7 +468,6 @@ describe('DateRangePicker', () => {
 	it('invalid: can render an invalid state when only to is invalid', async () => {
 		renderDateRangePicker({
 			initialValue: { from: new Date(2000, 1, 1), to: new Date(2000, 1, 2) },
-			onChange: console.log,
 			fromInvalid: false,
 			toInvalid: true,
 			message: errorMessage,

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import userEvent from '@testing-library/user-event';
 import { useForm, Controller } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { format } from 'date-fns';
 import * as yup from 'yup';
 import { cleanup, render, screen, act } from '../../../../test-utils';
 import { Stack } from '../stack';
@@ -27,6 +28,17 @@ jest.mock('use-debounce', () => ({
 		return callback;
 	}),
 }));
+
+// Mock the current date so snapshot outputs are always consistent
+const mockSystemTime = new Date(2015, 7, 5);
+beforeAll(() => {
+	jest.useFakeTimers({ advanceTimers: true });
+	jest.setSystemTime(mockSystemTime);
+});
+
+afterAll(() => {
+	jest.useRealTimers();
+});
 
 function renderDateRangePicker(props: DateRangePickerProps) {
 	return render(<DateRangePicker {...props} />);
@@ -355,8 +367,12 @@ describe('DateRangePicker', () => {
 		const inputToId = await (await getToInput())?.id;
 		const labelTo = container.querySelector(`[for="${inputToId}"]`);
 
-		expect(labelFrom?.textContent).toEqual('Start date (dd/mm/yyyy)');
-		expect(labelTo?.textContent).toEqual('End date (dd/mm/yyyy)');
+		expect(labelFrom?.textContent).toEqual(
+			`Start date (e.g. ${format(mockSystemTime, 'dd/MM/yyyy')})`
+		);
+		expect(labelTo?.textContent).toEqual(
+			`End date (e.g. ${format(mockSystemTime, 'dd/MM/yyyy')})`
+		);
 	});
 
 	it('shows date format when no legend is supplied', async () => {
@@ -371,9 +387,11 @@ describe('DateRangePicker', () => {
 		const labelTo = container.querySelector(`[for="${inputToId}"]`);
 
 		expect(labelFrom?.textContent).toEqual(
-			'Start date (dd/mm/yyyy) (optional)'
+			`Start date (e.g. ${format(mockSystemTime, 'dd/MM/yyyy')}) (optional)`
 		);
-		expect(labelTo?.textContent).toEqual('End date (dd/mm/yyyy) (optional)');
+		expect(labelTo?.textContent).toEqual(
+			`End date (e.g. ${format(mockSystemTime, 'dd/MM/yyyy')}) (optional)`
+		);
 	});
 
 	it('invalid: can render an invalid state when both fields are invalid', async () => {

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -333,11 +333,8 @@ describe('DateRangePicker', () => {
 		);
 	});
 
-	it('formats valid dates to the default date format (dd/mm/yyyy)', async () => {
+	it('formats valid dates to the default date format (dd/MM/yyyy)', async () => {
 		renderDateRangePicker({});
-
-		const inputFromId = await (await getFromInput())?.id;
-		const labelFrom = container.querySelector(`[for="${inputFromId}"]`);
 
 		// Type valid dates in the input fields that are not in the display format
 		await userEvent.type(await getFromInput(), '5 June 2023');

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -27,6 +27,7 @@ import {
 	formatDate,
 	constrainDate,
 	transformValuePropToInputValue,
+	AcceptedDateFormat,
 } from '../date-picker/utils';
 import { CalendarRange } from '../date-picker/Calendar';
 import { CalendarProvider } from '../date-picker/CalendarContext';
@@ -92,6 +93,8 @@ export type DateRangePickerProps = DateRangePickerCalendarProps & {
 	toInputRef?: Ref<HTMLInputElement>;
 	/** The range of options to display in calendar year select. */
 	yearRange?: { from: number; to: number };
+	/** The date format for dates. */
+	dateFormat?: AcceptedDateFormat;
 };
 
 export const DateRangePicker = ({
@@ -115,6 +118,7 @@ export const DateRangePicker = ({
 	fromInputRef,
 	toInputRef,
 	yearRange,
+	dateFormat = 'dd/MM/yyyy',
 }: DateRangePickerProps) => {
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
 	const toggleCalendar = isCalendarOpen ? closeCalendar : openCalendar;
@@ -155,8 +159,8 @@ export const DateRangePicker = ({
 			);
 
 			onChange(range);
-			setFromInputValue(range.from ? formatDate(range.from) : '');
-			setToInputValue(range.to ? formatDate(range.to) : '');
+			setFromInputValue(range.from ? formatDate(range.from, dateFormat) : '');
+			setToInputValue(range.to ? formatDate(range.to, dateFormat) : '');
 
 			if (range.from && range.to) {
 				closeCalendar();
@@ -174,12 +178,12 @@ export const DateRangePicker = ({
 				return;
 			}
 		},
-		[closeCalendar, inputMode, onChange, valueAsDateOrUndefined]
+		[closeCalendar, inputMode, onChange, valueAsDateOrUndefined, dateFormat]
 	);
 
 	// From input state
 	const [fromInputValue, setFromInputValue] = useState(
-		transformValuePropToInputValue(value.from)
+		transformValuePropToInputValue(value.from, dateFormat)
 	);
 
 	const debouncedAttemptDateParseFromDate = useDebouncedCallback(
@@ -220,7 +224,7 @@ export const DateRangePicker = ({
 
 	// To input state
 	const [toInputValue, setToInputValue] = useState(
-		transformValuePropToInputValue(value.to)
+		transformValuePropToInputValue(value.to, dateFormat)
 	);
 
 	const debouncedAttemptDateParseToDate = useDebouncedCallback(
@@ -261,9 +265,9 @@ export const DateRangePicker = ({
 
 	// Update the text inputs when the value updates
 	useEffect(() => {
-		setFromInputValue(transformValuePropToInputValue(value.from));
-		setToInputValue(transformValuePropToInputValue(value.to));
-	}, [value]);
+		setFromInputValue(transformValuePropToInputValue(value.from, dateFormat));
+		setToInputValue(transformValuePropToInputValue(value.to, dateFormat));
+	}, [value, dateFormat]);
 
 	// Close the calendar when the user clicks outside
 	const handleClickOutside = useCallback(() => {
@@ -357,10 +361,11 @@ export const DateRangePicker = ({
 							onChange={onFromInputChange}
 							buttonRef={fromTriggerRef}
 							buttonOnClick={onFromTriggerClick}
+							buttonAriaLabel={getFromDateInputButtonAriaLabel(fromInputValue)}
 							disabled={disabled}
 							required={required}
 							invalid={{ field: false, input: fromInvalid }}
-							buttonAriaLabel={getFromDateInputButtonAriaLabel(fromInputValue)}
+							dateFormat={dateFormat}
 						/>
 						<DateInput
 							aria-describedby={
@@ -377,6 +382,7 @@ export const DateRangePicker = ({
 							disabled={disabled}
 							required={required}
 							invalid={{ field: false, input: toInvalid }}
+							dateFormat={dateFormat}
 						/>
 					</Flex>
 				</Stack>

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -27,7 +27,7 @@ import {
 	formatDate,
 	constrainDate,
 	transformValuePropToInputValue,
-	AcceptedDateFormat,
+	AcceptedDateFormats,
 } from '../date-picker/utils';
 import { CalendarRange } from '../date-picker/Calendar';
 import { CalendarProvider } from '../date-picker/CalendarContext';
@@ -93,8 +93,8 @@ export type DateRangePickerProps = DateRangePickerCalendarProps & {
 	toInputRef?: Ref<HTMLInputElement>;
 	/** The range of options to display in calendar year select. */
 	yearRange?: { from: number; to: number };
-	/** The date format for dates. */
-	dateFormat?: AcceptedDateFormat;
+	/** Used to adjust the date format displayed in the text input and secondary label. */
+	dateFormat?: AcceptedDateFormats;
 };
 
 export const DateRangePicker = ({

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`DateRangePicker renders correctly 1`] = `
                 class="css-1rpt3h8-boxStyles-Text"
               >
                  
-                (dd/mm/yyyy) (optional)
+                (e.g. 05/08/2015) (optional)
               </span>
             </label>
             <div
@@ -122,7 +122,7 @@ exports[`DateRangePicker renders correctly 1`] = `
                 class="css-1rpt3h8-boxStyles-Text"
               >
                  
-                (dd/mm/yyyy) (optional)
+                (e.g. 05/08/2015) (optional)
               </span>
             </label>
             <div

--- a/packages/react/src/date-range-picker/docs/overview.mdx
+++ b/packages/react/src/date-range-picker/docs/overview.mdx
@@ -238,11 +238,13 @@ If a valid date is entered using the text input but it falls outside the constra
 };
 ```
 
-## Alternative date formats
+## Changing the date format
 
-Use the `dateFormat` prop to change the format of the date displayed in the text input and secondary label.
+The Date range picker component allows users to enter dates in various formats. To select the 18th February 2023, a user could input '18/02/2023', '18 Feb 2023', '18th February 2023', or any other supported date format.
 
-While the Date range picker component prefers the `dd/mm/yyyy` date format, any of the current dates are accepted:
+When a valid date is typed, the date will be formatted using the dateFormat prop, which is set to dd/MM/yyyy by default.
+
+To modify the date format, you can change the dateFormat prop to one of the supported date formats:
 
 - `dd/MM/yyyy` (e.g. 18/02/2023)
 - `dd-MM-yyyy` (e.g. 18-02-2023)

--- a/packages/react/src/date-range-picker/docs/overview.mdx
+++ b/packages/react/src/date-range-picker/docs/overview.mdx
@@ -237,3 +237,43 @@ If a valid date is entered using the text input but it falls outside the constra
 	);
 };
 ```
+
+## Alternative date formats
+
+Use the `dateFormat` prop to change the format of the date displayed in the text input and secondary label.
+
+While the Date range picker component prefers the `dd/mm/yyyy` date format, any of the current dates are accepted:
+
+- `dd/MM/yyyy` (e.g. 18/02/2023)
+- `dd-MM-yyyy` (e.g. 18-02-2023)
+- `dd MM yyyy` (e.g. 18 02 2023)
+- `MM/dd/yyyy` (e.g. 02/18/2023)
+- `MM-dd-yyyy` (e.g. 02-18-2023)
+- `MM dd yyyy` (e.g. 02 18 2023)
+- `do MMMM yyyy` (e.g. 8th February 2023)
+- `do MMM yyyy` (e.g. 8th Feb 2023)
+- `MMMM do yyyy` (e.g. February 8th 2023)
+- `MMM do yyyy` (e.g. Feb 8th 2023)
+- `d MMMM yyyy` (e.g. 8 February 2023)
+- `d MMM yyyy` (e.g. 8 Feb 2023)
+- `MMMM d yyyy` (e.g. February 8 2023)
+- `MMM d yyyy` (e.g. Feb 8 2023)
+- `dd MMMM yyyy` (e.g. 08 February 2023)
+- `dd MMM yyyy` (e.g. 08 Feb 2023)
+- `MMMM dd yyyy` (e.g. February 08 2023)
+- `MMM dd yyyy` (e.g. Feb 08 2023)
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState({ from: undefined, to: undefined });
+	return (
+		<DateRangePicker
+			value={value}
+			onChange={setValue}
+			onFromInputChange={(from) => setValue({ ...value, from })}
+			onToInputChange={(to) => setValue({ ...value, to })}
+			dateFormat="d MMM yyyy"
+		/>
+	);
+};
+```

--- a/packages/react/src/date-range-picker/docs/overview.mdx
+++ b/packages/react/src/date-range-picker/docs/overview.mdx
@@ -28,7 +28,7 @@ For an example of using this component in a form built with [react-hook-form](ht
 <DoHeading />
 
 - always display the date format above the text input
-- use Australian date format 'dd/mm/yyyy'
+- prefer Australian date format 'dd/mm/yyyy'
 - allow users to navigate dates via the calendar
 - ensure users can enter dates via the calendar or text input
 - make sure error messages are specific about what input is required.

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -8,12 +8,17 @@ relatedComponents: ['file-input']
 ---
 
 ```jsx live
-<FileUpload
-	label="Avatar image"
-	hint="Formats accepted: .png, .jpg, .jpeg"
-	multiple={false}
-	accept={['image/jpeg', 'image/png']}
-/>
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<FileUpload
+			label="Upload documents"
+			multiple={true}
+			value={value}
+			onChange={setValue}
+		/>
+	);
+};
 ```
 
 File upload is used in forms to enable users to upload files they need. There are 2 ways to upload – via drag and drop or file selection via search.
@@ -53,12 +58,7 @@ As normal, we indicate that the form is submitting by adding a `loading={true}` 
 ```jsx live
 <FormStack>
 	<div style={{ position: 'relative' }}>
-		<FileUpload
-			label="Avatar image"
-			hint="Formats accepted: .png, .jpg, .jpeg"
-			multiple={false}
-			accept={['image/jpeg', 'image/png']}
-		/>
+		<FileUpload label="Upload documents" multiple={false} />
 		<LoadingBlanket label="Uploading file (53%)" />
 	</div>
 	<div>
@@ -77,14 +77,35 @@ In this example, the file is instantly uploaded to a file hosting service, and t
 () => {
 	const uploadedFile = createExampleImageFile({ status: 'success' });
 	const uploadingFile = createExampleFile({ status: 'uploading' });
+
+	const [value, setValue] = React.useState([uploadedFile, uploadingFile]);
+
+	function onChange(files) {
+		setValue(
+			files.map((file) => {
+				file.status = file.status || 'uploading';
+				return file;
+			})
+		);
+		// Show uploaded state after simulated network request
+		setTimeout(() => {
+			setValue(
+				files.map((file) => {
+					if (file.status == 'uploading') {
+						file.status = 'success';
+					}
+					return file;
+				})
+			);
+		}, 1500);
+	}
+
 	return (
 		<FileUpload
-			label="Avatar image"
-			hint="Formats accepted: .png, .jpg, .jpeg"
-			multiple={false}
-			accept={['image/jpeg', 'image/png']}
-			value={[uploadedFile, uploadingFile]}
-			onChange={console.log}
+			label="Upload documents"
+			multiple={true}
+			value={value}
+			onChange={onChange}
 		/>
 	);
 };
@@ -151,9 +172,8 @@ If a user attempts to delete an existing file, a destructive confirmation modal 
 Image files should be displayed with thumbnails which are 72px by 72px. Passing full-size images to `thumbnailSrc` prop will result with long load times.
 
 ```jsx live
-<FileUpload
-	label="Upload documents"
-	existingFiles={[
+() => {
+	const [existingFiles, setExistingFiles] = useState([
 		{
 			name: 'example.png',
 			size: 123456,
@@ -163,9 +183,25 @@ Image files should be displayed with thumbnails which are 72px by 72px. Passing 
 			// This can be useful info when deleting the file
 			meta: { uid: 'abc-def', bucketId: '123-456' },
 		},
-	]}
-	onRemoveExistingFile={(fileToRemove) => {
-		console.log('Remove existing file', fileToRemove);
-	}}
-/>
+	]);
+
+	function onRemoveExistingFile(fileToRemove) {
+		setExistingFiles((existingFiles) =>
+			existingFiles.filter((file) => file.meta.uid !== fileToRemove.meta.uid)
+		);
+	}
+
+	const [value, setValue] = React.useState();
+
+	return (
+		<FileUpload
+			label="Upload documents"
+			multiple={true}
+			value={value}
+			onChange={setValue}
+			existingFiles={existingFiles}
+			onRemoveExistingFile={onRemoveExistingFile}
+		/>
+	);
+};
 ```


### PR DESCRIPTION
Follow up to #1555

---

## Date picker

Add new prop `dateFormat`, which can be used to adjust the date format displayed in the text input and secondary label.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1561/components/date-picker)

## Date range picker

Add new prop `dateFormat`, which can be used to adjust the date format displayed in the text input and secondary label.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1561/components/date-range-picker)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
