### PR TITLE
main-nav: `Add focusMode` prop. Deprecate `MainNavBottomBar`.

### DIFF
--- a/.changeset/dirty-dryers-yawn.md
+++ b/.changeset/dirty-dryers-yawn.md
@@ -1,8 +1,5 @@
 ---
-'@ag.ds-next/react': patch
-'@ag.ds-next/example-site': patch
-'@ag.ds-next/yourgov': patch
-'@ag.ds-next/docs': patch
+'@ag.ds-next/react': minor
 ---
 
 main-nav: `Add focusMode` prop. Deprecate `MainNavBottomBar`.

--- a/.changeset/dirty-dryers-yawn.md
+++ b/.changeset/dirty-dryers-yawn.md
@@ -1,0 +1,8 @@
+---
+'@ag.ds-next/react': patch
+'@ag.ds-next/example-site': patch
+'@ag.ds-next/yourgov': patch
+'@ag.ds-next/docs': patch
+---
+
+main-nav: `Add focusMode` prop. Deprecate `MainNavBottomBar`.

--- a/.changeset/sixty-swans-tie.md
+++ b/.changeset/sixty-swans-tie.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/example-site': minor
+'@ag.ds-next/yourgov': minor
+'@ag.ds-next/docs': minor
+---
+
+Use `MainNav`’s `focusMode` prop instead of conditional `MainNavBottom` bar logic.

--- a/.storybook/components/PageTemplate.tsx
+++ b/.storybook/components/PageTemplate.tsx
@@ -7,7 +7,7 @@ import { Footer, FooterDivider } from '@ag.ds-next/react/footer';
 import { Header } from '@ag.ds-next/react/header';
 import { AvatarIcon } from '@ag.ds-next/react/icon';
 import { LinkList } from '@ag.ds-next/react/link-list';
-import { MainNav, MainNavBottomBar } from '@ag.ds-next/react/main-nav';
+import { MainNav } from '@ag.ds-next/react/main-nav';
 import { Text } from '@ag.ds-next/react/text';
 
 type PageTemplateProps = PropsWithChildren<{
@@ -32,25 +32,22 @@ export function PageTemplate({
 					heading="Export Service"
 					subline="Supporting Australian agricultural exports"
 				/>
-				{!focusMode ? (
-					<MainNav
-						id="main-nav"
-						activePath="#home"
-						items={[
-							{ label: 'Home', href: '#home' },
-							{ label: 'Category', href: '#category' },
-						]}
-						secondaryItems={[
-							{
-								label: 'Sign in',
-								href: '#sign-in',
-								endElement: <AvatarIcon color="action" />,
-							},
-						]}
-					/>
-				) : (
-					<MainNavBottomBar />
-				)}
+				<MainNav
+					focusMode={focusMode}
+					id="main-nav"
+					activePath="#home"
+					items={[
+						{ label: 'Home', href: '#home' },
+						{ label: 'Category', href: '#category' },
+					]}
+					secondaryItems={[
+						{
+							label: 'Sign in',
+							href: '#sign-in',
+							endElement: <AvatarIcon color="action" />,
+						},
+					]}
+				/>
 			</Stack>
 			<Box flexGrow={1} {...(applyMainElement && { as: 'main' })}>
 				{children}

--- a/docs/content/templates/__shared/SiteLayout.tsx
+++ b/docs/content/templates/__shared/SiteLayout.tsx
@@ -6,7 +6,7 @@ import { Footer, FooterDivider } from '@ag.ds-next/react/footer';
 import { Header } from '@ag.ds-next/react/header';
 import { LinkList } from '@ag.ds-next/react/link-list';
 import { Logo } from '@ag.ds-next/react/ag-branding';
-import { MainNav, MainNavBottomBar } from '@ag.ds-next/react/main-nav';
+import { MainNav } from '@ag.ds-next/react/main-nav';
 import { Text } from '@ag.ds-next/react/text';
 import { tokens } from '@ag.ds-next/react/core';
 import { SkipLinks } from '@ag.ds-next/react/skip-link';
@@ -43,19 +43,16 @@ export const SiteLayout = ({
 					logo={<Logo />}
 					href="#"
 				/>
-				{focusMode ? (
-					<MainNavBottomBar />
-				) : (
-					<MainNav
-						id="main-nav"
-						items={[
-							{ label: 'Menu', href: '#' },
-							{ label: 'Menu', href: '#' },
-							{ label: 'Menu', href: '#' },
-						]}
-						secondaryItems={[{ label: 'Menu', href: '#' }]}
-					/>
-				)}
+				<MainNav
+					focusMode={focusMode}
+					id="main-nav"
+					items={[
+						{ label: 'Menu', href: '#' },
+						{ label: 'Menu', href: '#' },
+						{ label: 'Menu', href: '#' },
+					]}
+					secondaryItems={[{ label: 'Menu', href: '#' }]}
+				/>
 			</Stack>
 			<Box
 				flexGrow={1}

--- a/example-site/components/SiteHeader.tsx
+++ b/example-site/components/SiteHeader.tsx
@@ -3,7 +3,7 @@ import { Logo } from '@ag.ds-next/react/ag-branding';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Header } from '@ag.ds-next/react/header';
 import { AvatarIcon } from '@ag.ds-next/react/icon';
-import { MainNav, MainNavBottomBar } from '@ag.ds-next/react/main-nav';
+import { MainNav } from '@ag.ds-next/react/main-nav';
 import { SiteHeaderSearch } from './SiteHeaderSearch';
 
 const NAV_ITEMS = {
@@ -32,16 +32,13 @@ export const SiteHeader = ({ focusMode }: { focusMode: boolean }) => {
 				rightContent={<SiteHeaderSearch />}
 			/>
 
-			{!focusMode ? (
-				<MainNav
-					id="main-nav"
-					activePath={router.asPath}
-					items={NAV_ITEMS.primary}
-					secondaryItems={NAV_ITEMS.secondary}
-				/>
-			) : (
-				<MainNavBottomBar />
-			)}
+			<MainNav
+				activePath={router.asPath}
+				focusMode={focusMode}
+				id="main-nav"
+				items={NAV_ITEMS.primary}
+				secondaryItems={NAV_ITEMS.secondary}
+			/>
 		</Stack>
 	);
 };

--- a/packages/react/src/main-nav/MainNav.stories.tsx
+++ b/packages/react/src/main-nav/MainNav.stories.tsx
@@ -17,7 +17,6 @@ import { AvatarIcon, EmailIcon, ExitIcon } from '../icon';
 import { NotificationBadge } from '../notification-badge';
 import { SearchInput } from '../search-input';
 import { MainNav } from './MainNav';
-import { MainNavBottomBar } from './MainNavBottomBar';
 
 const meta: Meta<typeof MainNav> = {
 	title: 'navigation/MainNav',
@@ -192,8 +191,6 @@ export const EndElement: Story = {
 		],
 	},
 };
-
-export const BottomBar = () => <MainNavBottomBar />;
 
 export const WithHeaderAndDropdown: Story = {
 	parameters: {

--- a/packages/react/src/main-nav/MainNav.tsx
+++ b/packages/react/src/main-nav/MainNav.tsx
@@ -13,6 +13,8 @@ export type MainNavProps = PropsWithChildren<{
 	/** The background of the component. */
 	background?: MainNavBackground;
 	borderColor?: ResponsiveProp<BorderColor>;
+	/** When true, removes all navigation items to reduce distractions.  */
+	focusMode?: boolean;
 	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
 	/** List of navigation items to display. */
@@ -25,6 +27,7 @@ export function MainNav({
 	activePath,
 	background = 'body',
 	borderColor = 'accent',
+	focusMode = false,
 	id,
 	items,
 	secondaryItems,
@@ -43,6 +46,7 @@ export function MainNav({
 				activePath={bestMatch}
 				background={background}
 				borderColor={borderColor}
+				focusMode={focusMode}
 				id={id}
 				items={items}
 				openMobileMenu={openMobileMenu}

--- a/packages/react/src/main-nav/MainNavBottomBar.tsx
+++ b/packages/react/src/main-nav/MainNavBottomBar.tsx
@@ -1,6 +1,11 @@
 import { Box, type BorderColor } from '../box';
 import { type ResponsiveProp } from '../core';
 
+/**
+ * @deprecated
+ * Use `focusMode={true}` on `MainNav` instead.
+ * This will be removed in the next major version.
+ */
 export function MainNavBottomBar({
 	borderColor = 'accent',
 }: {

--- a/packages/react/src/main-nav/MainNavContainer.tsx
+++ b/packages/react/src/main-nav/MainNavContainer.tsx
@@ -4,7 +4,6 @@ import { packs, tokens, type ResponsiveProp } from '../core';
 import { Flex } from '../flex';
 import { setLocalPaletteVars, MainNavBackground } from './localPalette';
 import { MainNavOpenButton } from './MainNavMenuButtons';
-import { MainNavBottomBar } from './MainNavBottomBar';
 import { MainNavList, type MainNavListItemType } from './MainNavList';
 import { MainNavListDropdown } from './MainNavListItemDropdown';
 import { mobileBreakpoint } from './utils';
@@ -13,6 +12,7 @@ export type MainNavContainerProps = {
 	activePath: string;
 	background: MainNavBackground;
 	borderColor: ResponsiveProp<BorderColor>;
+	focusMode?: boolean;
 	id?: string;
 	items?: MainNavListItemType[];
 	openMobileMenu: () => void;
@@ -23,6 +23,7 @@ export function MainNavContainer({
 	activePath,
 	background,
 	borderColor,
+	focusMode = false,
 	id,
 	items,
 	openMobileMenu,
@@ -31,9 +32,6 @@ export function MainNavContainer({
 	const containerRef = useRef<HTMLDivElement>(null);
 	return (
 		<Box
-			id={id}
-			tabIndex={-1}
-			ref={containerRef}
 			background={background}
 			color="text"
 			css={[
@@ -41,27 +39,34 @@ export function MainNavContainer({
 				setLocalPaletteVars(background),
 				packs.print.hidden,
 			]}
+			id={id}
+			ref={containerRef}
+			tabIndex={-1}
 		>
-			<Flex
-				justifyContent="space-between"
-				maxWidth={tokens.maxWidth.container}
-				paddingX={{ xs: 0.75, [mobileBreakpoint]: 2 }}
-				width="100%"
-				minHeight={{ xs: '5rem', [mobileBreakpoint]: '3.5rem' }}
-				css={{ margin: '0 auto' }}
-			>
-				{items?.length ? <MainNavOpenButton onClick={openMobileMenu} /> : null}
-				<MainNavList type="primary" items={items} activePath={activePath} />
-				{secondaryItems?.length ? (
-					<MainNavList
-						aria-label="Supplementary"
-						type="secondary"
-						items={secondaryItems}
-						activePath={activePath}
-					/>
-				) : null}
-			</Flex>
-			<MainNavBottomBar borderColor={borderColor} />
+			{!focusMode && (
+				<Flex
+					css={{ margin: '0 auto' }}
+					justifyContent="space-between"
+					maxWidth={tokens.maxWidth.container}
+					minHeight={{ xs: '5rem', [mobileBreakpoint]: '3.5rem' }}
+					paddingX={{ xs: 0.75, [mobileBreakpoint]: 2 }}
+					width="100%"
+				>
+					{items?.length ? (
+						<MainNavOpenButton onClick={openMobileMenu} />
+					) : null}
+					<MainNavList activePath={activePath} items={items} type="primary" />
+					{secondaryItems?.length ? (
+						<MainNavList
+							activePath={activePath}
+							aria-label="Supplementary"
+							items={secondaryItems}
+							type="secondary"
+						/>
+					) : null}
+				</Flex>
+			)}
+			<Box borderBottom borderBottomWidth="xxl" borderColor={borderColor} />
 		</Box>
 	);
 }

--- a/packages/react/src/main-nav/docs/code.mdx
+++ b/packages/react/src/main-nav/docs/code.mdx
@@ -1,5 +1,3 @@
 ## Props
 
 <ComponentPropsTable name="MainNav" />
-
-<ComponentPropsTable name="MainNavBottomBar" />

--- a/packages/react/src/main-nav/docs/overview.mdx
+++ b/packages/react/src/main-nav/docs/overview.mdx
@@ -4,7 +4,7 @@ description: The main nav is the primary way users navigate the user interface. 
 group: Navigation
 storybookPath: /story/navigation-mainnav--body
 figmaGalleryNodeId: 11978%3A107135
-relatedComponents: ['header']
+relatedComponents: ['app-layout', 'header']
 ---
 
 ```jsx live
@@ -131,4 +131,29 @@ Secondary items can also display a [Dropdown menu](/components/dropdown-menu) by
 		</Box>
 	);
 };
+```
+
+## Focus mode
+
+Focus mode refers to temporarily hiding the main navigation of a website or application to reduce distractions and cognitive load.
+
+```jsx live
+<Box palette="dark">
+	<MainNav
+		activePath="#home"
+		items={[
+			{ href: '#home', label: 'Home' },
+			{ href: '#about', label: 'About' },
+			{ href: '#contact', label: 'Contact' },
+		]}
+		secondaryItems={[
+			{
+				href: '#sign-in',
+				label: 'Sign in',
+				endElement: <AvatarIcon color="action" />,
+			},
+		]}
+		focusMode={true}
+	/>
+</Box>
 ```

--- a/yourgov/components/Layout/SiteLayout.tsx
+++ b/yourgov/components/Layout/SiteLayout.tsx
@@ -9,7 +9,7 @@ import { Logo } from '@ag.ds-next/react/ag-branding';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Header } from '@ag.ds-next/react/header';
 import { AvatarIcon } from '@ag.ds-next/react/icon';
-import { MainNav, MainNavBottomBar } from '@ag.ds-next/react/main-nav';
+import { MainNav } from '@ag.ds-next/react/main-nav';
 import { Text } from '@ag.ds-next/react/text';
 import { LinkList } from '@ag.ds-next/react/link-list';
 import { useAuth } from '../../lib/useAuth';
@@ -102,16 +102,13 @@ const SiteHeader = ({ focusMode }: { focusMode: boolean }) => {
 				heading="yourGov"
 				subline="Access government services from one place"
 			/>
-			{!focusMode ? (
-				<MainNav
-					id="main-nav"
-					activePath={asPath}
-					items={navItems.primary}
-					secondaryItems={navItems.secondary}
-				/>
-			) : (
-				<MainNavBottomBar />
-			)}
+			<MainNav
+				activePath={asPath}
+				focusMode={focusMode}
+				id="main-nav"
+				items={navItems.primary}
+				secondaryItems={navItems.secondary}
+			/>
 		</Stack>
 	);
 };


### PR DESCRIPTION
`AppLayout` supports `focusMode`, as does Main nav in Figma, yet weirdly, `MainNav` in code required consumers to manually render either the main nav or the bottom bar depending on whether it should be in focus mode.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1698)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets