### PR TITLE
app-layout: Fix app layout mobile side bar not closing on press of nav item

### DIFF
--- a/.changeset/selfish-bobcats-decide.md
+++ b/.changeset/selfish-bobcats-decide.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Fix sidebar not closing on item press.

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -12,6 +12,7 @@ import { Flex } from '../flex';
 import { BaseButton, BaseButtonProps } from '../button';
 import { IconProps } from '../icon';
 import { Stack } from '../stack';
+import { useAppLayoutContext } from './AppLayoutContext';
 
 type NavLink = Omit<LinkProps, 'children'>;
 
@@ -89,14 +90,16 @@ function AppLayoutSidebarNavListItem({
 }: AppLayoutSidebarNavListItemProps) {
 	const Link = useLinkComponent();
 	const { endElement, icon: Icon, label, ...restItemProps } = item;
+	const { closeMobileMenu } = useAppLayoutContext();
 
 	// Link list item
 	if ('href' in item) {
 		const active = item.href === activePath;
 		return (
 			<AppLayoutSidebarNavItemInner
-				isActive={activePath === item.href}
 				hasEndElement={Boolean(endElement)}
+				isActive={activePath === item.href}
+				onClick={closeMobileMenu}
 			>
 				<Link aria-current={active ? 'page' : undefined} {...restItemProps}>
 					{Icon ? <Icon color="inherit" /> : null}
@@ -111,8 +114,9 @@ function AppLayoutSidebarNavListItem({
 	if ('onClick' in item) {
 		return (
 			<AppLayoutSidebarNavItemInner
-				isActive={false}
 				hasEndElement={Boolean(endElement)}
+				isActive={false}
+				onClick={closeMobileMenu}
 			>
 				<BaseButton {...restItemProps}>
 					{Icon ? <Icon color="inherit" /> : null}
@@ -134,14 +138,16 @@ function AppLayoutSidebarNavListItem({
 }
 
 type AppLayoutSidebarNavItemInnerProps = PropsWithChildren<{
-	isActive: boolean;
 	hasEndElement: boolean;
+	isActive: boolean;
+	onClick?: () => void;
 }>;
 
 function AppLayoutSidebarNavItemInner({
-	isActive,
 	children,
 	hasEndElement,
+	isActive,
+	onClick,
 }: AppLayoutSidebarNavItemInnerProps) {
 	return (
 		<li
@@ -209,6 +215,7 @@ function AppLayoutSidebarNavItemInner({
 					textDecoration: 'none',
 				},
 			}}
+			onClick={onClick}
 		>
 			{children}
 		</li>

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -99,7 +99,7 @@ function AppLayoutSidebarNavListItem({
 			<AppLayoutSidebarNavItemInner
 				hasEndElement={Boolean(endElement)}
 				isActive={activePath === item.href}
-				onClick={closeMobileMenu}
+				onClick={closeMobileMenu} // Let the click event bubble up and close the menu on press of interactive item
 			>
 				<Link aria-current={active ? 'page' : undefined} {...restItemProps}>
 					{Icon ? <Icon color="inherit" /> : null}
@@ -116,7 +116,7 @@ function AppLayoutSidebarNavListItem({
 			<AppLayoutSidebarNavItemInner
 				hasEndElement={Boolean(endElement)}
 				isActive={false}
-				onClick={closeMobileMenu}
+				onClick={closeMobileMenu} // Let the click event bubble up and close the menu on press of interactive item
 			>
 				<BaseButton {...restItemProps}>
 					{Icon ? <Icon color="inherit" /> : null}


### PR DESCRIPTION
Fixes a bug where the sidebar does not close on mobile when a nav item (link or button) is pressed.

Video of closing on press now working:

https://github.com/agriculturegovau/agds-next/assets/43688949/a96d5bf1-17e2-4a11-be28-6d568f62c20c


[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1677)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [ ] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
