### PR TITLE
drawer: fix elementToFocusOnClose docs

### DIFF
--- a/.changeset/smart-fireants-sniff.md
+++ b/.changeset/smart-fireants-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+drawer: Fix docs for `elementToFocusOnClose` not returning focus to button when no alert is shown.

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -553,7 +553,7 @@ export const linkStyles = {
 type FocusProps = Partial<{
 	/** @deprecated use focusRingFor="keyboard". */
 	focus: boolean;
-	/** Display a focus indicator when the element receives focus. 'all' shows for all users, includes programmatic focus, and 'keyboard' is for keyboard-only focus*/
+	/** Display a focus indicator when the element receives focus. 'all' shows for all users, includes programmatic focus, and 'keyboard' is for keyboard-only focus. */
 	focusRingFor: 'all' | 'keyboard';
 }>;
 export const focusStyles = {

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -395,7 +395,9 @@ When a drawer closes, focus is returned to the element that opened it. You can o
 						</Button>
 					</ButtonGroup>
 				}
-				elementToFocusOnClose={sectionAlertContainerRef.current}
+				elementToFocusOnClose={
+					error ? sectionAlertContainerRef.current : undefined
+				}
 				isOpen={isDrawerOpen}
 				onClose={closeDrawer}
 				title="Drawer title"


### PR DESCRIPTION
Fixes an omission from the docs for Drawer's `elementToFocusOnClose` that prevented focus being returned to the trigger button when there was no alert to focus. Also cleaned up a typo in a JSDoc from Box.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1681)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
