### PR TITLE
build: Add 'use client' to entrypoints to allow importing directly in server components

### DIFF
--- a/.changeset/new-parrots-love.md
+++ b/.changeset/new-parrots-love.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+build: Add `'use client'` to entrypoints so they can be imported and used directly from server components

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -53,6 +53,21 @@ const config: StorybookConfig = {
 			},
 			build: {
 				...config.build,
+				rollupOptions: {
+					...config.build?.rollupOptions,
+					onwarn(warning, defaultHandler) {
+						if (
+							warning.message.startsWith(
+								'Module level directives cause errors when bundled, "use client"'
+							) ||
+							warning.message ===
+								"Error when using sourcemap for reporting an error: Can't resolve original location of error."
+						) {
+							return;
+						}
+						defaultHandler(warning);
+					},
+				},
 				commonjsOptions: {
 					...config.build?.commonjsOptions,
 					include: [

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"@emotion/react": "^11.7.0",
 		"@faker-js/faker": "^7.6.0",
 		"@manypkg/cli": "^0.20.0",
-		"@preconstruct/cli": "^2.5.0",
+		"@preconstruct/cli": "^2.8.4",
 		"@preconstruct/next": "^4.0.0",
 		"@storybook/addon-a11y": "^7.6.7",
 		"@storybook/addon-actions": "^7.6.7",

--- a/packages/react/src/_collapsing-side-bar/index.ts
+++ b/packages/react/src/_collapsing-side-bar/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './CollapsingSideBar';
 export * from './CollapsingSideBarTitle';
 export * from './utils';

--- a/packages/react/src/_popover/index.ts
+++ b/packages/react/src/_popover/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Popover';

--- a/packages/react/src/a11y/index.ts
+++ b/packages/react/src/a11y/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './ExternalLinkCallout';
 export * from './VisuallyHidden';

--- a/packages/react/src/accordion/index.ts
+++ b/packages/react/src/accordion/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './Accordion';
 export * from './AccordionItem';

--- a/packages/react/src/ag-branding/index.ts
+++ b/packages/react/src/ag-branding/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './theme';
 export * from './Logo';

--- a/packages/react/src/app-layout/index.ts
+++ b/packages/react/src/app-layout/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './AppLayout';
 export * from './AppLayoutHeader';
 export * from './AppLayoutSidebar';

--- a/packages/react/src/autocomplete/index.ts
+++ b/packages/react/src/autocomplete/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export { Autocomplete } from './Autocomplete';
 export { AutocompleteRenderItem } from './AutocompleteRenderItem';

--- a/packages/react/src/avatar/index.ts
+++ b/packages/react/src/avatar/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Avatar';

--- a/packages/react/src/badge/index.ts
+++ b/packages/react/src/badge/index.ts
@@ -1,3 +1,4 @@
+'use client';
 import {
 	IndicatorDot as _IndicatorDot,
 	IndicatorDotProps as _IndicatorDotProps,

--- a/packages/react/src/box/index.ts
+++ b/packages/react/src/box/index.ts
@@ -1,3 +1,4 @@
+'use client';
 import { Flex as _Flex, FlexProps as _FlexProps } from '../flex';
 import { Stack as _Stack, StackProps as _StackProps } from '../stack';
 

--- a/packages/react/src/breadcrumbs/index.ts
+++ b/packages/react/src/breadcrumbs/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Breadcrumbs';
 export * from './BreadcrumbsContainer';
 export * from './BreadcrumbsDivider';

--- a/packages/react/src/button/index.ts
+++ b/packages/react/src/button/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Button';
 export * from './ButtonGroup';
 export * from './BaseButton';

--- a/packages/react/src/call-to-action/index.ts
+++ b/packages/react/src/call-to-action/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './CallToAction';

--- a/packages/react/src/callout/index.ts
+++ b/packages/react/src/callout/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './Callout';
 export * from './CalloutTitle';

--- a/packages/react/src/card/index.ts
+++ b/packages/react/src/card/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Card';
 export * from './CardFooter';
 export * from './CardHeader';

--- a/packages/react/src/checkbox/index.ts
+++ b/packages/react/src/checkbox/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Checkbox';

--- a/packages/react/src/columns/index.ts
+++ b/packages/react/src/columns/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './Columns';
 export * from './Column';

--- a/packages/react/src/combobox/index.ts
+++ b/packages/react/src/combobox/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Combobox';
 export * from './ComboboxMulti';
 export * from './ComboboxAsync';

--- a/packages/react/src/content/index.ts
+++ b/packages/react/src/content/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Content';
 export * from './PageContent';
 export * from './SectionContent';

--- a/packages/react/src/control-group/index.ts
+++ b/packages/react/src/control-group/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './ControlGroup';

--- a/packages/react/src/control-input/index.ts
+++ b/packages/react/src/control-input/index.ts
@@ -1,3 +1,4 @@
+'use client';
 import {
 	ControlGroup as _ControlGroup,
 	ControlGroupProps as _ControlGroupProps,

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Core';
 export * from './CoreProvider';
 export * from './tokens';

--- a/packages/react/src/date-picker/index.ts
+++ b/packages/react/src/date-picker/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './DatePicker';
 
 import {

--- a/packages/react/src/date-range-picker/index.ts
+++ b/packages/react/src/date-range-picker/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './DateRangePicker';

--- a/packages/react/src/details/index.ts
+++ b/packages/react/src/details/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Details';

--- a/packages/react/src/direction-link/index.ts
+++ b/packages/react/src/direction-link/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './DirectionLink';

--- a/packages/react/src/divider/index.ts
+++ b/packages/react/src/divider/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Divider';

--- a/packages/react/src/drawer/index.ts
+++ b/packages/react/src/drawer/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Drawer';

--- a/packages/react/src/dropdown-menu/index.ts
+++ b/packages/react/src/dropdown-menu/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './DropdownMenu';
 export * from './DropdownMenuButton';
 export * from './DropdownMenuContext';

--- a/packages/react/src/field/index.ts
+++ b/packages/react/src/field/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Field';
 export * from './FieldContainer';
 export * from './FieldHint';

--- a/packages/react/src/fieldset/index.ts
+++ b/packages/react/src/fieldset/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Fieldset';
 export * from './FieldsetContainer';
 export * from './FieldsetContent';

--- a/packages/react/src/file-input/index.ts
+++ b/packages/react/src/file-input/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './FileInput';

--- a/packages/react/src/file-upload/index.ts
+++ b/packages/react/src/file-upload/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './FileUpload';
 export { formatFileSize } from './utils';
 export type {

--- a/packages/react/src/filter-drawer/index.ts
+++ b/packages/react/src/filter-drawer/index.ts
@@ -1,3 +1,4 @@
+'use client';
 import { Drawer, DrawerProps } from '../drawer';
 
 /**

--- a/packages/react/src/filter-sidebar/index.ts
+++ b/packages/react/src/filter-sidebar/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './FilterSidebar';

--- a/packages/react/src/flex/index.ts
+++ b/packages/react/src/flex/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Flex';

--- a/packages/react/src/footer/index.ts
+++ b/packages/react/src/footer/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './Footer';
 export * from './FooterDivider';

--- a/packages/react/src/form-stack/index.ts
+++ b/packages/react/src/form-stack/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './FormStack';

--- a/packages/react/src/global-alert/index.ts
+++ b/packages/react/src/global-alert/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './GlobalAlert';

--- a/packages/react/src/grouped-fields/index.ts
+++ b/packages/react/src/grouped-fields/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './GroupedFields';

--- a/packages/react/src/header/index.ts
+++ b/packages/react/src/header/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './HeaderBrand';
 export * from './HeaderContainer';
 export * from './Header';

--- a/packages/react/src/heading/index.ts
+++ b/packages/react/src/heading/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Heading';

--- a/packages/react/src/hero-banner/index.ts
+++ b/packages/react/src/hero-banner/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './HeroBanner';
 export * from './HeroCategoryBanner';
 export * from './HeroSubcategoryBanner';

--- a/packages/react/src/icon/index.ts
+++ b/packages/react/src/icon/index.ts
@@ -1,3 +1,4 @@
+'use client';
 import type { IconProps as _IconProps } from './Icon';
 export type IconProps = _IconProps;
 

--- a/packages/react/src/indicator-dot/index.ts
+++ b/packages/react/src/indicator-dot/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './IndicatorDot';

--- a/packages/react/src/inpage-nav/index.ts
+++ b/packages/react/src/inpage-nav/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './InpageNav';
 export * from './InpageNavContainer';
 export * from './InpageNavItem';

--- a/packages/react/src/link-list/index.ts
+++ b/packages/react/src/link-list/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './LinkList';
 export * from './LinkListContainer';
 export * from './LinkListItem';

--- a/packages/react/src/list/index.ts
+++ b/packages/react/src/list/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './UnorderedList';
 export * from './OrderedList';
 export * from './ListItem';

--- a/packages/react/src/loading/index.ts
+++ b/packages/react/src/loading/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './LoadingBlanket';
 export * from './LoadingBlanketContainer';
 export * from './LoadingBlanketContent';

--- a/packages/react/src/main-nav/index.ts
+++ b/packages/react/src/main-nav/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './MainNav';
 export * from './MainNavBottomBar';

--- a/packages/react/src/modal/index.ts
+++ b/packages/react/src/modal/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Modal';

--- a/packages/react/src/notification-badge/index.ts
+++ b/packages/react/src/notification-badge/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './NotificationBadge';

--- a/packages/react/src/page-alert/index.ts
+++ b/packages/react/src/page-alert/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './PageAlert';
 export * from './PageAlertTitle';

--- a/packages/react/src/pagination/index.ts
+++ b/packages/react/src/pagination/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Pagination';
 export * from './PaginationButtons';
 export * from './usePagination';

--- a/packages/react/src/password-input/index.ts
+++ b/packages/react/src/password-input/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './PasswordInput';

--- a/packages/react/src/progress-indicator/index.ts
+++ b/packages/react/src/progress-indicator/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './ProgressIndicator';
 export * from './ProgressIndicatorItem';
 export * from './ProgressIndicatorItemButton';

--- a/packages/react/src/prose/index.ts
+++ b/packages/react/src/prose/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Prose';

--- a/packages/react/src/radio/index.ts
+++ b/packages/react/src/radio/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Radio';

--- a/packages/react/src/search-box/index.ts
+++ b/packages/react/src/search-box/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './SearchBox';
 export * from './SearchBoxButton';
 export * from './SearchBoxInput';

--- a/packages/react/src/search-input/index.ts
+++ b/packages/react/src/search-input/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './SearchInput';

--- a/packages/react/src/section-alert/index.ts
+++ b/packages/react/src/section-alert/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './SectionAlert';

--- a/packages/react/src/select/index.ts
+++ b/packages/react/src/select/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Select';

--- a/packages/react/src/side-nav/index.ts
+++ b/packages/react/src/side-nav/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './SideNav';

--- a/packages/react/src/skeleton/index.ts
+++ b/packages/react/src/skeleton/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './SkeletonBox';
 export * from './SkeletonHeading';
 export * from './SkeletonText';

--- a/packages/react/src/skip-link/index.ts
+++ b/packages/react/src/skip-link/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './SkipLinks';
 export * from './SkipLinkContainer';
 export * from './SkipLinkItem';

--- a/packages/react/src/stack/index.ts
+++ b/packages/react/src/stack/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Stack';

--- a/packages/react/src/status-badge/index.ts
+++ b/packages/react/src/status-badge/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './StatusBadge';

--- a/packages/react/src/sub-nav/index.ts
+++ b/packages/react/src/sub-nav/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './SubNav';
 export * from './SubNavContainer';
 export * from './SubNavList';

--- a/packages/react/src/summary-list/index.ts
+++ b/packages/react/src/summary-list/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './SummaryList';

--- a/packages/react/src/switch/index.ts
+++ b/packages/react/src/switch/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Switch';

--- a/packages/react/src/table/index.ts
+++ b/packages/react/src/table/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Table';
 export * from './TableHeader';
 export * from './TableCaption';

--- a/packages/react/src/tabs/index.ts
+++ b/packages/react/src/tabs/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './TabButton';
 export * from './TabList';
 export * from './TabPanel';

--- a/packages/react/src/tags/index.ts
+++ b/packages/react/src/tags/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Tags';
 export * from './TagsContainer';
 export * from './TagsList';

--- a/packages/react/src/task-list/index.ts
+++ b/packages/react/src/task-list/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './TaskList';
 export * from './TaskListContainer';
 export * from './TaskListHeading';

--- a/packages/react/src/text-input/index.ts
+++ b/packages/react/src/text-input/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './TextInput';

--- a/packages/react/src/text-link/index.ts
+++ b/packages/react/src/text-link/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './TextLink';
 export * from './TextLinkExternal';

--- a/packages/react/src/text/index.ts
+++ b/packages/react/src/text/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Text';

--- a/packages/react/src/textarea/index.ts
+++ b/packages/react/src/textarea/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Textarea';

--- a/packages/react/src/time-input/TimeInput.tsx
+++ b/packages/react/src/time-input/TimeInput.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	forwardRef,
 	type ChangeEvent,

--- a/packages/react/src/time-input/index.ts
+++ b/packages/react/src/time-input/index.ts
@@ -1,3 +1,2 @@
-'use client';
 export * from './TimeInput';
 export { formatTime, isValidTime } from './utils';

--- a/packages/react/src/time-input/index.ts
+++ b/packages/react/src/time-input/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './TimeInput';
 export { formatTime, isValidTime } from './utils';

--- a/packages/react/src/time-picker/TimePicker.tsx
+++ b/packages/react/src/time-picker/TimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 import { useCombobox } from 'downshift';
 import { type ComboboxProps } from '../combobox/Combobox';

--- a/packages/react/src/time-picker/index.ts
+++ b/packages/react/src/time-picker/index.ts
@@ -1,3 +1,2 @@
-'use client';
 export * from './TimePicker';
 export { formatTime, isValidTime } from '../time-input/utils';

--- a/packages/react/src/time-picker/index.ts
+++ b/packages/react/src/time-picker/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './TimePicker';
 export { formatTime, isValidTime } from '../time-input/utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4231,10 +4231,10 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
-"@preconstruct/cli@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.5.0.tgz#f66ac50aa9a3f7801efacffc8040fdf9b6d7f483"
-  integrity sha512-EIpiKdSS2KD3hvSKMftJB8jY36YNYoe1+v2u3UcLY0kutqSpxfh/kBKaYmLvXmBQhBo21ccYARB8itwFLOVKjw==
+"@preconstruct/cli@^2.8.4":
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.8.4.tgz#430ef74b84492c9fc1f05958cc2d5160d3879dcc"
+  integrity sha512-PeNDyPmrTeqRd2g2DrBzOvu0+J/KJ5iW5zqp6RNq7lk3ZHizRRc2E73G8aShuIbn3PONEtuQvm05cllTlX2/Qw==
   dependencies:
     "@babel/code-frame" "^7.5.5"
     "@babel/core" "^7.7.7"
@@ -4248,6 +4248,7 @@
     "@rollup/plugin-replace" "^2.4.1"
     builtin-modules "^3.1.0"
     chalk "^4.1.0"
+    ci-info "^3.8.0"
     dataloader "^2.0.0"
     detect-indent "^6.0.0"
     enquirer "^2.3.6"
@@ -4255,7 +4256,6 @@
     fast-deep-equal "^2.0.1"
     fast-glob "^3.2.4"
     fs-extra "^9.0.1"
-    is-ci "^2.0.0"
     is-reference "^1.2.1"
     jest-worker "^26.3.0"
     magic-string "^0.30.0"
@@ -4273,6 +4273,7 @@
     semver "^7.3.4"
     terser "^5.16.8"
     v8-compile-cache "^2.1.1"
+    zod "^3.21.4"
 
 "@preconstruct/hook@^0.4.0":
   version "0.4.0"
@@ -7535,15 +7536,15 @@ chromium-bidi@0.4.20:
   dependencies:
     mitt "3.0.1"
 
-ci-info@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
-  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
-
 ci-info@^3.1.0, ci-info@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
   integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
+
+ci-info@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
@@ -10753,13 +10754,6 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
-
-is-ci@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
-  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
-  dependencies:
-    ci-info "^2.0.0"
 
 is-ci@^3.0.1:
   version "3.0.1"
@@ -17129,6 +17123,11 @@ yup@^0.32.11:
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
+
+zod@^3.21.4:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
 
 zwitch@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
This adds `'use client'` to all the entrypoints so they can be directly imported in server components to avoid having to create a module with `'use client'` to re-export AgDS components. Obligatory note that client components still render on the server and this doesn't break server rendering. I also upgraded Preconstruct here because there have been some fixes for the `'use client'` handling since the version you're on. Also, sometimes things won't want to have `'use client'` because they're also useful on the server, I didn't find much here that would be (which is to be expected for a design system), but I did do the `time-picker` & `time-input` entrypoints differently so that `formatTime` and `isValidTime` are usable in server components as an example (otherwise they would just be client references that couldn't be called from the server, only passed to a client component and used there (though that wouldn't be very useful since a client component could just import them)).

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets

**Creating new component**

- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Preconstruct entrypoint has been created (run `yarn` in the root of the repo to do this)
- [ ] Changeset file includes a minor
- [ ] Export components for docs site and Playroom (`docs/components/designSystemComponents.tsx`)
- [ ] Add component to Kitchen Sink (`.storybook/stories/KitchenSink.tsx`)
- [ ] Add snippets to Playroom (`docs/playroom/snippets.ts`)
- [ ] Add pictogram to Docs (`docs/components/pictograms/index.tsx`)
