### PR TITLE
section-alert: replace "Dismiss" with "Close"

### DIFF
--- a/.changeset/nice-peaches-press.md
+++ b/.changeset/nice-peaches-press.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+section-alert: Changing "Dismiss" button text to say "Close" instead. This is to align with Global Alert and Modal.

--- a/.changeset/nice-peaches-press.md
+++ b/.changeset/nice-peaches-press.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-section-alert: Changing "Dismiss" button text to say "Close" instead. This is to align with Global Alert and Modal.
+section-alert: Changed "Dismiss" button text to say "Close" instead. This was to align with Global Alert and Modal.

--- a/packages/react/src/section-alert/SectionAlertDismissButton.tsx
+++ b/packages/react/src/section-alert/SectionAlertDismissButton.tsx
@@ -16,7 +16,7 @@ export const SectionAlertDismissButton = ({
 			onClick={onClick}
 			iconAfter={CloseIcon}
 			variant="text"
-			aria-label="Dismiss"
+			aria-label="Close"
 			css={{
 				flexShrink: 0,
 				// Hide the button text on small screens
@@ -28,7 +28,7 @@ export const SectionAlertDismissButton = ({
 				},
 			}}
 		>
-			Dismiss
+			Close
 		</Button>
 	);
 };

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`SectionAlert which is dismissable renders correctly 1`] = `
       </div>
     </div>
     <button
-      aria-label="Dismiss"
+      aria-label="Close"
       class="css-1myr4hy-BaseButton-SectionAlertDismissButton"
       type="button"
     >
@@ -46,7 +46,7 @@ exports[`SectionAlert which is dismissable renders correctly 1`] = `
         <span
           class="css-oobk4c-Button"
         >
-          Dismiss
+          Close
         </span>
         <span
           aria-live="assertive"


### PR DESCRIPTION
Changed SectionAlert "Dismiss" button text to say "Close" instead. This was to align with Global Alert and Modal.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1575)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website