### PR TITLE
docs: grouped-fields - Update select options. Allow appropriate ones to be changed

### DIFF
--- a/.changeset/silver-ravens-confess.md
+++ b/.changeset/silver-ravens-confess.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+docs: grouped-fields. Update select options. Allow appropriate ones to be changed

--- a/packages/react/src/grouped-fields/docs/overview.mdx
+++ b/packages/react/src/grouped-fields/docs/overview.mdx
@@ -28,11 +28,11 @@ relatedComponents:
 					{ value: 'mg', label: 'mg' },
 					{ value: 'g', label: 'g' },
 					{ value: 'kg', label: 'kg' },
-					{ value: 'ton', label: 'ton' },
+					{ value: 't', label: 't' },
+					{ value: 'Mt', label: 'Mt' },
 				]}
 				hideOptionalLabel
 				maxWidth="sm"
-				value="kg"
 				{...field2Props}
 			/>
 		</>
@@ -71,7 +71,8 @@ When both inputs are required or one input is optional and the other has no empt
 						{ value: 'mg', label: 'mg' },
 						{ value: 'g', label: 'g' },
 						{ value: 'kg', label: 'kg' },
-						{ value: 'ton', label: 'ton' },
+						{ value: 't', label: 't' },
+						{ value: 'Mt', label: 'Mt' },
 					]}
 					maxWidth="sm"
 					placeholder="Choose"
@@ -92,10 +93,10 @@ When both inputs are required or one input is optional and the other has no empt
 						{ value: 'mg', label: 'mg' },
 						{ value: 'g', label: 'g' },
 						{ value: 'kg', label: 'kg' },
-						{ value: 'ton', label: 'ton' },
+						{ value: 't', label: 't' },
+						{ value: 'Mt', label: 'Mt' },
 					]}
 					maxWidth="sm"
-					value="kg"
 					hideOptionalLabel
 					{...field2Props}
 				/>
@@ -122,7 +123,8 @@ When both fields are required, remember to also use `hideOptionalLabel` so scree
 					{ value: 'mg', label: 'mg' },
 					{ value: 'g', label: 'g' },
 					{ value: 'kg', label: 'kg' },
-					{ value: 'ton', label: 'ton' },
+					{ value: 't', label: 't' },
+					{ value: 'Mt', label: 'Mt' },
 				]}
 				maxWidth="sm"
 				placeholder="Choose"
@@ -153,10 +155,11 @@ Don’t include links within hint text. While screen readers will read out the l
 					{ value: 'mg', label: 'mg' },
 					{ value: 'g', label: 'g' },
 					{ value: 'kg', label: 'kg' },
-					{ value: 'ton', label: 'ton' },
+					{ value: 't', label: 't' },
+					{ value: 'Mt', label: 'Mt' },
 				]}
 				maxWidth="sm"
-				value="kg"
+				placeholder="Choose"
 				{...field2Props}
 			/>
 		</>
@@ -187,7 +190,8 @@ The `message` should be helpful but generic enough to apply and make sense to bo
 						{ value: 'mg', label: 'mg' },
 						{ value: 'g', label: 'g' },
 						{ value: 'kg', label: 'kg' },
-						{ value: 'ton', label: 'ton' },
+						{ value: 't', label: 't' },
+						{ value: 'Mt', label: 'Mt' },
 					]}
 					maxWidth="sm"
 					placeholder="Choose"
@@ -214,7 +218,8 @@ The `message` should be helpful but generic enough to apply and make sense to bo
 						{ value: 'mg', label: 'mg' },
 						{ value: 'g', label: 'g' },
 						{ value: 'kg', label: 'kg' },
-						{ value: 'ton', label: 'ton' },
+						{ value: 't', label: 't' },
+						{ value: 'Mt', label: 'Mt' },
 					]}
 					maxWidth="sm"
 					placeholder="Choose"
@@ -241,7 +246,8 @@ The `message` should be helpful but generic enough to apply and make sense to bo
 						{ value: 'mg', label: 'mg' },
 						{ value: 'g', label: 'g' },
 						{ value: 'kg', label: 'kg' },
-						{ value: 'ton', label: 'ton' },
+						{ value: 't', label: 't' },
+						{ value: 'Mt', label: 'Mt' },
 					]}
 					maxWidth="sm"
 					placeholder="Choose"


### PR DESCRIPTION
The grouped fields docs didn't allow the selects to change, and the options were incorrect.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1592)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets