### PR TITLE
button: Add focusRingFor prop to Button component

### DIFF
--- a/.changeset/wet-windows-shout.md
+++ b/.changeset/wet-windows-shout.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/react': minor
+'@ag.ds-next/docs': minor
+---
+
+button: Add `focusRingFor` prop to allow programmatic focus, e.g. via a link, to render the focus ring.

--- a/.changeset/wet-windows-shout.md
+++ b/.changeset/wet-windows-shout.md
@@ -4,3 +4,5 @@
 ---
 
 button: Add `focusRingFor` prop to allow programmatic focus, e.g. via a link, to render the focus ring.
+
+button-link: Add `focusRingFor` prop to allow programmatic focus, e.g. via a link, to render the focus ring.

--- a/.changeset/wet-windows-shout.md
+++ b/.changeset/wet-windows-shout.md
@@ -3,6 +3,4 @@
 '@ag.ds-next/docs': minor
 ---
 
-button: Add `focusRingFor` prop to allow programmatic focus, e.g. via a link, to render the focus ring.
-
-button-link: Add `focusRingFor` prop to allow programmatic focus, e.g. via a link, to render the focus ring.
+button: Add `focusRingFor` prop to allow programmatic focus, e.g. via a link, to render the focus ring. This is available for `Button` and `ButtonLink`.

--- a/docs/components/LinkComponent.tsx
+++ b/docs/components/LinkComponent.tsx
@@ -14,10 +14,13 @@ export const LinkComponent = forwardRef<HTMLAnchorElement, LinkComponentProps>(
 		// Use an `a` tag when linking externally
 		// Regex finds links starting with: `http://` | `https://` | `//`
 		const hrefAsString = typeof href === 'string' ? href : href?.pathname;
-		if (hrefAsString && /^(https?:\/\/|\/\/)/i.test(hrefAsString)) {
+		if (
+			(hrefAsString && /^(https?:\/\/|\/\/)/i.test(hrefAsString)) ||
+			hrefAsString?.includes('#')
+		) {
 			return <a ref={ref} href={hrefAsString} {...props} />;
 		}
 
-		return <Link ref={ref} href={href} {...props} />;
+		return <Link shallow ref={ref} href={href} {...props} />;
 	}
 );

--- a/docs/components/LinkComponent.tsx
+++ b/docs/components/LinkComponent.tsx
@@ -21,6 +21,6 @@ export const LinkComponent = forwardRef<HTMLAnchorElement, LinkComponentProps>(
 			return <a ref={ref} href={hrefAsString} {...props} />;
 		}
 
-		return <Link shallow ref={ref} href={href} {...props} />;
+		return <Link ref={ref} href={href} {...props} />;
 	}
 );

--- a/docs/components/LinkComponent.tsx
+++ b/docs/components/LinkComponent.tsx
@@ -15,8 +15,8 @@ export const LinkComponent = forwardRef<HTMLAnchorElement, LinkComponentProps>(
 		// Regex finds links starting with: `http://` | `https://` | `//`
 		const hrefAsString = typeof href === 'string' ? href : href?.pathname;
 		if (
-			(hrefAsString && /^(https?:\/\/|\/\/)/i.test(hrefAsString)) ||
-			hrefAsString?.includes('#')
+			hrefAsString &&
+			(/^(https?:\/\/|\/\/)/i.test(hrefAsString) || hrefAsString.includes('#'))
 		) {
 			return <a ref={ref} href={hrefAsString} {...props} />;
 		}

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -545,7 +545,7 @@ export const focusStylesAll = {
 	':focus': packs.outline,
 };
 
-const focusStylesMap = {
+export const focusStylesMap = {
 	all: focusStylesAll,
 	keyboard: focusStyles,
 };

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -2,6 +2,7 @@ import { ComponentType, forwardRef } from 'react';
 import { LinkProps, useLinkComponent } from '../core';
 import { IconProps } from '../icon';
 import { LoadingDots } from '../loading';
+import { BoxProps } from '../box';
 import {
 	buttonStyles,
 	ButtonSize,
@@ -14,6 +15,8 @@ import { BaseButton, BaseButtonProps } from './BaseButton';
 type CommonButtonProps = {
 	/** If true, the button will stretch to the fill the width of its container. */
 	block?: boolean;
+	/** Display a focus indicator when the button receives focus. By default, this is set to 'keyboard'. 'all' shows for all users, includes programmatic focus, and 'keyboard' is for keyboard-only focus. */
+	focusRingFor?: BoxProps['focusRingFor'];
 	/** The icon to display before the buttons children. */
 	iconBefore?: ComponentType<IconProps>;
 	/** The icon to display after the buttons children. */
@@ -40,6 +43,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		{
 			block = false,
 			children,
+			focusRingFor,
 			iconAfter: IconAfter,
 			iconBefore: IconBefore,
 			loading = false,
@@ -51,7 +55,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		},
 		ref
 	) {
-		const styles = buttonStyles({ block, size, variant });
+		const styles = buttonStyles({ block, focusRingFor, size, variant });
 		return (
 			<BaseButton ref={ref} css={styles} type={type} {...props}>
 				{IconBefore ? (

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -43,7 +43,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		{
 			block = false,
 			children,
-			focusRingFor,
+			focusRingFor = 'keyboard',
 			iconAfter: IconAfter,
 			iconBefore: IconBefore,
 			loading = false,
@@ -92,6 +92,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 		{
 			children,
 			block = false,
+			focusRingFor = 'keyboard',
 			iconBefore: IconBefore,
 			iconAfter: IconAfter,
 			size = 'md',
@@ -100,7 +101,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 		},
 		ref
 	) {
-		const styles = buttonStyles({ block, size, variant });
+		const styles = buttonStyles({ block, focusRingFor, size, variant });
 		const Link = useLinkComponent();
 		return (
 			<Link ref={ref} css={styles} {...props}>

--- a/packages/react/src/button/docs/overview.mdx
+++ b/packages/react/src/button/docs/overview.mdx
@@ -201,11 +201,31 @@ On mobile, buttons will be stacked on top of one another and span the full width
 A button will receive a focus ring when navigated to via the keyboard. If you need to display a focus ring outside of these interactions, e.g. when navigating to a button via a link, use the `focusRingFor` prop.
 
 ```jsx live
-<Stack gap={2} alignItems="flex-start">
+<Stack alignItems="flex-start" gap={2}>
 	<TextLink href="#focus-button-via-link">Focus the button</TextLink>
 
 	<Button focusRingFor="all" id="focus-button-via-link">
 		Upload
 	</Button>
 </Stack>
+```
+
+You can also programmatically focus a button using a `ref`.
+
+```jsx live
+() => {
+	const ref = React.useRef(null);
+
+	return (
+		<Stack alignItems="flex-start" gap={2}>
+			<Button onClick={() => ref.current.focus()} variant="secondary">
+				Focus the button
+			</Button>
+
+			<Button focusRingFor="all" ref={ref}>
+				Upload
+			</Button>
+		</Stack>
+	);
+};
 ```

--- a/packages/react/src/button/docs/overview.mdx
+++ b/packages/react/src/button/docs/overview.mdx
@@ -195,3 +195,17 @@ On mobile, buttons will be stacked on top of one another and span the full width
 	<Button variant="tertiary">Tertiary</Button>
 </ButtonGroup>
 ```
+
+## Focus ring
+
+A button will receive a focus ring when navigated to via the keyboard. If you need to display a focus ring outside of these interactions, e.g. when navigating to a button via a link, use the `focusRingFor` prop.
+
+```jsx live
+<Stack gap={2}>
+	<TextLink href="#focus-button-via-link">Focus the button</TextLink>
+
+	<Button focusRingFor="all" id="focus-button-via-link">
+		Upload
+	</Button>
+</Stack>
+```

--- a/packages/react/src/button/docs/overview.mdx
+++ b/packages/react/src/button/docs/overview.mdx
@@ -201,7 +201,7 @@ On mobile, buttons will be stacked on top of one another and span the full width
 A button will receive a focus ring when navigated to via the keyboard. If you need to display a focus ring outside of these interactions, e.g. when navigating to a button via a link, use the `focusRingFor` prop.
 
 ```jsx live
-<Stack gap={2}>
+<Stack gap={2} alignItems="flex-start">
 	<TextLink href="#focus-button-via-link">Focus the button</TextLink>
 
 	<Button focusRingFor="all" id="focus-button-via-link">

--- a/packages/react/src/button/styles.ts
+++ b/packages/react/src/button/styles.ts
@@ -1,4 +1,4 @@
-import { focusStyles } from '../box';
+import { BoxProps, focusStylesMap } from '../box';
 import { packs, boxPalette, tokens, mapSpacing } from '../core';
 
 const variants = {
@@ -95,12 +95,14 @@ export const loadingSize = {
 
 export function buttonStyles({
 	block,
-	variant,
+	focusRingFor = 'keyboard',
 	size,
+	variant,
 }: {
 	block: boolean;
-	variant: ButtonVariant;
 	size: ButtonSize;
+	variant: ButtonVariant;
+	focusRingFor?: BoxProps['focusRingFor'];
 }) {
 	return {
 		appearance: 'none',
@@ -131,7 +133,7 @@ export function buttonStyles({
 			flexShrink: 0,
 		},
 
-		...focusStyles,
+		...focusStylesMap[focusRingFor],
 		...sizes[size],
 		...variants[variant],
 	} as const;


### PR DESCRIPTION
This PR adds the `focusRingFor` prop to the `Button` component on the back of its establishment in the [custom element focus on close work recently completed in the Drawer](https://github.com/agriculturegovau/agds-next/pull/1669). This allows programmatic focusing via `.focus()`, and links, to render the focus ring. Our current use-case is for when a `SectionAlert` drives focus to a table with an action column full of the same named buttons.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1675)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
