### PR TITLE
footer, main-nav: Add borderColor props

### DIFF
--- a/.changeset/blue-oranges-allow.md
+++ b/.changeset/blue-oranges-allow.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+footer: Add `borderColor` prop to `Footer` and `color` prop to `FooterDivider`.
+
+main-nav: Add `borderColor` prop.

--- a/.changeset/blue-oranges-allow.md
+++ b/.changeset/blue-oranges-allow.md
@@ -4,4 +4,4 @@
 
 footer: Add `borderColor` prop to `Footer` and `color` prop to `FooterDivider`.
 
-main-nav: Add `borderColor` prop.
+main-nav: Add `borderColor` prop to `MainNav` and `MainNavBottomBar`.

--- a/packages/react/src/footer/Footer.stories.tsx
+++ b/packages/react/src/footer/Footer.stories.tsx
@@ -13,10 +13,10 @@ import { Footer, FooterDivider } from './';
 const meta: Meta<typeof Footer> = {
 	title: 'layout/Footer',
 	component: Footer,
-	render: function Render(props) {
+	render: function Render({ borderColor, ...props }) {
 		const year = useMemo(() => new Date().getFullYear(), []);
 		return (
-			<Footer {...props}>
+			<Footer borderColor={borderColor} {...props}>
 				<nav aria-label="footer">
 					<LinkList
 						horizontal
@@ -28,7 +28,7 @@ const meta: Meta<typeof Footer> = {
 						]}
 					/>
 				</nav>
-				<FooterDivider />
+				<FooterDivider color={borderColor} />
 				<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
 					We acknowledge the traditional owners of country throughout Australia
 					and recognise their continuing connection to land, waters and culture.

--- a/packages/react/src/footer/Footer.tsx
+++ b/packages/react/src/footer/Footer.tsx
@@ -1,26 +1,32 @@
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
+import { type BorderColor } from '../box';
+import { tokens, type ResponsiveProp } from '../core';
 import { Flex } from '../flex';
 import { Stack } from '../stack';
-import { tokens } from '../core';
 
 export type FooterProps = PropsWithChildren<{
 	background?: 'body' | 'bodyAlt';
+	borderColor?: ResponsiveProp<BorderColor>;
 }>;
 
-export const Footer = ({ background = 'body', children }: FooterProps) => {
+export const Footer = ({
+	background = 'body',
+	borderColor = 'accent',
+	children,
+}: FooterProps) => {
 	return (
 		<Flex
 			as="footer"
-			justifyContent="center"
 			background={background}
-			color="text"
-			paddingY={3}
+			borderColor={borderColor}
 			borderTop
 			borderTopWidth="xl"
-			borderColor="accent"
+			color="text"
 			css={{
 				li: { marginLeft: 0 },
 			}}
+			justifyContent="center"
+			paddingY={3}
 		>
 			<Stack
 				maxWidth={tokens.maxWidth.container}

--- a/packages/react/src/footer/FooterDivider.tsx
+++ b/packages/react/src/footer/FooterDivider.tsx
@@ -1,18 +1,20 @@
-import { boxPalette } from '../core';
+import { Box, type BorderColor } from '../box';
+import { type ResponsiveProp } from '../core';
 
-export function FooterDivider() {
+export function FooterDivider({
+	color = 'accent',
+}: {
+	color?: ResponsiveProp<BorderColor>;
+}) {
 	return (
-		<hr
+		<Box
 			aria-hidden="true"
+			as="hr"
+			borderColor={color}
+			borderTop
+			borderTopWidth="sm"
 			css={{
-				boxSizing: 'content-box',
-				height: 0,
-				margin: 0,
 				overflow: 'visible',
-				border: 'none',
-				borderTopWidth: 1,
-				borderTopStyle: 'solid',
-				borderColor: boxPalette.accent,
 				width: '100%',
 			}}
 		/>

--- a/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Footer renders correctly 1`] = `
       </nav>
       <hr
         aria-hidden="true"
-        class="css-jcokw4-FooterDivider"
+        class="css-vsn6gl-boxStyles-FooterDivider"
       />
       <span
         class="css-1oewark-boxStyles"

--- a/packages/react/src/footer/docs/code.mdx
+++ b/packages/react/src/footer/docs/code.mdx
@@ -1,3 +1,5 @@
 ## Props
 
 <ComponentPropsTable name="Footer" />
+
+<ComponentPropsTable name="FooterDivider" />

--- a/packages/react/src/main-nav/MainNav.tsx
+++ b/packages/react/src/main-nav/MainNav.tsx
@@ -1,9 +1,10 @@
-import { PropsWithChildren, Fragment } from 'react';
-import { findBestMatch, useTernaryState } from '../core';
+import { Fragment, type PropsWithChildren } from 'react';
+import { type BorderColor } from '../box';
+import { findBestMatch, type ResponsiveProp, useTernaryState } from '../core';
+import { MainNavBackground } from './localPalette';
 import { MainNavContainer } from './MainNavContainer';
 import { MainNavDialog } from './MainNavDialog';
-import { MainNavListItemType } from './MainNavList';
-import { MainNavBackground } from './localPalette';
+import { type MainNavListItemType } from './MainNavList';
 import { MainNavListDropdown } from './MainNavListItemDropdown';
 
 export type MainNavProps = PropsWithChildren<{
@@ -11,6 +12,7 @@ export type MainNavProps = PropsWithChildren<{
 	activePath?: string;
 	/** The background of the component. */
 	background?: MainNavBackground;
+	borderColor?: ResponsiveProp<BorderColor>;
 	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
 	/** List of navigation items to display. */
@@ -20,11 +22,12 @@ export type MainNavProps = PropsWithChildren<{
 }>;
 
 export function MainNav({
-	background = 'body',
 	activePath,
+	background = 'body',
+	borderColor = 'accent',
+	id,
 	items,
 	secondaryItems,
-	id,
 }: MainNavProps) {
 	const [isMobileMenuOpen, openMobileMenu, closeMobileMenu] =
 		useTernaryState(false);
@@ -37,19 +40,20 @@ export function MainNav({
 	return (
 		<Fragment>
 			<MainNavContainer
-				background={background}
-				id={id}
-				openMobileMenu={openMobileMenu}
 				activePath={bestMatch}
+				background={background}
+				borderColor={borderColor}
+				id={id}
 				items={items}
+				openMobileMenu={openMobileMenu}
 				secondaryItems={secondaryItems}
 			/>
 			{/* Mobile dialog menu */}
 			<MainNavDialog
-				isMobileMenuOpen={isMobileMenuOpen}
-				closeMobileMenu={closeMobileMenu}
-				items={items}
 				activePath={bestMatch}
+				closeMobileMenu={closeMobileMenu}
+				isMobileMenuOpen={isMobileMenuOpen}
+				items={items}
 			/>
 		</Fragment>
 	);

--- a/packages/react/src/main-nav/MainNavBottomBar.tsx
+++ b/packages/react/src/main-nav/MainNavBottomBar.tsx
@@ -2,9 +2,9 @@ import { Box, type BorderColor } from '../box';
 import { type ResponsiveProp } from '../core';
 
 export function MainNavBottomBar({
-	borderColor,
+	borderColor = 'accent',
 }: {
-	borderColor: ResponsiveProp<BorderColor>;
+	borderColor?: ResponsiveProp<BorderColor>;
 }) {
 	return <Box borderBottom borderBottomWidth="xxl" borderColor={borderColor} />;
 }

--- a/packages/react/src/main-nav/MainNavBottomBar.tsx
+++ b/packages/react/src/main-nav/MainNavBottomBar.tsx
@@ -1,5 +1,10 @@
-import { Box } from '../box';
+import { Box, type BorderColor } from '../box';
+import { type ResponsiveProp } from '../core';
 
-export function MainNavBottomBar() {
-	return <Box borderBottom borderBottomWidth="xxl" borderColor="accent" />;
+export function MainNavBottomBar({
+	borderColor,
+}: {
+	borderColor: ResponsiveProp<BorderColor>;
+}) {
+	return <Box borderBottom borderBottomWidth="xxl" borderColor={borderColor} />;
 }

--- a/packages/react/src/main-nav/MainNavContainer.tsx
+++ b/packages/react/src/main-nav/MainNavContainer.tsx
@@ -1,30 +1,32 @@
 import { useRef } from 'react';
-import { Box } from '../box';
+import { Box, type BorderColor } from '../box';
+import { packs, tokens, type ResponsiveProp } from '../core';
 import { Flex } from '../flex';
-import { tokens, packs } from '../core';
 import { setLocalPaletteVars, MainNavBackground } from './localPalette';
 import { MainNavOpenButton } from './MainNavMenuButtons';
 import { MainNavBottomBar } from './MainNavBottomBar';
-import { MainNavList, MainNavListItemType } from './MainNavList';
+import { MainNavList, type MainNavListItemType } from './MainNavList';
 import { MainNavListDropdown } from './MainNavListItemDropdown';
 import { mobileBreakpoint } from './utils';
 
 export type MainNavContainerProps = {
 	activePath: string;
 	background: MainNavBackground;
+	borderColor: ResponsiveProp<BorderColor>;
 	id?: string;
-	openMobileMenu: () => void;
 	items?: MainNavListItemType[];
+	openMobileMenu: () => void;
 	secondaryItems?: (MainNavListItemType | MainNavListDropdown)[];
 };
 
 export function MainNavContainer({
-	id,
-	background,
-	openMobileMenu,
-	items,
-	secondaryItems,
 	activePath,
+	background,
+	borderColor,
+	id,
+	items,
+	openMobileMenu,
+	secondaryItems,
 }: MainNavContainerProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	return (
@@ -59,7 +61,7 @@ export function MainNavContainer({
 					/>
 				) : null}
 			</Flex>
-			<MainNavBottomBar />
+			<MainNavBottomBar borderColor={borderColor} />
 		</Box>
 	);
 }


### PR DESCRIPTION
We recently added palette and borderColor support to AppLayout, but the standard MainNav and Footer also needs borderColor.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1694)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.