### PR TITLE
app-layout-header: Add co-branding

### DIFF
--- a/.changeset/brown-suns-end.md
+++ b/.changeset/brown-suns-end.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+app-layout: Add co-branding to the `AppLayoutHeader` via `secondHref`, `secondLogo`, and `dividerPosition` props.
+
+header: Fix spacing on desktop and divider not being hidden when wrapping to a second line.

--- a/.changeset/brown-suns-end.md
+++ b/.changeset/brown-suns-end.md
@@ -2,6 +2,6 @@
 '@ag.ds-next/react': minor
 ---
 
-app-layout: Add co-branding to the `AppLayoutHeader` via `secondHref`, `secondLogo`, and `dividerPosition` props.
+app-layout: Add co-branding to the `AppLayoutHeader` via `secondHref`, `secondLogo`, and `dividerPosition` props. Fix divider width.
 
 header: Fix spacing on desktop and divider not being hidden when wrapping to a second line.

--- a/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
@@ -107,11 +107,6 @@ export const WithAccountLinkLongName: Story = {
 
 export const CoBranding: Story = {
 	args: {
-		accountDetails: {
-			name: exampleData.userNames.long,
-			secondaryText: exampleData.businessNames.regular[0],
-			href: '#',
-		},
 		secondHref: '/',
 		secondLogo: <AISLogo />,
 	},

--- a/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Logo } from '../ag-branding';
+import { AISLogo } from '../../../../.storybook/components/AISLogo';
 import { AppLayout } from './AppLayout';
 import { AppLayoutHeader } from './AppLayoutHeader';
 import { ExampleAccountDropdown, exampleData } from './test-utils';
@@ -30,6 +31,8 @@ const meta: Meta<typeof AppLayoutHeader> = {
 		href: '/',
 		logo: <Logo />,
 		subLine: 'Supporting Australian agricultural exports',
+		secondHref: '/',
+		secondLogo: <AISLogo />,
 	},
 	render: (props) => (
 		<AppLayout focusMode={false}>

--- a/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
@@ -31,8 +31,6 @@ const meta: Meta<typeof AppLayoutHeader> = {
 		href: '/',
 		logo: <Logo />,
 		subLine: 'Supporting Australian agricultural exports',
-		secondHref: '/',
-		secondLogo: <AISLogo />,
 	},
 	render: (props) => (
 		<AppLayout focusMode={false}>
@@ -104,5 +102,37 @@ export const WithAccountLinkLongName: Story = {
 			secondaryText: exampleData.businessNames.regular[0],
 			href: '#',
 		},
+	},
+};
+
+export const CoBranding: Story = {
+	args: {
+		accountDetails: {
+			name: exampleData.userNames.long,
+			secondaryText: exampleData.businessNames.regular[0],
+			href: '#',
+		},
+		secondHref: '/',
+		secondLogo: <AISLogo />,
+	},
+};
+
+export const CoBrandingDividerPositionBetween: Story = {
+	args: {
+		dividerPosition: 'between',
+		secondHref: '/',
+		secondLogo: <AISLogo />,
+	},
+};
+
+export const CoBrandingWithAccountDetails: Story = {
+	args: {
+		accountDetails: {
+			name: exampleData.userNames.long,
+			secondaryText: exampleData.businessNames.regular[0],
+			href: '#',
+		},
+		secondHref: '/',
+		secondLogo: <AISLogo />,
 	},
 };

--- a/packages/react/src/app-layout/AppLayoutHeader.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.tsx
@@ -23,6 +23,8 @@ export type AppLayoutHeaderProps = {
 	/** Used to indicate if an application is in a prerelease state. */
 	badgeLabel?: string;
 	borderColor?: ResponsiveProp<BorderColor>;
+	/** When using two logos, position the horizontal dividing line 'between' the logos or 'after' them. */
+	dividerPosition?: 'after' | 'between';
 	/** The heading should be set to the website or service title. */
 	heading: string;
 	/**  The href to link to, for example "/". */
@@ -32,6 +34,10 @@ export type AppLayoutHeaderProps = {
 	/** The logo to display. */
 	logo: JSX.Element;
 	palette?: ResponsiveProp<BoxPalette>;
+	/** The href to link to, for example "/". */
+	secondHref?: string;
+	/** The second logo to display for co-branding. */
+	secondLogo?: JSX.Element;
 	/** Used to provide additional information to describe your website or service. */
 	subLine?: string;
 };
@@ -41,11 +47,14 @@ export function AppLayoutHeader({
 	background = 'bodyAlt',
 	badgeLabel,
 	borderColor = 'accent',
+	dividerPosition = 'after',
 	heading,
 	href,
 	id,
 	logo,
 	palette = 'dark',
+	secondHref,
+	secondLogo,
 	subLine,
 }: AppLayoutHeaderProps) {
 	return (
@@ -74,9 +83,13 @@ export function AppLayoutHeader({
 			>
 				<AppLayoutHeaderBrand
 					badgeLabel={badgeLabel}
+					dividerPosition={dividerPosition}
+					hasAccountDetails={Boolean(accountDetails)}
 					heading={heading}
 					href={href}
 					logo={logo}
+					secondHref={secondHref}
+					secondLogo={secondLogo}
 					subLine={subLine}
 				/>
 				<Box

--- a/packages/react/src/app-layout/AppLayoutHeader.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { Box, type BorderColor } from '../box';
 import { Flex } from '../flex';
 import { tokens, type BoxPalette, type ResponsiveProp } from '../core';
@@ -32,12 +32,12 @@ export type AppLayoutHeaderProps = {
 	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
 	/** The logo to display. */
-	logo: JSX.Element;
+	logo: ReactElement;
 	palette?: ResponsiveProp<BoxPalette>;
 	/** The href to link to, for example "/". */
 	secondHref?: string;
 	/** The second logo to display for co-branding. */
-	secondLogo?: JSX.Element;
+	secondLogo?: ReactElement;
 	/** Used to provide additional information to describe your website or service. */
 	subLine?: string;
 };

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -9,24 +9,138 @@ import {
 } from '../core';
 import { Text } from '../text';
 import { Box } from '../box';
+import { Stack } from '../stack';
+import { AppLayoutHeaderProps } from './AppLayoutHeader';
+
+const GAP_REM = 1.5;
 
 export type AppLayoutHeaderBrandProps = {
 	href: string;
 	logo: JSX.Element;
+	hasAccountDetails: boolean;
 	heading: string;
-	subLine?: string;
 	badgeLabel?: string;
+	dividerPosition?: AppLayoutHeaderProps['dividerPosition'];
+	secondHref?: AppLayoutHeaderProps['secondHref'];
+	secondLogo?: AppLayoutHeaderProps['secondLogo'];
+	subLine?: string;
 };
 
 export function AppLayoutHeaderBrand({
-	heading,
-	subLine,
 	badgeLabel,
+	dividerPosition,
 	logo,
+	heading,
+	hasAccountDetails,
 	href,
+	secondHref,
+	secondLogo,
+	subLine,
 }: AppLayoutHeaderBrandProps) {
 	const Link = useLinkComponent();
-	return (
+
+	return logo && secondLogo ? (
+		<Flex
+			css={{ overflow: 'hidden' }}
+			flexDirection={{ xs: 'column', lg: 'row' }}
+			flexWrap={{ xs: 'wrap', xl: 'nowrap' }}
+			gap={GAP_REM}
+			inline
+			paddingY={1}
+		>
+			<Flex
+				css={{
+					marginRight:
+						hasAccountDetails && dividerPosition === 'after'
+							? mapSpacing(GAP_REM)
+							: 0,
+				}} // Create a gap when there is right content
+				flexDirection={{ xs: 'column', sm: 'row' }}
+				flexShrink={0}
+				gap={GAP_REM}
+			>
+				<Flex
+					as={Link}
+					color="text"
+					css={{
+						' img, svg': { height: '3.75rem' },
+						...packs.print.hidden,
+					}}
+					focusRingFor="keyboard"
+					href={href}
+				>
+					{logo}
+				</Flex>
+
+				{dividerPosition === 'between' && (
+					<DividingLine dividerPosition={dividerPosition} />
+				)}
+
+				<Flex
+					alignSelf={{ xs: 'start', sm: 'center' }}
+					as={secondHref ? Link : 'span'}
+					color="text"
+					css={{
+						' img, svg': { width: '100%' },
+						...packs.print.hidden,
+					}}
+					focusRingFor="keyboard"
+					{...(secondHref && { href: secondHref })}
+				>
+					{secondLogo}
+				</Flex>
+			</Flex>
+
+			<Flex
+				css={
+					dividerPosition === 'after'
+						? {
+								[tokens.mediaQuery.min.lg]: {
+									marginLeft: `calc(-${
+										hasAccountDetails ? mapSpacing(GAP_REM) : 0 // Offset the gap when there is right content
+									} - ${tokens.borderWidth.sm}px)`, // Hide the divider when the heading text flows to the second row
+								},
+						  }
+						: undefined
+				}
+				gap={GAP_REM}
+			>
+				{dividerPosition === 'after' && (
+					<DividingLine dividerPosition={dividerPosition} />
+				)}
+
+				<Stack
+					as={Link}
+					color="text"
+					css={{
+						textDecoration: 'none',
+						':hover': packs.underline,
+					}}
+					focusRingFor="keyboard"
+					href={href}
+					justifyContent="center"
+				>
+					<Flex alignItems="flex-start" gap={0.5}>
+						<Text fontSize="lg" fontWeight="bold">
+							{heading}
+						</Text>
+
+						{badgeLabel && (
+							<AppLayoutHeaderBrandBadge>
+								{badgeLabel}
+							</AppLayoutHeaderBrandBadge>
+						)}
+					</Flex>
+
+					{subLine && (
+						<Text color="muted" fontSize="xs">
+							{subLine}
+						</Text>
+					)}
+				</Stack>
+			</Flex>
+		</Flex>
+	) : (
 		<Flex
 			as={Link}
 			href={href}
@@ -44,6 +158,7 @@ export function AppLayoutHeaderBrand({
 			}}
 		>
 			{logo}
+
 			<Flex
 				flexDirection="column"
 				justifyContent="center"
@@ -64,15 +179,17 @@ export function AppLayoutHeaderBrand({
 					<Text fontSize="lg" fontWeight="bold">
 						{heading}
 					</Text>
+
 					{badgeLabel && (
 						<AppLayoutHeaderBrandBadge>{badgeLabel}</AppLayoutHeaderBrandBadge>
 					)}
 				</Flex>
-				{subLine ? (
+
+				{subLine && (
 					<Text color="muted" fontSize="xs">
 						{subLine}
 					</Text>
-				) : null}
+				)}
 			</Flex>
 		</Flex>
 	);
@@ -104,3 +221,21 @@ function AppLayoutHeaderBrandBadge({
 		</Box>
 	);
 }
+
+const DividingLine = ({
+	dividerPosition,
+}: Pick<AppLayoutHeaderBrandProps, 'dividerPosition'>) => (
+	<Box
+		css={{
+			borderLeft: boxPalette.border,
+			borderLeftStyle: 'solid',
+			borderLeftColor: boxPalette.border,
+			...packs.print.hidden,
+		}}
+		display={{
+			xs: 'none',
+			sm: dividerPosition === 'between' ? 'block' : undefined,
+			lg: 'block',
+		}}
+	/>
+);

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -13,6 +13,7 @@ import { Stack } from '../stack';
 import { AppLayoutHeaderProps } from './AppLayoutHeader';
 
 const GAP_REM = 1.5;
+const LOGO_HEIGHT = '3.75rem';
 
 export type AppLayoutHeaderBrandProps = {
 	href: string;
@@ -44,7 +45,7 @@ export function AppLayoutHeaderBrand({
 			css={{ overflow: 'hidden' }}
 			flexDirection={{ xs: 'column', lg: 'row' }}
 			flexWrap={{ xs: 'wrap', xl: 'nowrap' }}
-			gap={GAP_REM}
+			gap={{ xs: 1, md: GAP_REM }}
 			inline
 			paddingY={1}
 		>
@@ -63,7 +64,7 @@ export function AppLayoutHeaderBrand({
 					as={Link}
 					color="text"
 					css={{
-						' img, svg': { height: '3.75rem' },
+						' img, svg': { height: LOGO_HEIGHT },
 						...packs.print.hidden,
 					}}
 					focusRingFor="keyboard"
@@ -154,7 +155,7 @@ export function AppLayoutHeaderBrand({
 				textDecoration: 'none',
 				'&:hover': packs.underline,
 				// Logo styles
-				svg: { display: 'block', height: '3.75rem', flexShrink: 0 },
+				svg: { display: 'block', height: LOGO_HEIGHT, flexShrink: 0 },
 			}}
 		>
 			{logo}

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -222,10 +222,8 @@ const DividingLine = ({
 	singleLogo?: boolean;
 }) => (
 	<Box
+		borderLeft
 		css={{
-			borderLeft: boxPalette.border,
-			borderLeftStyle: 'solid',
-			borderLeftColor: boxPalette.border,
 			margin: singleLogo ? '0 1rem' : undefined,
 			...packs.print.hidden,
 		}}
@@ -238,6 +236,6 @@ const DividingLine = ({
 						lg: 'block',
 				  }
 		}
-		height={singleLogo ? '3.5rem' : undefined}
+		height={singleLogo ? LOGO_HEIGHT : undefined}
 	/>
 );

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactElement } from 'react';
 import { Flex } from '../flex';
 import {
 	boxPalette,
@@ -17,7 +17,7 @@ const LOGO_HEIGHT = '3.75rem';
 
 export type AppLayoutHeaderBrandProps = {
 	href: string;
-	logo: JSX.Element;
+	logo: ReactElement;
 	hasAccountDetails: boolean;
 	heading: string;
 	badgeLabel?: string;
@@ -160,21 +160,13 @@ export function AppLayoutHeaderBrand({
 		>
 			{logo}
 
+			<DividingLine singleLogo />
+
 			<Flex
 				flexDirection="column"
 				justifyContent="center"
 				alignItems="flex-start"
 				maxWidth={tokens.maxWidth.bodyText}
-				css={{
-					// Border between logo and heading/subLine
-					[tokens.mediaQuery.min.md]: {
-						paddingLeft: mapSpacing(1),
-						marginLeft: mapSpacing(1),
-						borderLeft: boxPalette.border,
-						borderLeftStyle: 'solid',
-						borderLeftColor: boxPalette.border,
-					},
-				}}
 			>
 				<Flex alignItems="flex-start" gap={0.5}>
 					<Text fontSize="lg" fontWeight="bold">
@@ -225,18 +217,27 @@ function AppLayoutHeaderBrandBadge({
 
 const DividingLine = ({
 	dividerPosition,
-}: Pick<AppLayoutHeaderBrandProps, 'dividerPosition'>) => (
+	singleLogo,
+}: Pick<AppLayoutHeaderBrandProps, 'dividerPosition'> & {
+	singleLogo?: boolean;
+}) => (
 	<Box
 		css={{
 			borderLeft: boxPalette.border,
 			borderLeftStyle: 'solid',
 			borderLeftColor: boxPalette.border,
+			margin: singleLogo ? '0 1rem' : undefined,
 			...packs.print.hidden,
 		}}
-		display={{
-			xs: 'none',
-			sm: dividerPosition === 'between' ? 'block' : undefined,
-			lg: 'block',
-		}}
+		display={
+			singleLogo
+				? { xs: 'none', md: 'block' }
+				: {
+						xs: 'none',
+						sm: dividerPosition === 'between' ? 'block' : undefined,
+						lg: 'block',
+				  }
+		}
+		height={singleLogo ? '3.5rem' : undefined}
 	/>
 );

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -47,7 +47,10 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </svg>
           <div
-            class="css-1l41q-boxStyles-AppLayoutHeaderBrand"
+            class="css-iwg4xq-boxStyles-DividingLine"
+          />
+          <div
+            class="css-udlvh9-boxStyles"
           >
             <div
               class="css-1qp4da6-boxStyles"

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </svg>
           <div
-            class="css-iwg4xq-boxStyles-DividingLine"
+            class="css-u8206f-boxStyles-DividingLine"
           />
           <div
             class="css-udlvh9-boxStyles"

--- a/packages/react/src/app-layout/docs/overview.mdx
+++ b/packages/react/src/app-layout/docs/overview.mdx
@@ -44,6 +44,12 @@ The app layout header tells users what application they’re using and displays 
 
 - **Account details** - A user’s name and avatar or entity information should be displayed in the top right corner to clearly show which account they’re signed in to. Users can access their account settings via the dropdown.
 
+### Co-branding
+
+The app layout header component can be used with no logo, one logo, or two logos when the [Australian Government Brand Guidelines](https://www.pmc.gov.au/publications/australian-government-branding-guildelines) for Program or International branding are met. Each logo can be a link when an `href` and `secondHref` are defined.
+
+_Note: The first logo’s `href` will be assigned to the `heading` and `subLine` text as well._
+
 ## App layout sidebar
 
 The app layout sidebar houses the main navigational menu which provides users with a consistent way to navigate around a web application.

--- a/packages/react/src/header/Header.tsx
+++ b/packages/react/src/header/Header.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Column } from '../columns';
 import { packs } from '../core';
 import { HeaderBrand } from './HeaderBrand';
@@ -16,13 +16,13 @@ export type HeaderProps = {
 	/** The href to link to, for example "/". */
 	href?: string;
 	/** The logo to display. */
-	logo?: JSX.Element;
+	logo?: ReactElement;
 	/** Content to placed on the right side of the Header. */
 	rightContent?: ReactNode;
 	/** The href to link to, for example "/". */
 	secondHref?: string;
 	/** The second logo to display for co-branding. */
-	secondLogo?: JSX.Element;
+	secondLogo?: ReactElement;
 	/** The size of the Header controls the vertical height. */
 	size?: 'sm' | 'md';
 	/** Used to provide additional information to describe your website or service. */

--- a/packages/react/src/header/HeaderBrand.tsx
+++ b/packages/react/src/header/HeaderBrand.tsx
@@ -29,7 +29,7 @@ type HeaderBrandProps = Pick<
 
 export function HeaderBrand({
 	badgeLabel,
-	dividerPosition,
+	dividerPosition = 'after',
 	hasRightContent,
 	heading,
 	href = '/',
@@ -99,10 +99,10 @@ export function HeaderBrand({
 				css={
 					dividerPosition === 'after'
 						? {
-								[`${tokens.mediaQuery.min.lg}`]: {
+								[tokens.mediaQuery.min.lg]: {
 									marginLeft: `calc(-${
 										hasRightContent ? mapSpacing(GAP_REM) : 0 // Offset the gap when there is right content
-									} -${tokens.borderWidth.sm}px)`, // Hide the divider when the heading text flows to the second row
+									} - ${tokens.borderWidth.sm}px)`, // Hide the divider when the heading text flows to the second row
 								},
 						  }
 						: undefined

--- a/packages/react/src/header/HeaderBrand.tsx
+++ b/packages/react/src/header/HeaderBrand.tsx
@@ -29,7 +29,7 @@ type HeaderBrandProps = Pick<
 
 export function HeaderBrand({
 	badgeLabel,
-	dividerPosition = 'after',
+	dividerPosition,
 	hasRightContent,
 	heading,
 	href = '/',


### PR DESCRIPTION
Matching the co-branding (second href, second logo) implementation from the `Header` component. This one is slightly different so as to fit the structure + styles of the app layout. Also fixed a bug I noticed on the `Header` where a `calc` wasn't working.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1704)

---

**AppLayoutHeader**

Desktop:

![image](https://github.com/agriculturegovau/agds-next/assets/43688949/1838e425-ea82-4266-91dc-6b829657d1c5)

Tablet:

![image](https://github.com/agriculturegovau/agds-next/assets/43688949/cac67a66-05e4-4a0e-a98a-dac848036031)

Mobile:

![image](https://github.com/agriculturegovau/agds-next/assets/43688949/d1e0750b-d4e1-4487-98e7-5fc4e0812267)

---

**Header bug** (gap after second logo in first image, divider visible on wrapping in second image)

Before:

![image](https://github.com/agriculturegovau/agds-next/assets/43688949/ed9bf4d8-5312-418e-9aef-4e52bf2d710f)

![image](https://github.com/agriculturegovau/agds-next/assets/43688949/270d534d-11d3-4253-a6e3-a1c909e07934)

After:

![image](https://github.com/agriculturegovau/agds-next/assets/43688949/5626c592-ea0a-4fcd-b688-8ac6c614317b)

![image](https://github.com/agriculturegovau/agds-next/assets/43688949/96c0f2f1-b4b7-43e8-ae59-7d4ac2cb99e3)

---

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
