### PR TITLE
main-nav: Fix mobile dialog menu not closing when you press the active link

### DIFF
--- a/.changeset/shiny-pots-do.md
+++ b/.changeset/shiny-pots-do.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+main-nav: Fix mobile dialog menu not closing when you press the active link.

--- a/packages/react/src/main-nav/MainNavDialog.tsx
+++ b/packages/react/src/main-nav/MainNavDialog.tsx
@@ -70,9 +70,10 @@ export function MainNavDialog({
 				>
 					<MainNavCloseButton onClick={closeMobileMenu} />
 					<MainNavDialogNavList
-						aria-label="Main"
-						items={items}
 						activePath={activePath}
+						aria-label="Main"
+						closeMobileMenu={closeMobileMenu}
+						items={items}
 					/>
 				</Flex>
 			</FocusLock>

--- a/packages/react/src/main-nav/MainNavDialogNavList.tsx
+++ b/packages/react/src/main-nav/MainNavDialogNavList.tsx
@@ -9,12 +9,14 @@ import { isItemLink, MainNavListItemType } from './MainNavList';
 export type MainNavDialogNavListProps = {
 	'aria-label': string;
 	activePath: string;
+	closeMobileMenu: () => void;
 	items?: MainNavListItemType[];
 };
 
 export function MainNavDialogNavList({
 	'aria-label': ariaLabel,
 	activePath,
+	closeMobileMenu,
 	items,
 }: MainNavDialogNavListProps) {
 	const Link = useLinkComponent();
@@ -25,7 +27,11 @@ export function MainNavDialogNavList({
 					if (isItemLink(item)) {
 						const active = item.href === activePath;
 						return (
-							<MainNavDialogNavListItem key={index} active={active}>
+							<MainNavDialogNavListItem
+								active={active}
+								key={index}
+								onClick={active ? closeMobileMenu : undefined} // Let the click event bubble up and close the menu on press of interactive item
+							>
 								<Link aria-current={active ? 'page' : undefined} {...item}>
 									<span>{label}</span>
 									{endElement}
@@ -49,17 +55,17 @@ export function MainNavDialogNavList({
 
 export type MainNavDialogNavListItemProps = PropsWithChildren<{
 	active: boolean;
+	onClick?: () => void;
 }>;
 
 export function MainNavDialogNavListItem({
 	active,
 	children,
+	onClick,
 }: MainNavDialogNavListItemProps) {
 	return (
 		<Flex
 			as="li"
-			height="100%"
-			fontSize="xs"
 			borderBottom
 			borderColor="muted"
 			css={{
@@ -89,6 +95,9 @@ export function MainNavDialogNavListItem({
 					...focusStyles,
 				},
 			}}
+			fontSize="xs"
+			height="100%"
+			onClick={onClick}
 		>
 			{children}
 		</Flex>


### PR DESCRIPTION
In the mobile menu, if you were on the active page, pressing the link would not close the menu.

This PR fixes that, but only closes the menu if you press the active link and not always. I have done this, because, in dev, a route change is slow so I don't want to see the focus ring move to the button, and then move off it.

The route change is still announced when you press the same link, so a screen reader user is told they go to Components or whatever. The only weirdness is that when you are in a sub-page (like a component detail), the nav will close and then the route change will happen, but there's no way around that…?

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1706)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.