### PR TITLE
docs: live code editor debounce

### DIFF
--- a/.changeset/hot-scissors-visit.md
+++ b/.changeset/hot-scissors-visit.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/docs': patch
 ---
 
-live-code-editor: applied debounce so that it can keep up with the users keystrokes as they type
+docs: Applied debounce to live code editors so that they can keep up with the users keystrokes as they type.

--- a/.changeset/hot-scissors-visit.md
+++ b/.changeset/hot-scissors-visit.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+live-code-editor: applied debounce so that it can keep up with the users keystrokes as they type

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -8,6 +8,7 @@ import React, {
 	useContext,
 } from 'react';
 import { LiveProvider, LiveEditor, LivePreview, LiveContext } from 'react-live';
+import { useDebouncedCallback } from 'use-debounce';
 import { createUrl } from 'playroom/utils';
 import { Highlight, Prism } from 'prism-react-renderer';
 import copy from 'clipboard-copy';
@@ -75,13 +76,10 @@ function LiveCode({
 		copy(localCopy);
 	}, [localCopy]);
 
-	const handleChange = useCallback(
-		(code: string) => {
-			liveOnChange(code);
-			setLocalCopy(code);
-		},
-		[liveOnChange]
-	);
+	const handleChange = useDebouncedCallback((code: string) => {
+		liveOnChange(code);
+		setLocalCopy(code);
+	}, 200);
 
 	const playroomUrl = createUrl({
 		baseUrl: process.env.NEXT_PUBLIC_PLAYROOM_URL,


### PR DESCRIPTION
Applied debounce so that the live code editors can keep up with the users keystrokes as they type.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1578)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website