### PR TITLE
field: Ensure all form inputs always try to achieve their maxWidth

### DIFF
--- a/.changeset/cuddly-steaks-add.md
+++ b/.changeset/cuddly-steaks-add.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+field: Ensure all form inputs always try to achieve their maxWidth.

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`Autocomplete renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1gfcn9r-Field"
+      class="css-137y9c6-Field"
     />
   </div>
 </div>

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -79,6 +79,10 @@ exports[`Autocomplete renders correctly 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1gfcn9r-Field"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -106,6 +106,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 			hideOptionalLabel={hideOptionalLabel}
 			required={Boolean(required)}
 			hint={hint}
+			maxWidth={maxWidthProp}
 			message={message}
 			invalid={invalid}
 			id={inputId}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -155,6 +155,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 			hideOptionalLabel={hideOptionalLabel}
 			required={Boolean(required)}
 			hint={hint}
+			maxWidth={maxWidthProp}
 			message={message}
 			invalid={invalid}
 			id={inputId}

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -85,6 +85,10 @@ exports[`Combobox renders correctly 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1gfcn9r-Field"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`Combobox renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1gfcn9r-Field"
+      class="css-137y9c6-Field"
     />
   </div>
 </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`ComboboxAsync renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1gfcn9r-Field"
+      class="css-137y9c6-Field"
     />
   </div>
 </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -85,6 +85,10 @@ exports[`ComboboxAsync renders correctly 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1gfcn9r-Field"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -93,6 +93,10 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1gfcn9r-Field"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1gfcn9r-Field"
+      class="css-137y9c6-Field"
     />
   </div>
 </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -93,6 +93,10 @@ exports[`ComboboxMulti renders correctly 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1gfcn9r-Field"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`ComboboxMulti renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1gfcn9r-Field"
+      class="css-137y9c6-Field"
     />
   </div>
 </div>

--- a/packages/react/src/date-picker/DatePickerInput.tsx
+++ b/packages/react/src/date-picker/DatePickerInput.tsx
@@ -55,6 +55,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 			<Field
 				label={label}
 				secondaryLabel="(dd/mm/yyyy)"
+				maxWidth={maxWidthProp}
 				hideOptionalLabel={hideOptionalLabel}
 				required={Boolean(required)}
 				hint={hint}

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -78,6 +78,10 @@ exports[`DatePicker renders correctly 1`] = `
           </span>
         </button>
       </div>
+      <div
+        aria-hidden="true"
+        class="css-1e19z34-Field"
+      />
     </div>
   </div>
 </div>

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`DatePicker renders correctly 1`] = `
       </div>
       <div
         aria-hidden="true"
-        class="css-1e19z34-Field"
+        class="css-9l8g4f-Field"
       />
     </div>
   </div>

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -105,6 +105,10 @@ exports[`DateRangePicker renders correctly 1`] = `
                 </span>
               </button>
             </div>
+            <div
+              aria-hidden="true"
+              class="css-1e19z34-Field"
+            />
           </div>
           <div
             class="css-1904cz9-boxStyles-FieldContainer"
@@ -181,6 +185,10 @@ exports[`DateRangePicker renders correctly 1`] = `
                 </span>
               </button>
             </div>
+            <div
+              aria-hidden="true"
+              class="css-1e19z34-Field"
+            />
           </div>
         </div>
       </div>

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             </div>
             <div
               aria-hidden="true"
-              class="css-1e19z34-Field"
+              class="css-9l8g4f-Field"
             />
           </div>
           <div
@@ -187,7 +187,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             </div>
             <div
               aria-hidden="true"
-              class="css-1e19z34-Field"
+              class="css-9l8g4f-Field"
             />
           </div>
         </div>

--- a/packages/react/src/field/Field.tsx
+++ b/packages/react/src/field/Field.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { useId } from '../core';
+import { useId, FieldMaxWidth, tokens } from '../core';
 import { FieldContainer } from './FieldContainer';
 import { FieldLabel } from './FieldLabel';
 import { FieldHint } from './FieldHint';
@@ -14,6 +14,7 @@ export type FieldProps = {
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
 	/** Describes the purpose of the field. */
+	maxWidth?: FieldMaxWidth;
 	label: string;
 	/** Defines an identifier (ID) of the label element, which must be unique. */
 	labelId?: string;
@@ -34,6 +35,7 @@ export const Field = ({
 	invalid,
 	label,
 	labelId,
+	maxWidth,
 	secondaryLabel,
 	hideOptionalLabel,
 	message,
@@ -52,7 +54,7 @@ export const Field = ({
 	});
 
 	return (
-		<FieldContainer invalid={invalid}>
+		<FieldContainer invalid={invalid} maxWidth={maxWidth}>
 			<FieldLabel
 				id={labelId}
 				htmlFor={fieldId}
@@ -67,6 +69,21 @@ export const Field = ({
 				<FieldMessage id={messageId}>{message}</FieldMessage>
 			) : null}
 			{typeof children === 'function' ? children(a11yProps) : children}
+			{maxWidth ? (
+				// This acts as spacer so that inputs always try to be as wide as their maxWidth
+				<span
+					css={{
+						display: 'block',
+						height: 0,
+						maxWidth: tokens.maxWidth.field[maxWidth],
+						overflow: 'hidden',
+						'::after': {
+							content:
+								'"---------------------------------------------------------------"',
+						},
+					}}
+				/>
+			) : null}
 		</FieldContainer>
 	);
 };

--- a/packages/react/src/field/Field.tsx
+++ b/packages/react/src/field/Field.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { useId, FieldMaxWidth, tokens } from '../core';
+import { FieldMaxWidth, tokens, useId } from '../core';
 import { FieldContainer } from './FieldContainer';
 import { FieldLabel } from './FieldLabel';
 import { FieldHint } from './FieldHint';
@@ -71,7 +71,8 @@ export const Field = ({
 			) : null}
 			{typeof children === 'function' ? children(a11yProps) : children}
 			{maxWidth ? (
-				// This acts as spacer so that inputs always try to be as wide as their maxWidth
+				// This acts as spacer so that inputs always try to be as wide as their maxWidth.
+				// Otherwise, when inside a Flex they will shrink to an undesired size.
 				<div
 					aria-hidden
 					css={{

--- a/packages/react/src/field/Field.tsx
+++ b/packages/react/src/field/Field.tsx
@@ -14,10 +14,11 @@ export type FieldProps = {
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
 	/** Describes the purpose of the field. */
-	maxWidth?: FieldMaxWidth;
 	label: string;
 	/** Defines an identifier (ID) of the label element, which must be unique. */
 	labelId?: string;
+	/** The maximum width of the field. */
+	maxWidth?: FieldMaxWidth;
 	/** Text to prepend to the default secondary label. */
 	secondaryLabel?: string;
 	/** If true, "(optional)" will never be appended to the label even when `required` is `false`. */
@@ -54,7 +55,7 @@ export const Field = ({
 	});
 
 	return (
-		<FieldContainer invalid={invalid} maxWidth={maxWidth}>
+		<FieldContainer invalid={invalid}>
 			<FieldLabel
 				id={labelId}
 				htmlFor={fieldId}

--- a/packages/react/src/field/Field.tsx
+++ b/packages/react/src/field/Field.tsx
@@ -71,9 +71,9 @@ export const Field = ({
 			{typeof children === 'function' ? children(a11yProps) : children}
 			{maxWidth ? (
 				// This acts as spacer so that inputs always try to be as wide as their maxWidth
-				<span
+				<div
+					aria-hidden
 					css={{
-						display: 'block',
 						height: 0,
 						maxWidth: tokens.maxWidth.field[maxWidth],
 						overflow: 'hidden',

--- a/packages/react/src/field/Field.tsx
+++ b/packages/react/src/field/Field.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { FieldMaxWidth, tokens, useId } from '../core';
+import { FieldMaxWidth, mapSpacing, tokens, useId } from '../core';
 import { FieldContainer } from './FieldContainer';
 import { FieldLabel } from './FieldLabel';
 import { FieldHint } from './FieldHint';
@@ -77,6 +77,7 @@ export const Field = ({
 					aria-hidden
 					css={{
 						height: 0,
+						marginTop: `-${mapSpacing(0.5)}`,
 						maxWidth: tokens.maxWidth.field[maxWidth],
 						overflow: 'hidden',
 						'::after': {

--- a/packages/react/src/field/FieldContainer.tsx
+++ b/packages/react/src/field/FieldContainer.tsx
@@ -1,12 +1,13 @@
 import { PropsWithChildren } from 'react';
 import { Stack } from '../stack';
-import { boxPalette } from '../core';
+import { FieldMaxWidth, boxPalette } from '../core';
 
 export type FieldContainerProps = PropsWithChildren<{
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
 	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
+	maxWidth?: FieldMaxWidth;
 }>;
 
 export const FieldContainer = ({

--- a/packages/react/src/field/FieldContainer.tsx
+++ b/packages/react/src/field/FieldContainer.tsx
@@ -1,13 +1,12 @@
 import { PropsWithChildren } from 'react';
 import { Stack } from '../stack';
-import { FieldMaxWidth, boxPalette } from '../core';
+import { boxPalette } from '../core';
 
 export type FieldContainerProps = PropsWithChildren<{
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
 	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
-	maxWidth?: FieldMaxWidth;
 }>;
 
 export const FieldContainer = ({

--- a/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           />
           <div
             aria-hidden="true"
-            class="css-1e19z34-Field"
+            class="css-9l8g4f-Field"
           />
         </div>
         <div
@@ -71,7 +71,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           />
           <div
             aria-hidden="true"
-            class="css-1e19z34-Field"
+            class="css-9l8g4f-Field"
           />
         </div>
       </div>
@@ -132,7 +132,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           />
           <div
             aria-hidden="true"
-            class="css-1e19z34-Field"
+            class="css-9l8g4f-Field"
           />
         </div>
         <div
@@ -157,7 +157,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           />
           <div
             aria-hidden="true"
-            class="css-1e19z34-Field"
+            class="css-9l8g4f-Field"
           />
         </div>
       </div>

--- a/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -44,6 +44,10 @@ exports[`Fieldset Basic renders correctly 1`] = `
             id="field-:r1:"
             type="text"
           />
+          <div
+            aria-hidden="true"
+            class="css-1e19z34-Field"
+          />
         </div>
         <div
           class="css-1904cz9-boxStyles-FieldContainer"
@@ -64,6 +68,10 @@ exports[`Fieldset Basic renders correctly 1`] = `
             class="css-sgg6k9"
             id="field-:r2:"
             type="text"
+          />
+          <div
+            aria-hidden="true"
+            class="css-1e19z34-Field"
           />
         </div>
       </div>
@@ -122,6 +130,10 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
             id="field-:ra:"
             type="text"
           />
+          <div
+            aria-hidden="true"
+            class="css-1e19z34-Field"
+          />
         </div>
         <div
           class="css-1904cz9-boxStyles-FieldContainer"
@@ -142,6 +154,10 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
             class="css-sgg6k9"
             id="field-:rb:"
             type="text"
+          />
+          <div
+            aria-hidden="true"
+            class="css-1e19z34-Field"
           />
         </div>
       </div>

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -31,6 +31,10 @@ exports[`PasswordInput renders correctly 1`] = `
         id="password-input-:r0:"
         type="password"
       />
+      <div
+        aria-hidden="true"
+        class="css-1e19z34-Field"
+      />
     </div>
     <label
       class="css-hp3wbe-boxStyles-CheckboxContainer"

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`PasswordInput renders correctly 1`] = `
       />
       <div
         aria-hidden="true"
-        class="css-1e19z34-Field"
+        class="css-9l8g4f-Field"
       />
     </div>
     <label

--- a/packages/react/src/search-input/SearchInput.tsx
+++ b/packages/react/src/search-input/SearchInput.tsx
@@ -107,6 +107,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 				hideOptionalLabel={hideOptionalLabel}
 				required={Boolean(required)}
 				hint={hint}
+				maxWidth={maxWidthProp}
 				message={message}
 				invalid={invalid}
 				id={id}

--- a/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -58,6 +58,10 @@ exports[`SearchInput Basic renders correctly 1`] = `
         value=""
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -154,6 +158,10 @@ exports[`SearchInput Invalid renders correctly 1`] = `
         value=""
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -223,6 +231,10 @@ exports[`SearchInput With hint renders correctly 1`] = `
         value=""
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`SearchInput Basic renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -160,7 +160,7 @@ exports[`SearchInput Invalid renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -233,7 +233,7 @@ exports[`SearchInput With hint renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>

--- a/packages/react/src/select/Select.tsx
+++ b/packages/react/src/select/Select.tsx
@@ -82,6 +82,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 				hideOptionalLabel={hideOptionalLabel}
 				required={Boolean(required)}
 				hint={hint}
+				maxWidth={maxWidth}
 				message={message}
 				invalid={invalid}
 				id={id}

--- a/packages/react/src/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react/src/select/__snapshots__/Select.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Select Basic renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -159,7 +159,7 @@ exports[`Select Grouped options renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -264,7 +264,7 @@ exports[`Select Invalid renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -335,7 +335,7 @@ exports[`Select With hint renders correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>

--- a/packages/react/src/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react/src/select/__snapshots__/Select.test.tsx.snap
@@ -63,6 +63,10 @@ exports[`Select Basic renders correctly 1`] = `
         />
       </svg>
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -153,6 +157,10 @@ exports[`Select Grouped options renders correctly 1`] = `
         />
       </svg>
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -254,6 +262,10 @@ exports[`Select Invalid renders correctly 1`] = `
         />
       </svg>
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -321,6 +333,10 @@ exports[`Select With hint renders correctly 1`] = `
         />
       </svg>
     </div>
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/text-input/TextInput.tsx
+++ b/packages/react/src/text-input/TextInput.tsx
@@ -64,6 +64,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 				hideOptionalLabel={hideOptionalLabel}
 				required={Boolean(required)}
 				hint={hint}
+				maxWidth={maxWidth}
 				message={message}
 				invalid={invalid}
 				id={id}
@@ -103,8 +104,7 @@ export const textInputStyles = ({
 		...packs.input.md,
 
 		...(maxWidth && {
-			maxWidth: '100vw',
-			width: tokens.maxWidth.field[maxWidth],
+			maxWidth: tokens.maxWidth.field[maxWidth],
 		}),
 
 		...(block && {

--- a/packages/react/src/text-input/TextInput.tsx
+++ b/packages/react/src/text-input/TextInput.tsx
@@ -103,7 +103,8 @@ export const textInputStyles = ({
 		...packs.input.md,
 
 		...(maxWidth && {
-			maxWidth: tokens.maxWidth.field[maxWidth],
+			maxWidth: '100vw',
+			width: tokens.maxWidth.field[maxWidth],
 		}),
 
 		...(block && {

--- a/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
@@ -28,6 +28,10 @@ exports[`TextInput Basic renders correctly 1`] = `
       id="field-:r0:"
       type="text"
     />
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -94,6 +98,10 @@ exports[`TextInput Invalid renders correctly 1`] = `
       id="field-:r4:"
       type="text"
     />
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -132,6 +140,10 @@ exports[`TextInput With hint renders correctly 1`] = `
       class="css-sgg6k9"
       id="field-:r2:"
       type="text"
+    />
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
     />
   </div>
 </div>

--- a/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`TextInput Basic renders correctly 1`] = `
     />
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -100,7 +100,7 @@ exports[`TextInput Invalid renders correctly 1`] = `
     />
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -143,7 +143,7 @@ exports[`TextInput With hint renders correctly 1`] = `
     />
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>

--- a/packages/react/src/textarea/Textarea.tsx
+++ b/packages/react/src/textarea/Textarea.tsx
@@ -66,6 +66,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 				hideOptionalLabel={hideOptionalLabel}
 				required={Boolean(required)}
 				hint={hint}
+				maxWidth={maxWidth}
 				message={message}
 				invalid={invalid}
 				id={id}

--- a/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Textarea Basic renders correctly 1`] = `
     />
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -98,7 +98,7 @@ exports[`Textarea Invalid renders correctly 1`] = `
     />
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>
@@ -140,7 +140,7 @@ exports[`Textarea With hint renders correctly 1`] = `
     />
     <div
       aria-hidden="true"
-      class="css-1e19z34-Field"
+      class="css-9l8g4f-Field"
     />
   </div>
 </div>

--- a/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
@@ -27,6 +27,10 @@ exports[`Textarea Basic renders correctly 1`] = `
       class="css-18qypsc"
       id="field-:r0:"
     />
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -92,6 +96,10 @@ exports[`Textarea Invalid renders correctly 1`] = `
       class="css-y6rxld"
       id="field-:r4:"
     />
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
+    />
   </div>
 </div>
 `;
@@ -129,6 +137,10 @@ exports[`Textarea With hint renders correctly 1`] = `
       aria-required="false"
       class="css-18qypsc"
       id="field-:r2:"
+    />
+    <div
+      aria-hidden="true"
+      class="css-1e19z34-Field"
     />
   </div>
 </div>


### PR DESCRIPTION
This fixes a bug where standard form inputs didn't try to use their `maxWidth` as soon as they were put in a `Flex` container.

The requirements for the fix are:

1. Inputs will always try to be as wide as their `maxWidth` but will shrink if there is not enough space.
2. The label (and hint text) will be as long as they need to be, which may be longer than the input.
3. Any flex siblings must sit immediately beside the input/label (whichever is largest)

You can see a comparison in Playroom here: [**Before**](https://design-system.agriculture.gov.au/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF5gBmAXwD4AdYzTJAZQBdcwBrTU3NkoAmekxYskACRj4SpTBwCe2GOQYgAFsI10Aks1w4ANrhKZO3HkgD0MuWUbMJ7Lr36DKARjHOJrABUYdA4DbABXDkxTACMYY3UQdABnTBIIjg1MAFtcdAB1QigOTUSUrIAnGABHcMIqqEwbJ39JIJCwyOjcOISNZOy04gys3IKiksSBypq6hqaW1qR20OGu2PjE7Mb0yNG8wuLSjW2Z2vqYRubxJZXOqI2%2BkGMFXcyQHIOJ4%2BfSM7nLgsbv5lsFVhlur0ysYhiMPmNDpMNOhjP8LldFiC7mtMn5Wo9obCugB3QglTBGABuMAqSmiEDIkPiik0uCiuTpEAqnzpxAgUWJFUEmFgqmIREZDJZMEwyTAVRgzGShAAXjANMDWgjvtCNXj-FVzg1NSxrnjbJZeE5NUgACKESlFGlA4g2%2BwShTKVSJbS6fJC7CqHbMABixmCtnd8kxrEtfAEQmAPhjkjDwUwADNwwUA4lBYIsgnvDQKcZCKRiHoODBsslEmBFdWKroTS5sRCCcjUm99uMjmVkmj5mbWqwbGn0CnWBPM9n-Z4NPnsIXPEmS7gyxWqzW6xoG8Qmy39W2wfcmU8BkT3p8%2B0iQNMPoaARjW7YJ1OkDOs8F50JFwGV0THxS3LStq1retGxpI9RzaU8cXPLZgzhG9ER%2BU5H1mdEXVHN9sw-L851zf8Cw%2BIs1xArdwN3cAoObEApzgjoEM7X4r17NDEheIdARHJZx3w19CJ-YiQCXQDi0osCd0gg9oIY1smPBdYek2ZEYR7eEvn7dSeJfY88OCAjs1nESFzEgCyNXYCN1A7cIL3OiYNg0FmI7VSnhRK9MFJckjGVGIyzIDidV0zCjV4xjWDQSc9GybJLkINl4jpOJlVgTAuR8gMg1sGKPwEoyhJM78c3M8SrKA9dN2khzaLk%2Biotc5TcVgiRWK8t4fLJTQKUwalaXpRlHhZNkeUy7kOUwPkBQDEUYDFD1MuYEoZTlBUlVVdUQEUiRtR0pJUR248DSw40Tpw-j3xtGw40WC03B4Jw8owJwQAAGjE75kgQABtKhhAABneqgAHYAFZ3tBgA2AAOABdGggA) - [**After**](https://design-system.agriculture.gov.au/pr-preview/pr-1565/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF5gBmAXwD4AdYzTJAZQBdcwBrTU3NkoAmekxYskACRj4SpTBwCe2GOQYgAFsI10Aks1w4ANrhKZO3HkgD0MuWUbMJ7Lr36DKARjHOJrABUYdA4DbABXDkxTACMYY3UQdABnTBIIjg1MAFtcdAB1QigOTUSUrIAnGABHcMIqqEwbJ39JIJCwyOjcOISNZOy04gys3IKiksSBypq6hqaW1qR20OGu2PjE7Mb0yNG8wuLSjW2Z2vqYRubxJZXOqI2%2BkGMFXcyQHIOJ4%2BfSM7nLgsbv5lsFVhlur0ysYhiMPmNDpMNOhjP8LldFiC7mtMn5Wo9obCugB3QglTBGABuMAqSmiEDIkPiik0uCiuTpEAqnzpxAgUWJFUEmFgqmIREZDJZMEwyTAVRgzGShAAXjANMDWgjvtCNXj-FVzg1NSxrnjbJZeE5NUgACKESlFGlA4g2%2BwShTKVSJbS6fJC7CqHbMABixmCtnd8kxrEtfAEQmAPhjkjDwUwADNwwUA4lBYIsgnvDQKcZCKRiHoODBsslEmBFdWKroTS5sRCCcjUm99uMjmVkmj5mbWqwbGn0CnWBPM9n-Z4NPnsIXPEmS7gyxWqzW6xoG8Qmy39W2wfcmU8BkT3p8%2B0iQNMPoaARjW7YJ1OkDOs8F50JFwGV0THxS3LStq1retGxpI9RzaU8cXPLZgzhG9ER%2BU5H1mdEXVHN9sw-L851zf8Cw%2BIs1xArdwN3cAoObEApzgjoEM7X4r17NDEheIdARHJZx3w19CJ-YiQCXQDi0osCd0gg9oIY1smPBdYek2ZEYR7eEvn7dSeJfY88OCAjs1nESFzEgCyNXYCN1A7cIL3OiYNg0FmI7VSnhRK9MFJckjGVGIyzIDidV0zCjV4xjWDQSc9GybJLkINl4jpOJlVgTAuR8gMg1sGKPwEoyhJM78c3M8SrKA9dN2khzaLk%2Biotc5TcVgiRWK8t4fLJTQKUwalaXpRlHhZNkeUy7kOUwPkBQDEUYDFD1MuYEoZTlBUlVVdUQEUiRtR0pJUR248DSw40Tpw-j3xtGw40WC03B4Jw8owJwQAAGjE75kgQABtKhhAABneqgAHYAFZ3tBgA2AAOABdGggA)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1565)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.