### PR TITLE
drawer: Add support for form tag

### DIFF
--- a/.changeset/quiet-apricots-dance.md
+++ b/.changeset/quiet-apricots-dance.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+button: Add `form` prop from native button props.
+
+drawer: Add docs and Storybook example of creating an accessible form within a drawer.

--- a/.changeset/quiet-apricots-dance.md
+++ b/.changeset/quiet-apricots-dance.md
@@ -2,6 +2,6 @@
 '@ag.ds-next/react': minor
 ---
 
-button: Add `form` prop from native button props.
+button: Add `form` prop from native button props to allow submit buttons to be connected from outside a form.
 
 drawer: Add docs and Storybook example of creating an accessible form within a drawer.

--- a/packages/react/src/button/BaseButton.tsx
+++ b/packages/react/src/button/BaseButton.tsx
@@ -25,6 +25,8 @@ export type BaseButtonProps = PropsWithChildren<{
 	disabled?: boolean;
 	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
+	/** The id of the form to attach the button to. Use in conjunction with type="submit". */
+	form?: NativeButtonProps['form'];
 	/** Function to be fired following a keydown event of the button. */
 	onKeyDown?: NativeButtonProps['onKeyDown'];
 	/** Function to be fired following a blur event of the button. */

--- a/packages/react/src/drawer/Drawer.stories.tsx
+++ b/packages/react/src/drawer/Drawer.stories.tsx
@@ -584,7 +584,7 @@ export const WithForm: Story = {
 					actions={
 						<ButtonGroup>
 							<Button type="submit" form="form-id" onClick={onSubmitForm}>
-								Submit form
+								Submit
 							</Button>
 
 							<Button variant="secondary" onClick={clearForm}>

--- a/packages/react/src/drawer/Drawer.stories.tsx
+++ b/packages/react/src/drawer/Drawer.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Fragment, useState } from 'react';
+import { FormEvent, Fragment, useState } from 'react';
 import { Button, ButtonGroup } from '../button';
 import { Checkbox } from '../checkbox';
 import { ComboboxMulti, DefaultComboboxOption } from '../combobox';
@@ -16,6 +16,7 @@ import { Select } from '../select';
 import { Stack } from '../stack';
 import { Switch } from '../switch';
 import { Text } from '../text';
+import { TextInput } from '../text-input';
 import { Drawer } from './Drawer';
 
 const meta: Meta<typeof Drawer> = {
@@ -361,7 +362,6 @@ export const FiltersWithFieldsets: Story = {
 			comboboxMulti: [],
 		};
 
-		const [filters, setFilters] = useState(initialFilterState);
 		const [formState, setFormState] = useState(initialFilterState);
 
 		const updateFormState = (formState: Partial<FormState>) => {
@@ -372,17 +372,14 @@ export const FiltersWithFieldsets: Story = {
 		};
 
 		const onApplyFiltersClick = () => {
-			setFilters(formState);
 			closeDrawer();
 		};
 
 		const onClearFiltersClick = () => {
 			setFormState(initialFilterState);
-			setFilters(initialFilterState);
 		};
 
 		const onCloseClick = () => {
-			setFormState(filters);
 			closeDrawer();
 		};
 
@@ -529,6 +526,111 @@ export const FiltersWithFieldsets: Story = {
 							</FormStack>
 						</Fieldset>
 					</Stack>
+				</Drawer>
+			</Fragment>
+		);
+	},
+};
+
+export const WithForm: Story = {
+	args: {
+		title: 'Drawer with form',
+	},
+	render: function Render(props) {
+		const [isDrawerOpen, openDrawer, closeDrawer] = useTernaryState(false);
+
+		type FormState = {
+			datePicker: Date | string | undefined;
+			number: string | undefined;
+			text: string | undefined;
+		};
+
+		const initialFilterState: FormState = {
+			datePicker: undefined,
+			number: undefined,
+			text: '',
+		};
+
+		const [filters, setFilters] = useState(initialFilterState);
+		const [formState, setFormState] = useState(initialFilterState);
+
+		const updateFormState = (formState: Partial<FormState>) => {
+			setFormState((currentState) => ({
+				...currentState,
+				...formState,
+			}));
+		};
+
+		const onSubmitForm = (event: FormEvent) => {
+			event.preventDefault();
+			setFilters(formState);
+			closeDrawer();
+		};
+
+		const onClearForm = () => {
+			setFormState(initialFilterState);
+			setFilters(initialFilterState);
+		};
+
+		const onCloseClick = () => {
+			setFormState(filters);
+			closeDrawer();
+		};
+
+		return (
+			<Fragment>
+				<Button onClick={openDrawer}>Open Drawer</Button>
+
+				<Drawer
+					isOpen={isDrawerOpen}
+					onClose={onCloseClick}
+					title={props.title}
+					actions={
+						<ButtonGroup>
+							<Button type="submit" form="form-id" onClick={onSubmitForm}>
+								Submit form
+							</Button>
+
+							<Button variant="secondary" onClick={onClearForm}>
+								Clear form
+							</Button>
+
+							<Button variant="tertiary" onClick={onCloseClick}>
+								Cancel
+							</Button>
+						</ButtonGroup>
+					}
+				>
+					<form aria-label="Example form in drawer" id="form-id" noValidate>
+						<FormStack>
+							<TextInput
+								label="Example text input"
+								onChange={(event) =>
+									updateFormState({ text: event.target.value })
+								}
+								value={formState.text}
+							/>
+
+							<TextInput
+								label="Example number input"
+								onChange={(event) =>
+									updateFormState({ number: event.target.value })
+								}
+								type="number"
+								value={formState.number}
+							/>
+
+							<DatePicker
+								label="Example date input"
+								hideOptionalLabel
+								value={formState.datePicker}
+								onChange={(value) => updateFormState({ datePicker: value })}
+								onInputChange={(value) =>
+									updateFormState({ datePicker: value })
+								}
+							/>
+						</FormStack>
+					</form>
 				</Drawer>
 			</Fragment>
 		);

--- a/packages/react/src/drawer/Drawer.stories.tsx
+++ b/packages/react/src/drawer/Drawer.stories.tsx
@@ -362,6 +362,7 @@ export const FiltersWithFieldsets: Story = {
 			comboboxMulti: [],
 		};
 
+		const [filters, setFilters] = useState(initialFilterState);
 		const [formState, setFormState] = useState(initialFilterState);
 
 		const updateFormState = (formState: Partial<FormState>) => {
@@ -372,14 +373,17 @@ export const FiltersWithFieldsets: Story = {
 		};
 
 		const onApplyFiltersClick = () => {
+			setFilters(formState);
 			closeDrawer();
 		};
 
 		const onClearFiltersClick = () => {
 			setFormState(initialFilterState);
+			setFilters(initialFilterState);
 		};
 
 		const onCloseClick = () => {
+			setFormState(filters);
 			closeDrawer();
 		};
 
@@ -551,7 +555,6 @@ export const WithForm: Story = {
 			text: '',
 		};
 
-		const [filters, setFilters] = useState(initialFilterState);
 		const [formState, setFormState] = useState(initialFilterState);
 
 		const updateFormState = (formState: Partial<FormState>) => {
@@ -563,18 +566,11 @@ export const WithForm: Story = {
 
 		const onSubmitForm = (event: FormEvent) => {
 			event.preventDefault();
-			setFilters(formState);
 			closeDrawer();
 		};
 
-		const onClearForm = () => {
+		const clearForm = () => {
 			setFormState(initialFilterState);
-			setFilters(initialFilterState);
-		};
-
-		const onCloseClick = () => {
-			setFormState(filters);
-			closeDrawer();
 		};
 
 		return (
@@ -583,7 +579,7 @@ export const WithForm: Story = {
 
 				<Drawer
 					isOpen={isDrawerOpen}
-					onClose={onCloseClick}
+					onClose={closeDrawer}
 					title={props.title}
 					actions={
 						<ButtonGroup>
@@ -591,17 +587,17 @@ export const WithForm: Story = {
 								Submit form
 							</Button>
 
-							<Button variant="secondary" onClick={onClearForm}>
+							<Button variant="secondary" onClick={clearForm}>
 								Clear form
 							</Button>
 
-							<Button variant="tertiary" onClick={onCloseClick}>
+							<Button variant="tertiary" onClick={closeDrawer}>
 								Cancel
 							</Button>
 						</ButtonGroup>
 					}
 				>
-					<form aria-label="Example form in drawer" id="form-id" noValidate>
+					<form aria-label="Example form in drawer" id="form-id">
 						<FormStack>
 							<TextInput
 								label="Example text input"
@@ -621,13 +617,13 @@ export const WithForm: Story = {
 							/>
 
 							<DatePicker
-								label="Example date input"
 								hideOptionalLabel
-								value={formState.datePicker}
+								label="Example date input"
 								onChange={(value) => updateFormState({ datePicker: value })}
 								onInputChange={(value) =>
 									updateFormState({ datePicker: value })
 								}
+								value={formState.datePicker}
 							/>
 						</FormStack>
 					</form>

--- a/packages/react/src/drawer/Drawer.stories.tsx
+++ b/packages/react/src/drawer/Drawer.stories.tsx
@@ -597,7 +597,7 @@ export const WithForm: Story = {
 						</ButtonGroup>
 					}
 				>
-					<form aria-label="Example form in drawer" id="form-id">
+					<form id="form-id">
 						<FormStack>
 							<TextInput
 								label="Example text input"

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -442,7 +442,7 @@ This will allow keyboard users to submit the form by pressing "enter" on the for
 				actions={
 					<ButtonGroup>
 						<Button type="submit" form="form-id" onClick={onSubmitForm}>
-							Submit form
+							Submit
 						</Button>
 
 						<Button variant="tertiary" onClick={closeDrawer}>

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -421,48 +421,51 @@ To create an accessible form within a drawer we need to do two things:
 
 This will allow keyboard users to submit the form by pressing "enter" on the form inputs.
 
-````jsx live
-	() => {
-		const [isDrawerOpen, openDrawer, closeDrawer] = useTernaryState(false);
-		const onSubmitForm = (event) => {
-			event.preventDefault();
+```jsx live
+() => {
+	const [isDrawerOpen, openDrawer, closeDrawer] = useTernaryState(false);
+	const onSubmitForm = (event) => {
+		event.preventDefault();
 
-			console.log('Form submitted with values:', event.target.textInput.value, event.target.numberInput.value)
-		}
+		console.log(
+			'Form submitted with values:',
+			event.target.textInput.value,
+			event.target.numberInput.value
+		);
+	};
 
-			return (<React.Fragment>
-				<Button onClick={openDrawer}>Open Drawer</Button>
+	return (
+		<React.Fragment>
+			<Button onClick={openDrawer}>Open Drawer</Button>
 
-				<Drawer
-					actions={
-						<ButtonGroup>
-							<Button type="submit" form="form-id" onClick={onSubmitForm}>
-								Submit form
-							</Button>
+			<Drawer
+				actions={
+					<ButtonGroup>
+						<Button type="submit" form="form-id" onClick={onSubmitForm}>
+							Submit form
+						</Button>
 
-							<Button variant="tertiary" onClick={onCloseClick}>
-								Cancel
-							</Button>
-						</ButtonGroup>
-					}
-						isOpen={isDrawerOpen}
-						title="Example form"
-				>
-					<form aria-label="Example form in drawer" id="form-id">
-						<FormStack>
-							<TextInput
-								label="Example text input"
-								name="textInput"
-							/>
+						<Button variant="tertiary" onClick={onCloseClick}>
+							Cancel
+						</Button>
+					</ButtonGroup>
+				}
+				isOpen={isDrawerOpen}
+				title="Example form"
+			>
+				<form aria-label="Example form in drawer" id="form-id">
+					<FormStack>
+						<TextInput label="Example text input" name="textInput" />
 
-							<TextInput
-								label="Example text input"
-								name="numberInput"
-								type="number"
-							/>
-						</FormStack>
-					</form>
-				</Drawer>
-			</React.Fragment>)}
-			```
-````
+						<TextInput
+							label="Example text input"
+							name="numberInput"
+							type="number"
+						/>
+					</FormStack>
+				</form>
+			</Drawer>
+		</React.Fragment>
+	);
+};
+```

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -423,15 +423,19 @@ This will allow keyboard users to submit the form by pressing "enter" on the for
 
 ```jsx live
 () => {
+	const formRef = React.useRef(null);
 	const [isDrawerOpen, openDrawer, closeDrawer] = useTernaryState(false);
 	const onSubmitForm = (event) => {
 		event.preventDefault();
 
 		console.log(
 			'Form submitted with values:',
-			event.target.textInput.value,
-			event.target.numberInput.value
+			// event.target.textInput.value,
+			// event.target.numberInput.value
+			new FormData(formRef.current, event.target)
 		);
+
+		closeDrawer();
 	};
 
 	return (
@@ -445,15 +449,16 @@ This will allow keyboard users to submit the form by pressing "enter" on the for
 							Submit form
 						</Button>
 
-						<Button variant="tertiary" onClick={onCloseClick}>
+						<Button variant="tertiary" onClick={closeDrawer}>
 							Cancel
 						</Button>
 					</ButtonGroup>
 				}
 				isOpen={isDrawerOpen}
+				onClose={closeDrawer}
 				title="Example form"
 			>
-				<form aria-label="Example form in drawer" id="form-id">
+				<form aria-label="Example form in drawer" id="form-id" ref={formRef}>
 					<FormStack>
 						<TextInput label="Example text input" name="textInput" />
 

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -428,12 +428,8 @@ This will allow keyboard users to submit the form by pressing "enter" on the for
 	const onSubmitForm = (event) => {
 		event.preventDefault();
 
-		console.log(
-			'Form submitted with values:',
-			// event.target.textInput.value,
-			// event.target.numberInput.value
-			new FormData(formRef.current, event.target)
-		);
+		const formData = Object.fromEntries(new FormData(formRef.current));
+		console.log('Form submitted with values:', formData);
 
 		closeDrawer();
 	};

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -454,7 +454,7 @@ This will allow keyboard users to submit the form by pressing "enter" on the for
 				onClose={closeDrawer}
 				title="Example form"
 			>
-				<form aria-label="Example form in drawer" id="form-id" ref={formRef}>
+				<form id="form-id" ref={formRef}>
 					<FormStack>
 						<TextInput label="Example text input" name="textInput" />
 

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -411,3 +411,58 @@ When a drawer closes, focus is returned to the element that opened it. You can o
 	);
 };
 ```
+
+## Using a form in the drawer
+
+To create an accessible form within a drawer we need to do two things:
+
+1. Add an `id` to the `<form>`.
+2. Pass that `id` to the primary Button's `form` prop along with `type="submit"`.
+
+This will allow keyboard users to submit the form by pressing "enter" on the form inputs.
+
+````jsx live
+	() => {
+		const [isDrawerOpen, openDrawer, closeDrawer] = useTernaryState(false);
+		const onSubmitForm = (event) => {
+			event.preventDefault();
+
+			console.log('Form submitted with values:', event.target.textInput.value, event.target.numberInput.value)
+		}
+
+			return (<React.Fragment>
+				<Button onClick={openDrawer}>Open Drawer</Button>
+
+				<Drawer
+					actions={
+						<ButtonGroup>
+							<Button type="submit" form="form-id" onClick={onSubmitForm}>
+								Submit form
+							</Button>
+
+							<Button variant="tertiary" onClick={onCloseClick}>
+								Cancel
+							</Button>
+						</ButtonGroup>
+					}
+						isOpen={isDrawerOpen}
+						title="Example form"
+				>
+					<form aria-label="Example form in drawer" id="form-id">
+						<FormStack>
+							<TextInput
+								label="Example text input"
+								name="textInput"
+							/>
+
+							<TextInput
+								label="Example text input"
+								name="numberInput"
+								type="number"
+							/>
+						</FormStack>
+					</form>
+				</Drawer>
+			</React.Fragment>)}
+			```
+````

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -414,7 +414,7 @@ When a drawer closes, focus is returned to the element that opened it. You can o
 
 ## Using a form in the drawer
 
-To create an accessible form within a drawer we need to do two things:
+To create a fully accessible form within a drawer, we must do two things:
 
 1. Add an `id` to the `<form>`.
 2. Pass that `id` to the primary Button's `form` prop along with `type="submit"`.


### PR DESCRIPTION
Associating a form's submit button with a form is typically done by nesting the button within the form. The main advantage of this is the common pattern of submitting a form by pressing "enter" when focused on a form input. The drawer's `action` prop and content composition prevents this nesting. This PR adds examples of how to create the association via the button's `form="<form-id>"` and `type="submit"` props.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1697)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
