### PR TITLE
main-nav: Use correct ARIA in button & dialog

### DIFF
--- a/.changeset/chilly-singers-sip.md
+++ b/.changeset/chilly-singers-sip.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+main-nav: Use correct ARIA labels for menu button & dialog. Remove other incorrect ARIA properties.
+
+modal: Make the Close button’s visual and reading order identical.

--- a/packages/react/src/main-nav/MainNavDialog.tsx
+++ b/packages/react/src/main-nav/MainNavDialog.tsx
@@ -51,6 +51,7 @@ export function MainNavDialog({
 			<Overlay onClick={closeMobileMenu} />
 			<FocusLock returnFocus>
 				<Flex
+					aria-label="Main menu"
 					role="dialog"
 					aria-modal="true"
 					background="body"
@@ -69,7 +70,7 @@ export function MainNavDialog({
 				>
 					<MainNavCloseButton onClick={closeMobileMenu} />
 					<MainNavDialogNavList
-						aria-label="main"
+						aria-label="Main"
 						items={items}
 						activePath={activePath}
 					/>

--- a/packages/react/src/main-nav/MainNavMenuButtons.tsx
+++ b/packages/react/src/main-nav/MainNavMenuButtons.tsx
@@ -3,7 +3,7 @@ import { BaseButton } from '../button';
 import { Flex } from '../flex';
 import { boxPalette, packs } from '../core';
 import { CloseIcon, MenuIcon } from '../icon';
-import { ids, mobileBreakpoint } from './utils';
+import { mobileBreakpoint } from './utils';
 import { localPalette } from './localPalette';
 
 export type MainNavOpenButtonProps = PropsWithChildren<{
@@ -24,9 +24,7 @@ export function MainNavOpenButton({ onClick }: MainNavOpenButtonProps) {
 			gap={0.5}
 			focusRingFor="keyboard"
 			onClick={onClick}
-			aria-label="Open main menu"
-			aria-controls={ids.dialog}
-			aria-expanded="false"
+			aria-label="Menu (Open main menu)"
 			css={{
 				color: boxPalette.foregroundAction,
 				'&:hover': {
@@ -60,8 +58,6 @@ export function MainNavCloseButton({ onClick }: MainNavCloseButtonProps) {
 			focusRingFor="keyboard"
 			onClick={onClick}
 			aria-label="Close main menu"
-			aria-controls={ids.dialog}
-			aria-expanded="true"
 			css={{
 				alignSelf: 'flex-start',
 				color: boxPalette.foregroundAction,

--- a/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
@@ -10,9 +10,7 @@ exports[`MainNav renders correctly 1`] = `
       class="css-hcet0s-boxStyles-MainNavContainer"
     >
       <button
-        aria-controls="main-nav-dialog"
-        aria-expanded="false"
-        aria-label="Open main menu"
+        aria-label="Menu (Open main menu)"
         class="css-jb434h-BaseButton-boxStyles-MainNavOpenButton"
         type="button"
       >

--- a/packages/react/src/main-nav/utils.ts
+++ b/packages/react/src/main-nav/utils.ts
@@ -1,7 +1,3 @@
-export const ids = {
-	dialog: 'main-nav-dialog',
-};
-
 export const mobileMaxWidth = '17.5rem'; // 280 px
 
 export const mobileBreakpoint = 'lg';

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -56,6 +56,15 @@ export const ModalDialog = ({
 					},
 				}}
 			>
+				<Button
+					variant="text"
+					aria-label="Close modal"
+					onClick={closeHandler}
+					iconAfter={CloseIcon}
+					css={{ alignSelf: 'flex-end' }}
+				>
+					Close
+				</Button>
 				<ModalTitle id={titleId}>{title}</ModalTitle>
 				<Box>{children}</Box>
 				{actions ? (
@@ -63,15 +72,6 @@ export const ModalDialog = ({
 						{actions}
 					</Box>
 				) : null}
-				<Button
-					variant="text"
-					aria-label="Close modal"
-					onClick={closeHandler}
-					iconAfter={CloseIcon}
-					css={{ order: -1, alignSelf: 'flex-end' }}
-				>
-					Close
-				</Button>
 			</Stack>
 		</FocusLock>
 	);

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -22,45 +22,9 @@ exports[`Modal renders correctly 1`] = `
         class="css-1zh0al-boxStyles-ModalDialog"
         role="dialog"
       >
-        <h2
-          class="css-lltnmr-boxStyles"
-          data-autofocus="true"
-          id="modal-:r0:-title"
-          tabindex="-1"
-        >
-          Modal title
-        </h2>
-        <div
-          class="css-79i25n-boxStyles"
-        >
-          <p
-            class="css-dbscsh-boxStyles"
-          >
-            This is the Modal Body paragraph.
-          </p>
-        </div>
-        <div
-          class="css-1kzq3kl-boxStyles-ModalDialog"
-        >
-          <button
-            class="css-1xaxpdg-BaseButton-Button"
-            type="button"
-          >
-            <span>
-              <span
-                class="css-oobk4c-Button"
-              >
-                Close modal
-              </span>
-              <span
-                aria-live="assertive"
-              />
-            </span>
-          </button>
-        </div>
         <button
           aria-label="Close modal"
-          class="css-xzbqql-BaseButton-ModalDialog"
+          class="css-v8887w-BaseButton-ModalDialog"
           type="button"
         >
           <span>
@@ -99,6 +63,42 @@ exports[`Modal renders correctly 1`] = `
             />
           </svg>
         </button>
+        <h2
+          class="css-lltnmr-boxStyles"
+          data-autofocus="true"
+          id="modal-:r0:-title"
+          tabindex="-1"
+        >
+          Modal title
+        </h2>
+        <div
+          class="css-79i25n-boxStyles"
+        >
+          <p
+            class="css-dbscsh-boxStyles"
+          >
+            This is the Modal Body paragraph.
+          </p>
+        </div>
+        <div
+          class="css-1kzq3kl-boxStyles-ModalDialog"
+        >
+          <button
+            class="css-1xaxpdg-BaseButton-Button"
+            type="button"
+          >
+            <span>
+              <span
+                class="css-oobk4c-Button"
+              >
+                Close modal
+              </span>
+              <span
+                aria-live="assertive"
+              />
+            </span>
+          </button>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
The mobile nav menu button/dialog have a few issues:

1. The button's accessible label doesn't begin with what's on screen (Menu)
1. The dialog isn't labelled.
1. Both have an incorrect aria-controls to an element that doesn't exists
1. Both an incorrect aria-expanded attribute (it doesn't expand like a classic menu button)
1. Modal Close button is first in visual order but last in reading order.

Provide an overview of your changes here. Include screenshots, photos or links if necessary.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1705)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.