### PR TITLE
summary-list: increase horizontal gap in list item

### DIFF
--- a/.changeset/four-rats-hear.md
+++ b/.changeset/four-rats-hear.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+summary-list: Increase gap between SummaryListItemTerm and SummaryListItemDescription to show a clearer separation

--- a/packages/react/src/summary-list/SummaryList.tsx
+++ b/packages/react/src/summary-list/SummaryList.tsx
@@ -75,7 +75,7 @@ export function SummaryListItem({ children }: SummaryListItemProps) {
 			borderBottom
 			borderColor="muted"
 			flexDirection={['column', 'row']}
-			gap={0.25}
+			gap={0.5}
 			paddingY={0.75}
 		>
 			{children}

--- a/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
+++ b/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SummaryList renders correctly 1`] = `
     class="css-11haoc9-boxStyles"
   >
     <div
-      class="css-1gkaq3c-boxStyles"
+      class="css-balq7b-boxStyles"
     >
       <dt
         class="css-1w3kdnx-boxStyles"
@@ -30,7 +30,7 @@ exports[`SummaryList renders correctly 1`] = `
       </dd>
     </div>
     <div
-      class="css-1gkaq3c-boxStyles"
+      class="css-balq7b-boxStyles"
     >
       <dt
         class="css-1w3kdnx-boxStyles"
@@ -54,7 +54,7 @@ exports[`SummaryList renders correctly 1`] = `
       </dd>
     </div>
     <div
-      class="css-1gkaq3c-boxStyles"
+      class="css-balq7b-boxStyles"
     >
       <dt
         class="css-1w3kdnx-boxStyles"
@@ -80,7 +80,7 @@ exports[`SummaryList renders correctly 1`] = `
       </dd>
     </div>
     <div
-      class="css-1gkaq3c-boxStyles"
+      class="css-balq7b-boxStyles"
     >
       <dt
         class="css-1w3kdnx-boxStyles"


### PR DESCRIPTION
Adds extra gap for clearer separation between term and description.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1678)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
