### PR TITLE
docs: Fix playroom links returning 404

### DIFF
--- a/.changeset/smart-peas-wash.md
+++ b/.changeset/smart-peas-wash.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+docs: Fix Playroom links not working and returning not found 404 error.

--- a/.storybook/components/PageTemplate.tsx
+++ b/.storybook/components/PageTemplate.tsx
@@ -67,7 +67,7 @@ export function PageTemplate({
 								},
 								{
 									label: 'Playroom',
-									href: 'https://design-system.agriculture.gov.au/playroom/index.html',
+									href: 'https://design-system.agriculture.gov.au/playroom',
 								},
 								{
 									label: 'Starter kit',

--- a/docs/.env.production
+++ b/docs/.env.production
@@ -1,5 +1,5 @@
 SITE_URL=https://design-system.agriculture.gov.au
 NEXT_PUBLIC_FIGMA_URL=https://www.figma.com/file/MivOblJvHi3nJ4bQMDfnf3/AgDS---gallery
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-FNXK77EZLQ
-NEXT_PUBLIC_PLAYROOM_URL=/playroom/index.html
+NEXT_PUBLIC_PLAYROOM_URL=/playroom
 NEXT_PUBLIC_STORYBOOK_URL=/storybook/index.html

--- a/example-site/components/SiteFooter.tsx
+++ b/example-site/components/SiteFooter.tsx
@@ -13,7 +13,7 @@ const footerLinks = [
 	},
 	{
 		label: 'Playroom',
-		href: 'https://design-system.agriculture.gov.au/playroom/index.html',
+		href: 'https://design-system.agriculture.gov.au/playroom',
 	},
 	{
 		label: 'Starter kit',

--- a/packages/react/src/app-layout/AppLayout.stories.tsx
+++ b/packages/react/src/app-layout/AppLayout.stories.tsx
@@ -96,7 +96,7 @@ function AppLayoutTemplate({
 									},
 									{
 										label: 'Playroom',
-										href: 'https://design-system.agriculture.gov.au/playroom/index.html',
+										href: 'https://design-system.agriculture.gov.au/playroom',
 									},
 									{
 										label: 'Starter kit',

--- a/packages/react/src/app-layout/AppLayoutFooter.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutFooter.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof AppLayoutFooter> = {
 							},
 							{
 								label: 'Playroom',
-								href: 'https://design-system.agriculture.gov.au/playroom/index.html',
+								href: 'https://design-system.agriculture.gov.au/playroom',
 							},
 							{
 								label: 'Starter kit',

--- a/packages/react/src/text-link/docs/overview.mdx
+++ b/packages/react/src/text-link/docs/overview.mdx
@@ -44,7 +44,7 @@ For more information, please refer to:
 ```jsx live
 <Text>
 	Interact with our components in{' '}
-	<TextLinkExternal href="https://design-system.agriculture.gov.au/playroom/index.html">
+	<TextLinkExternal href="https://design-system.agriculture.gov.au/playroom">
 		Playroom
 	</TextLinkExternal>
 	.


### PR DESCRIPTION
This fixes broken production Playroom links such as this one from Drawer:

https://design-system.agriculture.gov.au/playroom/index.html/#?code=N4Igxg9gJgpiBcIA8AxANjAHgAgOYEMAHAXmAEYBfbAMw0wBEBLAJxjABdGIA7YgHRDMIAdwEA+Ptz7tUdSdOm0sTVhy68BkNAFcAtlJDz2iugHEhw0pSPTC+DO3Yx+INI1wALY4anH2dqChGblwrCht2ACN8MABrXCFtbigXSOgATwEjCV9pJABhfGYobABnD3woEWwwNzj8SIwchT8CoqgASW5uGGZmvxakAGV2GNi8IjD+lsGACRhK4NxsfFKXDwBmAWx2dMJnAQ8AFnEImdbC4oAZYPGPVmoXAGJxS5K3blikAHo3m8-pgNWt95osQoDzkgACpYdgQoHSK4QVi6bCMQilPTYKpoZFlRjsFa6GDsAA0NR4pTYTnY2mYKyChEYpTAS2wMDc7AAdNh8sxVthuDwzgj2NRgoxItpStgMBAuSLBt8YZg4YqZN8RmN4T83l0en0Irr2v0fugsKbzZgIkoGCxqeoXFo9AYbWYLGEInYHE4XFAirEsrl-JUgiFPcHonEEhAkikBGkoJkfNJAW1ijU6rEGk0RenOt1evC8lq4hMSOQKMXWqCw8tVustiAdnsDiBjqdg+c8n9bth7jBHgIXiAxG9ZbdjddbtW8iCFnXZzIVWqu6KkSi0RisTi8aUCUSSeTINwqRwSXSGejmayQuzOTy+QKhVI1+dxdxJdLZTB5eq5yu1Y-KWsQ6r87T6kWRrgcUprfFaORmnQYggBQQA

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1679)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
