### PR TITLE
table: Fix example header alignment

### DIFF
--- a/.changeset/stale-baboons-allow.md
+++ b/.changeset/stale-baboons-allow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+table: Fix example header alignment

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -446,10 +446,18 @@ Some tables require cells which represent multiple rows or columns. Instead of r
 		<TableHead>
 			<TableRow>
 				<TableHeader as="td" colSpan={2}></TableHeader>
-				<TableHeader scope="col">Trousers</TableHeader>
-				<TableHeader scope="col">Skirts</TableHeader>
-				<TableHeader scope="col">Dresses</TableHeader>
-				<TableHeader scope="col">Bracelets</TableHeader>
+				<TableHeader scope="col" textAlign="right">
+					Trousers
+				</TableHeader>
+				<TableHeader scope="col" textAlign="right">
+					Skirts
+				</TableHeader>
+				<TableHeader scope="col" textAlign="right">
+					Dresses
+				</TableHeader>
+				<TableHeader scope="col" textAlign="right">
+					Bracelets
+				</TableHeader>
 			</TableRow>
 		</TableHead>
 		<TableBody>


### PR DESCRIPTION
The header cells should have been right-aligned

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1671)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
