### PR TITLE
table-row: Allow error background indicator

### DIFF
--- a/.changeset/breezy-rockets-agree.md
+++ b/.changeset/breezy-rockets-agree.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': minor
 ---
 
-table: Add `hasRowError` prop to table row component to visually indicate row with error.
+table: Add `invalid` prop to table row component to visually indicate row with error.

--- a/.changeset/breezy-rockets-agree.md
+++ b/.changeset/breezy-rockets-agree.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+table: Add `hasRowError` prop to table row component to visually indicate row with error.

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -1,67 +1,70 @@
 import { PropsWithChildren } from 'react';
 import { boxPalette, tokens } from '../core';
+import { theme } from '../ag-branding';
 import { useTableContext } from './TableContext';
 
 export type TableRowProps = PropsWithChildren<{
-	/** Indicates the current selected state of the table row. */
-	selected?: boolean;
 	/** The row index of the table row. */
 	'aria-rowindex'?: number;
+	/** Style the row when one cell contains an error. */
+	hasRowError?: boolean;
+	/** Indicates the current selected state of the table row. */
+	selected?: boolean;
 }>;
 
 export function TableRow({
-	children,
-	selected,
 	'aria-rowindex': ariaRowindex,
+	children,
+	hasRowError,
+	selected,
 }: TableRowProps) {
 	const { tableLayout } = useTableContext();
 	return (
 		<tr
 			aria-selected={selected}
 			aria-rowindex={ariaRowindex}
-			css={
-				selected
-					? {
-							...(tableLayout === 'auto' && {
-								position: 'relative',
-								backgroundColor: boxPalette.selectedMuted,
+			css={{
+				...(selected && {
+					...(tableLayout === 'auto' && {
+						position: 'relative',
+						backgroundColor: boxPalette.selectedMuted,
 
-								// Add outline
-								'&:after': {
-									content: '""',
-									pointerEvents: 'none',
-									position: 'absolute',
-									inset: 0,
-									borderWidth: tokens.borderWidth.md,
-									borderColor: boxPalette.selected,
-									borderStyle: 'solid',
-								},
+						// Add outline
+						'&:after': {
+							content: '""',
+							pointerEvents: 'none',
+							position: 'absolute',
+							inset: 0,
+							borderWidth: tokens.borderWidth.md,
+							borderColor: boxPalette.selected,
+							borderStyle: 'solid',
+						},
 
-								// Remove the border top (if next table row is selected)
-								":has(+ tr[aria-selected='true']):after": {
-									borderBottomWidth: 0,
-								},
+						// Remove the border top (if next table row is selected)
+						":has(+ tr[aria-selected='true']):after": {
+							borderBottomWidth: 0,
+						},
 
-								// Remove the border top from the next table row (if next table row is selected)
-								'+ tr:after': {
-									borderTopWidth: 0,
-								},
-							}),
+						// Remove the border top from the next table row (if next table row is selected)
+						'+ tr:after': {
+							borderTopWidth: 0,
+						},
+					}),
 
-							// Chrome and Firefox doesn't support :after elements in fixed table layouts
-							// FIXME Once Chrome Firefox fixes this issue, these alternative styles should be removed
-							...(tableLayout === 'fixed'
-								? alternativeSelectedStyles
-								: undefined),
+					// Chrome and Firefox doesn't support :after elements in fixed table layouts
+					// FIXME Once Chrome Firefox fixes this issue, these alternative styles should be removed
+					...(tableLayout === 'fixed' ? alternativeSelectedStyles : undefined),
 
-							// Safari does not support relative positioning on `tr` elements
-							// FIXME Once safari fixes this issue, these alternative styles should be removed
-							// More info https://www.reddit.com/r/css/comments/s195xg/safari_alternative_to_positionrelative_on_tr/?rdt=41288
-							'@supports (-webkit-appearance: -apple-pay-button)':
-								alternativeSelectedStyles,
-					  }
-					: undefined
-			}
+					// Safari does not support relative positioning on `tr` elements
+					// FIXME Once safari fixes this issue, these alternative styles should be removed
+					// More info https://www.reddit.com/r/css/comments/s195xg/safari_alternative_to_positionrelative_on_tr/?rdt=41288
+					'@supports (-webkit-appearance: -apple-pay-button)':
+						alternativeSelectedStyles,
+				}),
+				...(hasRowError && {
+					background: theme.lightSystemErrorMuted,
+				}),
+			}}
 		>
 			{children}
 		</tr>

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -6,7 +6,7 @@ import { useTableContext } from './TableContext';
 export type TableRowProps = PropsWithChildren<{
 	/** The row index of the table row. */
 	'aria-rowindex'?: number;
-	/** Style the row when one cell contains an error. */
+	/** Style the row when a cell contains an error. */
 	invalid?: boolean;
 	/** Indicates the current selected state of the table row. */
 	selected?: boolean;

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -7,7 +7,7 @@ export type TableRowProps = PropsWithChildren<{
 	/** The row index of the table row. */
 	'aria-rowindex'?: number;
 	/** Style the row when one cell contains an error. */
-	hasRowError?: boolean;
+	invalid?: boolean;
 	/** Indicates the current selected state of the table row. */
 	selected?: boolean;
 }>;
@@ -15,7 +15,7 @@ export type TableRowProps = PropsWithChildren<{
 export function TableRow({
 	'aria-rowindex': ariaRowindex,
 	children,
-	hasRowError,
+	invalid,
 	selected,
 }: TableRowProps) {
 	const { tableLayout } = useTableContext();
@@ -53,7 +53,7 @@ export function TableRow({
 
 					// Chrome and Firefox doesn't support :after elements in fixed table layouts
 					// FIXME Once Chrome Firefox fixes this issue, these alternative styles should be removed
-					...(tableLayout === 'fixed' ? alternativeSelectedStyles : undefined),
+					...(tableLayout === 'fixed' && alternativeSelectedStyles),
 
 					// Safari does not support relative positioning on `tr` elements
 					// FIXME Once safari fixes this issue, these alternative styles should be removed
@@ -61,7 +61,7 @@ export function TableRow({
 					'@supports (-webkit-appearance: -apple-pay-button)':
 						alternativeSelectedStyles,
 				}),
-				...(hasRowError && {
+				...(invalid && {
 					background: theme.lightSystemErrorMuted,
 				}),
 			}}

--- a/packages/react/src/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/Table.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
         class="css-11khhn7-boxStyles"
       >
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1gy3b36-boxStyles"
@@ -51,7 +51,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
         class="css-8u32cd-boxStyles"
       >
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"
@@ -76,7 +76,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"
@@ -101,7 +101,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"
@@ -126,7 +126,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"
@@ -151,7 +151,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"
@@ -176,7 +176,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"
@@ -201,7 +201,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"
@@ -226,7 +226,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-0"
+          class="css-1tx0oac-TableRow"
         >
           <th
             class="css-1qlct29-boxStyles-TableCell"

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TableHeaderSortable with sort direction: ASC renders correctly 1`] = `
       class="css-11khhn7-boxStyles"
     >
       <tr
-        class="css-0"
+        class="css-1tx0oac-TableRow"
       >
         <th
           aria-sort="ascending"
@@ -57,7 +57,7 @@ exports[`TableHeaderSortable with sort direction: DESC renders correctly 1`] = `
       class="css-11khhn7-boxStyles"
     >
       <tr
-        class="css-0"
+        class="css-1tx0oac-TableRow"
       >
         <th
           aria-sort="descending"
@@ -105,7 +105,7 @@ exports[`TableHeaderSortable with sort direction: undefined renders correctly 1`
       class="css-11khhn7-boxStyles"
     >
       <tr
-        class="css-0"
+        class="css-1tx0oac-TableRow"
       >
         <th
           class="css-1m18mdw-boxStyles"

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -109,7 +109,8 @@ For data tables with a small amount of rows, use the default table. Align text c
 - have too many rows. Use pagination or start another table where logical – for example, an alphabetical list, Table 1: A to D, Table 2: E to H and so on
 - use bespoke styling - follow consistent layouts and styles
 - nest tables inside tables
-- don’t use inside an accorion.
+- use inside an accorion
+- set a row as invalid without adding a section alert.
 
 ## Striped
 
@@ -742,9 +743,9 @@ For more information, read the [Selectable tables with batch actions pattern](/p
 };
 ```
 
-## Row with action and error
+## Indicating an invalid row
 
-To indicate an error in a row containing an action, set the `hasRowError` prop to `true`. This should be accompanied by an section alert.
+To indicate an error in a row containing an action, set the `invalid` prop to `true`. This should be accompanied by a section alert.
 
 ```jsx live
 <Stack gap={2}>
@@ -788,7 +789,7 @@ To indicate an error in a row containing an action, set the `hasRowError` prop t
 						</Button>
 					</TableCell>
 				</TableRow>
-				<TableRow aria-rowindex={3} hasRowError={true}>
+				<TableRow aria-rowindex={3} invalid={true}>
 					<TableCell as="th" scope="row">
 						Operational Plan of Management
 					</TableCell>

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -542,7 +542,11 @@ If each table row can open a page to view more information, the cells in the fir
 				</TableCell>
 				<TableCell textAlign="right">20/06/2024</TableCell>
 				<TableCell textAlign="right">
-					<StatusBadge weight="subtle" tone="info" label="In progress" />
+					<StatusBadge
+						appearance="subtle"
+						tone="infoMedium"
+						label="In progress"
+					/>
 				</TableCell>
 				<TableCell textAlign="right">
 					<Flex gap={1}>
@@ -557,7 +561,11 @@ If each table row can open a page to view more information, the cells in the fir
 				</TableCell>
 				<TableCell textAlign="right">25/06/2024</TableCell>
 				<TableCell textAlign="right">
-					<StatusBadge weight="subtle" tone="info" label="In progress" />
+					<StatusBadge
+						appearance="subtle"
+						tone="infoMedium"
+						label="In progress"
+					/>
 				</TableCell>
 				<TableCell textAlign="right">
 					<Flex gap={1}>
@@ -572,7 +580,11 @@ If each table row can open a page to view more information, the cells in the fir
 				</TableCell>
 				<TableCell textAlign="right">02/07/2024</TableCell>
 				<TableCell textAlign="right">
-					<StatusBadge weight="subtle" tone="success" label="Completed" />
+					<StatusBadge
+						appearance="subtle"
+						tone="successMedium"
+						label="Completed"
+					/>
 				</TableCell>
 				<TableCell textAlign="right">
 					<Flex gap={1}>
@@ -587,7 +599,11 @@ If each table row can open a page to view more information, the cells in the fir
 				</TableCell>
 				<TableCell textAlign="right">05/08/2024</TableCell>
 				<TableCell textAlign="right">
-					<StatusBadge weight="subtle" tone="info" label="In progress" />
+					<StatusBadge
+						appearance="subtle"
+						tone="infoMedium"
+						label="In progress"
+					/>
 				</TableCell>
 				<TableCell textAlign="right">
 					<Flex gap={1}>
@@ -602,7 +618,11 @@ If each table row can open a page to view more information, the cells in the fir
 				</TableCell>
 				<TableCell textAlign="right">19/10/2024</TableCell>
 				<TableCell textAlign="right">
-					<StatusBadge weight="subtle" tone="success" label="Completed" />
+					<StatusBadge
+						appearance="subtle"
+						tone="successMedium"
+						label="Completed"
+					/>
 				</TableCell>
 				<TableCell textAlign="right">
 					<Flex gap={1}>
@@ -672,7 +692,7 @@ For more information, read the [Selectable tables with batch actions pattern](/p
 							{Array.from(new Array(3).keys()).map((idx) => {
 								const isRowSelected = selectedRows.includes(idx);
 								return (
-									<TableRow selected={isRowSelected}>
+									<TableRow selected={isRowSelected} key={idx}>
 										<TableCell>
 											<Checkbox
 												size="sm"
@@ -720,4 +740,96 @@ For more information, read the [Selectable tables with batch actions pattern](/p
 		</Stack>
 	);
 };
+```
+
+## Row with action and error
+
+To indicate an error in a row containing an action, set the `hasRowError` prop to `true`. This should be accompanied by an section alert.
+
+```jsx live
+<Stack gap={2}>
+	<SectionAlert title="There was an error" tone="error">
+		<UnorderedList>
+			<ListItem>
+				<TextLink href="#operational-plan-of-management-upload-button">
+					File is missing for Operational Plan of Management
+				</TextLink>
+			</ListItem>
+		</UnorderedList>
+	</SectionAlert>
+
+	<TableWrapper>
+		<Table>
+			<TableCaption>Assessment files</TableCaption>
+			<TableHead>
+				<TableRow>
+					<TableHeader scope="col">Document type</TableHeader>
+					<TableHeader scope="col">File</TableHeader>
+					<TableHeader scope="col">Size</TableHeader>
+					<TableHeader scope="col">Action</TableHeader>
+				</TableRow>
+			</TableHead>
+			<TableBody>
+				<TableRow aria-rowindex={2}>
+					<TableCell as="th" scope="row">
+						RMS Vehicle registration
+					</TableCell>
+					<TableCell>
+						<Box>filename.pdf</Box>
+					</TableCell>
+					<TableCell>88kb</TableCell>
+					<TableCell>
+						<Button
+							iconBefore={UploadIcon}
+							id="rms-vehicle-registration-upload-button"
+							variant="text"
+						>
+							Upload
+						</Button>
+					</TableCell>
+				</TableRow>
+				<TableRow aria-rowindex={3} hasRowError={true}>
+					<TableCell as="th" scope="row">
+						Operational Plan of Management
+					</TableCell>
+					<TableCell></TableCell>
+					<TableCell>
+						<StatusBadge
+							label="File missing"
+							appearance="subtle"
+							tone="errorHigh"
+						/>
+					</TableCell>
+					<TableCell>
+						<Button
+							iconBefore={UploadIcon}
+							id="operational-plan-of-management-upload-button"
+							variant="text"
+						>
+							Upload
+						</Button>
+					</TableCell>
+				</TableRow>
+				<TableRow aria-rowindex={4}>
+					<TableCell as="th" scope="row">
+						Vehicle build and layout plans
+					</TableCell>
+					<TableCell>
+						<Box>filename.pdf</Box>
+					</TableCell>
+					<TableCell>88kb</TableCell>
+					<TableCell>
+						<Button
+							iconBefore={UploadIcon}
+							id="vehicle-build-and-layout-plans-upload-button"
+							variant="text"
+						>
+							Upload
+						</Button>
+					</TableCell>
+				</TableRow>
+			</TableBody>
+		</Table>
+	</TableWrapper>
+</Stack>
 ```


### PR DESCRIPTION
Introducing `hasRowError` prop to enable a visual indicator via background colour for table rows containing an error. Updated the docs with an example and direction to incorporate a section alert.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1672)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
