### PR TITLE
table: Fix textAlign support in TableHeaderSortable

### DIFF
--- a/.changeset/giant-books-raise.md
+++ b/.changeset/giant-books-raise.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+table: Fix `textAlign` support in `TableHeaderSortable`.

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -75,6 +75,8 @@ export const TableHeaderSortable = ({
 								: undefined,
 						marginRight: textAlign === 'center' ? 'auto' : undefined,
 					}}
+					// Aligns text should it wrap
+					textAlign={textAlign}
 				>
 					{children}
 				</Box>

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -40,19 +40,11 @@ export const TableHeaderSortable = ({
 				borderBottom: true,
 				borderBottomWidth: 'xl',
 			})}
-			textAlign={textAlign}
 		>
 			<Flex
-				as={BaseButton}
-				gap={0.5}
-				onClick={onClick}
-				padding={0.75}
-				color="text"
-				fontWeight="bold"
-				width="100%"
-				justifyContent="space-between"
 				alignItems="center"
-				focusRingFor="keyboard"
+				as={BaseButton}
+				color="text"
 				css={{
 					...packs.underline,
 					svg: {
@@ -66,8 +58,26 @@ export const TableHeaderSortable = ({
 						},
 					},
 				}}
+				focusRingFor="keyboard"
+				fontWeight="bold"
+				gap={0.5}
+				justifyContent="space-between"
+				onClick={onClick}
+				padding={0.75}
+				width="100%"
 			>
-				{children}
+				<Box
+					as="span"
+					css={{
+						marginLeft:
+							textAlign === 'right' || textAlign === 'center'
+								? 'auto'
+								: undefined,
+						marginRight: textAlign === 'center' ? 'auto' : undefined,
+					}}
+				>
+					{children}
+				</Box>
 				<Icon size="md" color="inherit" />
 			</Flex>
 		</Box>

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -13,14 +13,18 @@ exports[`TableHeaderSortable with sort direction: ASC renders correctly 1`] = `
       >
         <th
           aria-sort="ascending"
-          class="css-vjwr8b-boxStyles"
+          class="css-cgixy1-boxStyles"
           scope="col"
         >
           <button
             class="css-1gm7gt9-BaseButton-boxStyles-TableHeaderSortable"
             type="button"
           >
-            Example
+            <span
+              class="css-tird59-boxStyles-TableHeaderSortable"
+            >
+              Example
+            </span>
             <svg
               aria-hidden="true"
               class="css-fyxrud-Icon"
@@ -61,14 +65,18 @@ exports[`TableHeaderSortable with sort direction: DESC renders correctly 1`] = `
       >
         <th
           aria-sort="descending"
-          class="css-vjwr8b-boxStyles"
+          class="css-cgixy1-boxStyles"
           scope="col"
         >
           <button
             class="css-1gm7gt9-BaseButton-boxStyles-TableHeaderSortable"
             type="button"
           >
-            Example
+            <span
+              class="css-tird59-boxStyles-TableHeaderSortable"
+            >
+              Example
+            </span>
             <svg
               aria-hidden="true"
               class="css-fyxrud-Icon"
@@ -108,14 +116,18 @@ exports[`TableHeaderSortable with sort direction: undefined renders correctly 1`
         class="css-1tx0oac-TableRow"
       >
         <th
-          class="css-1m18mdw-boxStyles"
+          class="css-79i25n-boxStyles"
           scope="col"
         >
           <button
             class="css-1gm7gt9-BaseButton-boxStyles-TableHeaderSortable"
             type="button"
           >
-            Example
+            <span
+              class="css-tird59-boxStyles-TableHeaderSortable"
+            >
+              Example
+            </span>
             <svg
               aria-hidden="true"
               class="css-fyxrud-Icon"

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`TableHeaderSortable with sort direction: ASC renders correctly 1`] = `
             type="button"
           >
             <span
-              class="css-tird59-boxStyles-TableHeaderSortable"
+              class="css-10iwr90-boxStyles-TableHeaderSortable"
             >
               Example
             </span>
@@ -73,7 +73,7 @@ exports[`TableHeaderSortable with sort direction: DESC renders correctly 1`] = `
             type="button"
           >
             <span
-              class="css-tird59-boxStyles-TableHeaderSortable"
+              class="css-10iwr90-boxStyles-TableHeaderSortable"
             >
               Example
             </span>
@@ -124,7 +124,7 @@ exports[`TableHeaderSortable with sort direction: undefined renders correctly 1`
             type="button"
           >
             <span
-              class="css-tird59-boxStyles-TableHeaderSortable"
+              class="css-10iwr90-boxStyles-TableHeaderSortable"
             >
               Example
             </span>

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -302,7 +302,12 @@ You can see a working example of this component in the [Search filters patterns]
 				>
 					Location
 				</TableHeaderSortable>
-				<TableHeaderSortable scope="col" width="50%" onClick={console.log}>
+				<TableHeaderSortable
+					scope="col"
+					width="50%"
+					onClick={console.log}
+					textAlign="right"
+				>
 					Population
 				</TableHeaderSortable>
 			</TableRow>


### PR DESCRIPTION
This fixes `textAlign` which wasn't being respected in `TableHeaderSortable`

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1693)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets