### PR TITLE
box: Document all style props

### DIFF
--- a/.changeset/metal-cheetahs-roll.md
+++ b/.changeset/metal-cheetahs-roll.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/react': patch
+'@ag.ds-next/docs': patch
+---
+
+box: Document all style props

--- a/docs/components/ComponentPropsTable.tsx
+++ b/docs/components/ComponentPropsTable.tsx
@@ -7,6 +7,9 @@ import {
 	TableCaption,
 	TableRow,
 } from '@ag.ds-next/react/table';
+import { Stack } from '@ag.ds-next/react/stack';
+import { Text } from '@ag.ds-next/react/text';
+import { TextLink } from '@ag.ds-next/react/text-link';
 
 export type ComponentPropsTableProps = {
 	data: {
@@ -65,6 +68,11 @@ export const ComponentPropsTable = ({ data }: ComponentPropsTableProps) => (
 					}
 				}
 
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const [_description, desc, _see, url] =
+					prop.description.match(/^(.*?)(\n?@see\s+)?(https?:\/\/\S+)?$/m) ||
+					[];
+
 				return (
 					<TableRow key={prop.name}>
 						<TableCell>
@@ -85,7 +93,14 @@ export const ComponentPropsTable = ({ data }: ComponentPropsTableProps) => (
 							</span>
 						</TableCell>
 						<TableCell>
-							<span css={{ wordBreak: 'break-word' }}>{prop.description}</span>
+							<Stack css={{ wordBreak: 'break-word' }} gap={0.25}>
+								{desc}
+								{url ? (
+									<Text fontSize="xs">
+										<TextLink href={url}>{url}</TextLink>
+									</Text>
+								) : null}
+							</Stack>
 						</TableCell>
 					</TableRow>
 				);

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, CSSObject } from '@emotion/react';
 import {
 	tokens,
 	BoxPalette,
@@ -449,12 +449,12 @@ type PaddingProps = Partial<{
 	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom
 	 */
 	paddingBottom: ResponsiveProp<Spacing>;
-	/** Maps tokens to the CSS padding-bottom property.
-	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom
-	 */
-	paddingRight: ResponsiveProp<Spacing>;
 	/** Maps tokens to the CSS padding-right property.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right
+	 */
+	paddingRight: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS padding-left property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left
 	 */
 	paddingLeft: ResponsiveProp<Spacing>;
 	/** Maps tokens to the CSS padding-left and padding-right properties.

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -1,4 +1,4 @@
-import { css, CSSObject } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	tokens,
 	BoxPalette,

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -20,8 +20,17 @@ import {
 } from '../core';
 
 type PaletteProps = Partial<{
+	/** Sets the colour palette, which can also be changed at breakpoints.
+	 * @see https://design-system.agriculture.gov.au/foundations/tokens/colour
+	 */
 	palette: ResponsiveProp<BoxPalette>;
+	/** Sets the colour palette to dark always.
+	 * @see https://design-system.agriculture.gov.au/foundations/tokens/colour
+	 */
 	dark: boolean;
+	/** Sets the colour palette to light always.
+	 * @see https://design-system.agriculture.gov.au/foundations/tokens/colour
+	 */
 	light: boolean;
 }>;
 
@@ -94,7 +103,13 @@ export const backgroundColorMap = {
 export type BackgroundColor = keyof typeof backgroundColorMap;
 
 type ColorProps = Partial<{
+	/** Maps tokens to the CSS color property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/color
+	 */
 	color: ResponsiveProp<ForegroundColor>;
+	/** Maps tokens to the CSS background-color property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/background-color
+	 */
 	background: ResponsiveProp<BackgroundColor>;
 }>;
 
@@ -110,10 +125,25 @@ function colorStyles({ color, background }: ColorProps) {
 }
 
 type TypographyProps = Partial<{
+	/** Maps tokens to the CSS font-weight property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
+	 */
 	fontWeight: ResponsiveProp<FontWeight>;
+	/** Maps tokens to the CSS font-family property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-family
+	 */
 	fontFamily: ResponsiveProp<Font>;
+	/** Maps tokens to the CSS font-size property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-size
+	 */
 	fontSize: ResponsiveProp<FontSize>;
+	/** Maps tokens to the CSS line-height property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/line-height
+	 */
 	lineHeight: LineHeight;
+	/** Maps tokens to the CSS text-align property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/text-align
+	 */
 	textAlign: ResponsiveProp<'left' | 'center' | 'right'>;
 }>;
 
@@ -160,6 +190,9 @@ function isEntry(a: unknown): a is {
 	return !!a; // ie. not null or undefined
 }
 type LayoutProps = Partial<{
+	/** Sets the CSS display property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+	 */
 	display: ResponsiveProp<
 		| 'block'
 		| 'flex'
@@ -179,15 +212,39 @@ type LayoutProps = Partial<{
 		| 'grid'
 		| 'inline-grid'
 	>;
+	/** Sets the CSS flex-direction property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction
+	 */
 	flexDirection: ResponsiveProp<
 		'row' | 'column' | 'row-reverse' | 'column-reverse'
 	>;
+	/** Sets the CSS flex-wrap property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap
+	 */
 	flexWrap: ResponsiveProp<'nowrap' | 'wrap' | 'wrap-reverse'>;
+	/** Sets the CSS flex-grow property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow
+	 */
 	flexGrow: ResponsiveProp<number>;
+	/** Sets the CSS flex-shrink property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
+	 */
 	flexShrink: ResponsiveProp<number>;
+	/** Sets a subset of the CSS grid-columns property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-columns
+	 */
 	gridColumnSpan: ResponsiveProp<number>;
+	/** Sets the CSS grid-column-start property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column-start
+	 */
 	gridColumnStart: ResponsiveProp<number>;
+	/** Sets the CSS grid-column-end property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column-end
+	 */
 	gridColumnEnd: ResponsiveProp<number>;
+	/** Sets the CSS justify-content property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
+	 */
 	justifyContent: ResponsiveProp<
 		| 'flex-start'
 		| 'flex-end'
@@ -196,17 +253,47 @@ type LayoutProps = Partial<{
 		| 'space-around'
 		| 'space-evenly'
 	>;
+	/** Sets the CSS align-items property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
+	 */
 	alignItems: ResponsiveProp<
 		'stretch' | 'flex-start' | 'flex-end' | 'center' | 'baseline'
 	>;
+	/** Maps tokens to the CSS gap property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/gap
+	 */
 	gap: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS column-gap property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap
+	 */
 	columnGap: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS row-gap property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap
+	 */
 	rowGap: ResponsiveProp<Spacing>;
+	/** Sets the CSS width property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/width
+	 */
 	width: ResponsiveProp<number | string>;
+	/** Sets the CSS min-width property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-width
+	 */
 	minWidth: ResponsiveProp<number | string>;
+	/** Sets the CSS max-width property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
+	 */
 	maxWidth: ResponsiveProp<number | string>;
+	/** Sets the CSS height property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/height
+	 */
 	height: ResponsiveProp<number | string>;
+	/** Sets the CSS min-height property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-height
+	 */
 	minHeight: ResponsiveProp<number | string>;
+	/** Sets the CSS max-height property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-height
+	 */
 	maxHeight: ResponsiveProp<number | string>;
 }>;
 
@@ -255,19 +342,47 @@ function layoutStyles({
 }
 
 type BorderProps = Partial<{
+	/** If true, renders a border on all sides using the relevant width. */
 	border: ResponsiveProp<boolean>;
+	/** Maps tokens to the CSS border-width property. Default: 'sm'.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/border-width
+	 */
 	borderWidth: ResponsiveProp<BorderWidth>;
+	/** Maps tokens to the CSS border-color property. Default: 'border'.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/border-color
+	 */
 	borderColor: ResponsiveProp<BorderColor>;
+	/** If true, renders a border on the left side using the relevant width. */
 	borderLeft: ResponsiveProp<boolean>;
+	/** Maps tokens to the CSS border-left-width property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width
+	 */
 	borderLeftWidth: ResponsiveProp<BorderWidth>;
+	/** If true, renders a border on the right side using the relevant width. */
 	borderRight: ResponsiveProp<boolean>;
+	/** Maps tokens to the CSS border-right-width property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-width
+	 */
 	borderRightWidth: ResponsiveProp<BorderWidth>;
+	/** If true, renders a border on the top side using the relevant width. */
 	borderTop: ResponsiveProp<boolean>;
+	/** Maps tokens to the CSS border-top-width property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width
+	 */
 	borderTopWidth: ResponsiveProp<BorderWidth>;
+	/** If true, renders a border on the bottom side using the relevant width. */
 	borderBottom: ResponsiveProp<boolean>;
+	/** Maps tokens to the CSS border-bottom-width property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-width
+	 */
 	borderBottomWidth: ResponsiveProp<BorderWidth>;
+	/** If true, renders a border on the left and right sides using the relevant width. */
 	borderX: ResponsiveProp<boolean>;
+	/** If true, renders a border on the top and bottom sides using the relevant width. */
 	borderY: ResponsiveProp<boolean>;
+	/** If true, rounds the element's corners by mapping tokens.borderRadius to the CSS border-radius property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius
+	 */
 	rounded: boolean;
 }>;
 
@@ -326,12 +441,33 @@ function borderStyles({
 }
 
 type PaddingProps = Partial<{
+	/** Maps tokens to the CSS padding-top property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-top
+	 */
 	paddingTop: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS padding-bottom property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom
+	 */
 	paddingBottom: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS padding-bottom property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom
+	 */
 	paddingRight: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS padding-right property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right
+	 */
 	paddingLeft: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS padding-left and padding-right properties.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left
+	 */
 	paddingX: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS padding-bottom and padding-top properties.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom
+	 */
 	paddingY: ResponsiveProp<Spacing>;
+	/** Maps tokens to the CSS padding property.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/padding
+	 */
 	padding: ResponsiveProp<Spacing>;
 }>;
 


### PR DESCRIPTION
None of the props in Box were documented. This fixes that for website and TypeScript users.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1670/components/box/code)

<img width="715" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/e191cb0e-65b7-4859-b529-96925b57a4bd">
<img width="745" alt="image" src="https://github.com/agriculturegovau/agds-next/assets/853552/c8c6afa4-abd6-40f3-8c99-73fbf6abbfd7">


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets