### PR TITLE
combobox-multi: Allow backspace to remove selected items when the popover is open

### DIFF
--- a/.changeset/purple-geese-raise.md
+++ b/.changeset/purple-geese-raise.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+combobox-multi: Allow backspace to remove selected items when the popover is open.

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -209,7 +209,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 										},
 										ref: inputRefs,
 										type: 'text',
-										preventKeyAction: combobox.isOpen,
+										preventKeyAction: false,
 										onFocus: (event: FocusEvent<HTMLInputElement>) => {
 											onFocus?.(event);
 											setInputFocused();


### PR DESCRIPTION
This PR turns off `downshift`'s `preventKeyAction` in order to allow deleting a selected item on press of backspace. As a byproduct, it allows navigating from the menu to the input without pressing "escape".

[More detail in the downshift docs](https://www.downshift-js.com/use-multiple-selection/#props-used-in-examples)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1690)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
