### PR TITLE
status-badge: Remove background colour for subtle appearance

### DIFF
--- a/.changeset/yellow-snakes-eat.md
+++ b/.changeset/yellow-snakes-eat.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+status-badge: Remove background colour for subtle appearance

--- a/packages/react/src/status-badge/StatusBadge.tsx
+++ b/packages/react/src/status-badge/StatusBadge.tsx
@@ -52,7 +52,6 @@ export const StatusBadge = ({
 		return (
 			<Flex
 				alignItems="center"
-				background="body"
 				borderColor={legacyTone}
 				display="inline-flex"
 				gap={0.5}
@@ -90,7 +89,6 @@ export const StatusBadge = ({
 	return (
 		<Flex
 			alignItems="center"
-			background="body"
 			borderColor={borderColor}
 			display="inline-flex"
 			gap={0.5}
@@ -125,6 +123,7 @@ const height = mapSpacing(2); // 32px
 const iconWidth = '1.375rem'; // 22px
 
 const regularAppearanceStyleProps = {
+	background: 'body',
 	border: true,
 	borderWidth: 'sm',
 	height,

--- a/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`StatusBadge Legacy weight: regular tone: warning renders correctly 1`] 
 exports[`StatusBadge Legacy weight: subtle tone: error renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -190,7 +190,7 @@ exports[`StatusBadge Legacy weight: subtle tone: error renders correctly 1`] = `
 exports[`StatusBadge Legacy weight: subtle tone: info renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -221,7 +221,7 @@ exports[`StatusBadge Legacy weight: subtle tone: info renders correctly 1`] = `
 exports[`StatusBadge Legacy weight: subtle tone: neutral renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <div
       class="css-1fa9oau-boxStyles-icon"
@@ -238,7 +238,7 @@ exports[`StatusBadge Legacy weight: subtle tone: neutral renders correctly 1`] =
 exports[`StatusBadge Legacy weight: subtle tone: success renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -272,7 +272,7 @@ exports[`StatusBadge Legacy weight: subtle tone: success renders correctly 1`] =
 exports[`StatusBadge Legacy weight: subtle tone: warning renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -866,7 +866,7 @@ exports[`StatusBadge appearance: regular tone: warningMedium renders correctly 1
 exports[`StatusBadge appearance: subtle tone: cannotStartLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -897,7 +897,7 @@ exports[`StatusBadge appearance: subtle tone: cannotStartLow renders correctly 1
 exports[`StatusBadge appearance: subtle tone: errorHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -930,7 +930,7 @@ exports[`StatusBadge appearance: subtle tone: errorHigh renders correctly 1`] = 
 exports[`StatusBadge appearance: subtle tone: errorLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -961,7 +961,7 @@ exports[`StatusBadge appearance: subtle tone: errorLow renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: errorMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -998,7 +998,7 @@ exports[`StatusBadge appearance: subtle tone: errorMedium renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: inProgressLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1044,7 +1044,7 @@ exports[`StatusBadge appearance: subtle tone: inProgressLow renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: infoHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1077,7 +1077,7 @@ exports[`StatusBadge appearance: subtle tone: infoHigh renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: infoLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1108,7 +1108,7 @@ exports[`StatusBadge appearance: subtle tone: infoLow renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: infoMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1139,7 +1139,7 @@ exports[`StatusBadge appearance: subtle tone: infoMedium renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: notStartedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1171,7 +1171,7 @@ exports[`StatusBadge appearance: subtle tone: notStartedLow renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: pausedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1202,7 +1202,7 @@ exports[`StatusBadge appearance: subtle tone: pausedLow renders correctly 1`] = 
 exports[`StatusBadge appearance: subtle tone: successHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1235,7 +1235,7 @@ exports[`StatusBadge appearance: subtle tone: successHigh renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: successLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1269,7 +1269,7 @@ exports[`StatusBadge appearance: subtle tone: successLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: successMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1303,7 +1303,7 @@ exports[`StatusBadge appearance: subtle tone: successMedium renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: unknownLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1334,7 +1334,7 @@ exports[`StatusBadge appearance: subtle tone: unknownLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: warningHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1367,7 +1367,7 @@ exports[`StatusBadge appearance: subtle tone: warningHigh renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: warningLow renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1398,7 +1398,7 @@ exports[`StatusBadge appearance: subtle tone: warningLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: warningMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-oil8xj-boxStyles-StatusBadge"
+    class="css-1ncy008-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"


### PR DESCRIPTION
In the enhancements of https://github.com/agriculturegovau/agds-next/pull/1579/, subtle appearance status badges were incorrectly given the `body` background color, which made them visible in zebra striped tables etc.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1601)

## Before

<img width="692" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/1a357b33-b995-483f-84c2-781859f3f157">
<img width="693" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/fa06985a-a9f0-424c-a086-f5fed7c52483">

## After

<img width="693" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/581a391e-1a10-45ec-a061-95aba68d23b8">
<img width="695" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/81dc790f-3237-4903-96c2-1ca8ada9f912">


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.