### PR TITLE
date-picker: Add allowedDateFormats prop

### DIFF
--- a/.changeset/friendly-jobs-float.md
+++ b/.changeset/friendly-jobs-float.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+date-picker: Add `allowedDateFormats` prop. Make preferred `dateFormat` the first to parse.
+
+date-range-picker: Add `allowedDateFormats` prop. Make preferred `dateFormat` the first to parse.

--- a/packages/react/src/date-picker/DatePicker.stories.tsx
+++ b/packages/react/src/date-picker/DatePicker.stories.tsx
@@ -79,6 +79,12 @@ export const AlternativeDateFormat: Story = {
 	},
 };
 
+export const CustomAllowedDateFormats: Story = {
+	args: {
+		allowedDateFormats: ['dd/MM/yyyy', 'dd-MM-yyyy', 'dd MM yyyy'],
+	},
+};
+
 export const ScrollExample: Story = {
 	render: (props) => (
 		<Box>

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -281,6 +281,59 @@ describe('DatePicker', () => {
 		expect(await getInput()).toHaveValue('5 Jun 2023');
 	});
 
+	describe('allowedDateFormats', () => {
+		const onChange = jest.fn();
+
+		it('formats when an allowed format is entered', async () => {
+			renderDatePicker({
+				allowedDateFormats: ['dd-MM-yyyy'],
+				label: 'Example',
+				onChange: onChange,
+			});
+
+			const dateString = '23-05-2023';
+			const date = parseDate(dateString) as Date;
+
+			// Type a valid date in the input field that is in the allowed format
+			await userEvent.type(await getInput(), dateString);
+			await userEvent.keyboard('{Tab}');
+
+			expect(onChange).toHaveBeenLastCalledWith(date);
+		});
+
+		it('doesn’t format when a disallowed format is entered', async () => {
+			renderDatePicker({
+				allowedDateFormats: ['dd-MM-yyyy'],
+				label: 'Example',
+				onChange: onChange,
+			});
+
+			// Type a valid date in the input field that isn't in the allowed format
+			await userEvent.type(await getInput(), '05-23-2023');
+			await userEvent.keyboard('{Tab}');
+
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('adds the dateFormat to allowedDateFormats if not explicitly specificied and formats appropriately', async () => {
+			renderDatePicker({
+				allowedDateFormats: ['MM/dd/yyyy'],
+				dateFormat: 'dd MMMM yyyy',
+				label: 'Example',
+				onChange: onChange,
+			});
+
+			const dateString = '08 February 2023';
+			const date = parseDate(dateString) as Date;
+
+			// Type a valid date in the input field that isn't in the display format
+			await userEvent.type(await getInput(), dateString);
+			await userEvent.keyboard('{Tab}');
+
+			expect(onChange).toHaveBeenLastCalledWith(date);
+		});
+	});
+
 	it('formSchema: yupDateField works when optional', () => {
 		const optionalFormSchema = formSchema(false);
 		expect(optionalFormSchema.isValidSync({ date: undefined })).toEqual(true);

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -285,7 +285,7 @@ describe('DatePicker', () => {
 		const onChange = jest.fn();
 		const onInputChange = jest.fn();
 
-		it('formats when an allowed format is entered', async () => {
+		it('formats when a valid format is entered', async () => {
 			renderDatePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
 				label: 'Example',
@@ -304,7 +304,7 @@ describe('DatePicker', () => {
 			expect(onInputChange).not.toHaveBeenCalled();
 		});
 
-		it('doesn’t format when a disallowed format is entered', async () => {
+		it('doesn’t format when an invalid format is entered', async () => {
 			renderDatePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
 				label: 'Example',

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -283,12 +283,14 @@ describe('DatePicker', () => {
 
 	describe('allowedDateFormats', () => {
 		const onChange = jest.fn();
+		const onInputChange = jest.fn();
 
 		it('formats when an allowed format is entered', async () => {
 			renderDatePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
 				label: 'Example',
-				onChange: onChange,
+				onChange,
+				onInputChange,
 			});
 
 			const dateString = '23-05-2023';
@@ -299,20 +301,25 @@ describe('DatePicker', () => {
 			await userEvent.keyboard('{Tab}');
 
 			expect(onChange).toHaveBeenLastCalledWith(date);
+			expect(onInputChange).not.toHaveBeenCalled();
 		});
 
 		it('doesn’t format when a disallowed format is entered', async () => {
 			renderDatePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
 				label: 'Example',
-				onChange: onChange,
+				onChange,
+				onInputChange,
 			});
 
+			const dateString = '05-23-2023';
+
 			// Type a valid date in the input field that isn't in the allowed format
-			await userEvent.type(await getInput(), '05-23-2023');
+			await userEvent.type(await getInput(), dateString);
 			await userEvent.keyboard('{Tab}');
 
 			expect(onChange).not.toHaveBeenCalled();
+			expect(onInputChange).toHaveBeenLastCalledWith(dateString);
 		});
 
 		it('adds the dateFormat to allowedDateFormats if not explicitly specificied and formats appropriately', async () => {
@@ -320,7 +327,8 @@ describe('DatePicker', () => {
 				allowedDateFormats: ['MM/dd/yyyy'],
 				dateFormat: 'dd MMMM yyyy',
 				label: 'Example',
-				onChange: onChange,
+				onChange,
+				onInputChange,
 			});
 
 			const dateString = '08 February 2023';
@@ -331,6 +339,7 @@ describe('DatePicker', () => {
 			await userEvent.keyboard('{Tab}');
 
 			expect(onChange).toHaveBeenLastCalledWith(date);
+			expect(onInputChange).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -187,32 +187,24 @@ describe('DatePicker', () => {
 		const date = parseDate(dateString) as Date;
 		const formattedDate = formatHumanReadableDate(date);
 
-		const { container } = render(<ClearableDatePicker initialValue={date} />);
-
-		async function getCalendarTrigger() {
-			return await container.querySelector('button[type="button"]');
-		}
+		render(<ClearableDatePicker initialValue={date} />);
 
 		// The input should be a formatted display value of `initialValue`
 		expect(await getInput()).toHaveValue(dateString);
 
 		// The calendar button trigger should have an aria-label with the formatted display value of `initialValue`
-		expect(await getCalendarTrigger()).toHaveAttribute(
-			'aria-label',
-			`Change date, ${formattedDate}`
-		);
+		expect(
+			screen.getByRole('button', { name: `Change date, ${formattedDate}` })
+		).toBeVisible();
 
 		// Click the `clear` button to clear the value
-		await userEvent.click(await screen.getByTestId('clear'));
+		await userEvent.click(screen.getByTestId('clear'));
 
 		// The input should be empty
 		expect(await getInput()).toHaveValue('');
 
 		// The calendar button triggers aria-label should be updated
-		expect(await getCalendarTrigger()).toHaveAttribute(
-			'aria-label',
-			'Choose date'
-		);
+		expect(screen.getByRole('button', { name: 'Choose date' })).toBeVisible();
 	});
 
 	it('can render an invalid state', async () => {
@@ -229,7 +221,7 @@ describe('DatePicker', () => {
 	it('responds to an `onChange` callback when a date is valid', async () => {
 		const onChange = jest.fn();
 
-		const { container } = renderDatePicker({
+		renderDatePicker({
 			label: 'Example',
 			onChange,
 		});
@@ -246,16 +238,15 @@ describe('DatePicker', () => {
 		expect(onChange).toHaveBeenLastCalledWith(date);
 
 		// The calendar button trigger should have an aria-label with the formatted display value
-		expect(container.querySelector('button[type="button"]')).toHaveAttribute(
-			'aria-label',
-			`Change date, ${formattedDate}`
-		);
+		expect(
+			screen.getByRole('button', { name: `Change date, ${formattedDate}` })
+		).toBeVisible();
 	});
 
 	it('responds to an `onInputChange` callback when a date is invalid', async () => {
 		const onInputChange = jest.fn();
 
-		const { container } = renderDatePicker({
+		renderDatePicker({
 			label: 'Example',
 			onInputChange,
 		});
@@ -270,10 +261,7 @@ describe('DatePicker', () => {
 		expect(onInputChange).toHaveBeenLastCalledWith(dateString);
 
 		// The calendar button trigger should have the default aria-label
-		expect(container.querySelector('button[type="button"]')).toHaveAttribute(
-			'aria-label',
-			`Choose date`
-		);
+		expect(screen.getByRole('button', { name: `Choose date` })).toBeVisible();
 	});
 
 	it('formats valid dates to the default date format (dd/MM/yyyy)', async () => {

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -70,7 +70,7 @@ type DatePickerCalendarProps = {
 
 type DatePickerBaseProps = {
 	/** Specifies the date formats that can be parsed. */
-	allowedDateFormats: ReadonlyArray<AcceptedDateFormats>;
+	allowedDateFormats?: ReadonlyArray<AcceptedDateFormats>;
 	/** The value of the field. */
 	value: Date | string | undefined;
 	/** Function to be fired following a change event. */
@@ -107,6 +107,7 @@ export const DatePicker = ({
 		() =>
 			Array.from(
 				new Set([
+					// We need to ensure that the dateFormat to render is included in allowedDateFormats. It should also be the preferred format.
 					dateFormat,
 					...allowedDateFormatsProp.filter((dateFormat) =>
 						acceptedDateFormats.includes(dateFormat)
@@ -237,10 +238,10 @@ export const DatePicker = ({
 					toggleCalendar();
 					setHasCalendarOpened(true);
 				}}
-				buttonAriaLabel={getDateInputButtonAriaLabel(
-					inputValue,
-					allowedDateFormats
-				)}
+				buttonAriaLabel={getDateInputButtonAriaLabel({
+					allowedDateFormats,
+					value: inputValue,
+				})}
 			/>
 			<CalendarProvider yearRange={yearRange}>
 				{/* We duplicate the Popover + Calendar as a workaround for a bug that scrolls the page to the top on initial open of the calandar - https://github.com/gpbl/react-day-picker/discussions/2059 */}

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -16,14 +16,14 @@ import { CalendarSingle } from './Calendar';
 import { CalendarProvider } from './CalendarContext';
 import { DateInput } from './DatePickerInput';
 import {
-	parseDate,
-	formatDate,
+	acceptedDateFormats,
 	constrainDate,
-	transformValuePropToInputValue,
+	formatDate,
 	getCalendarDefaultMonth,
 	getDateInputButtonAriaLabel,
+	parseDate,
+	transformValuePropToInputValue,
 	type AcceptedDateFormats,
-	acceptedDateFormats,
 } from './utils';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -7,13 +7,6 @@ figmaGalleryNodeId: 12444%3A100327
 relatedComponents: ['date-range-picker']
 ---
 
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return <DatePicker label="Select date" value={value} onChange={setValue} />;
-};
-```
-
 Date picker is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components) which means consumers of this component need to manage the state of this component by using the `value`, `onChange` and `onInputChange` props.
 
 For an example of using this component in a form built with [react-hook-form](https://react-hook-form.com/) and [yup](https://github.com/jquense/yup), please see the [Single-page form template](/templates/single-page-form).
@@ -75,167 +68,12 @@ In this case, you can use the `onInputChange` prop to keep track of the user’s
 				invalid: true,
 				message: 'Enter a valid date',
 			})}
-		/>
-	);
-};
-```
-
-## Hint
-
-Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
-
-Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
-
-Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker
-			label="Select date"
-			hint="Hint text"
-			value={value}
-			onChange={setValue}
-		/>
-	);
-};
-```
-
-## Block
-
-Use the `block` prop to expand the component to fill the available space.
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker label="Select date" value={value} onChange={setValue} block />
-	);
-};
-```
-
-## Invalid
-
-Use the `invalid` prop to indicate if the user input is invalid.
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker
-			label="Invalid"
-			invalid
-			message="Enter a valid date"
-			value={value}
-			onChange={setValue}
-		/>
-	);
-};
-```
-
-## Disabled
-
-Disabled input elements are unusable and can not be clicked. This prevents a user from interacting with the input element until another action is complete.
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker
-			label="Select date"
-			value={value}
-			onChange={setValue}
-			disabled
-		/>
-	);
-};
-```
-
-## Minimum and maximum dates
-
-The `minDate` property can be used to disable any days before a specific date.
-
-The `maxDate` property can be used to disable any days after a specific date.
-
-If a valid date is entered using the text input but it falls outside the constrained range, the closest valid date will be used.
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-
-	const today = new Date();
-	const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
-	const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
-
-	return (
-		<DatePicker
-			label="Select date"
-			minDate={lastWeek}
-			maxDate={nextWeek}
-			value={value}
-			onChange={setValue}
-		/>
-	);
-};
-```
-
-## Custom year range
-
-The `yearRange` prop can be used to change the range of options to display in calendar year select.
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	const thisYear = new Date().getFullYear();
-	const yearRange = { from: thisYear - 2, to: thisYear + 2 };
-	return (
-		<DatePicker
-			label="Select date"
-			yearRange={yearRange}
-			value={value}
-			onChange={setValue}
-		/>
-	);
-};
-```
-
-## Changing the date format
-
-The Date picker component allows users to enter dates in various formats. To select the 18th February 2023, a user could input '18/02/2023', '18 Feb 2023', '18th February 2023', or any other supported date format.
-
-When a valid date is typed, on blur, the date will be formatted using the `dateFormat` prop, which is set to `'dd/MM/yyyy'` by default.
-
-To modify the date format, you can change the `dateFormat` prop to one of these supported date formats:
-
-- `'dd/MM/yyyy'` (e.g. 18/02/2023)
-- `'dd-MM-yyyy'` (e.g. 18-02-2023)
-- `'dd MM yyyy'` (e.g. 18 02 2023)
-- `'MM/dd/yyyy'` (e.g. 02/18/2023)
-- `'MM-dd-yyyy'` (e.g. 02-18-2023)
-- `'MM dd yyyy'` (e.g. 02 18 2023)
-- `'do MMMM yyyy'` (e.g. 8th February 2023)
-- `'do MMM yyyy'` (e.g. 8th Feb 2023)
-- `'MMMM do yyyy'` (e.g. February 8th 2023)
-- `'MMM do yyyy'` (e.g. Feb 8th 2023)
-- `'d MMMM yyyy'` (e.g. 8 February 2023)
-- `'d MMM yyyy'` (e.g. 8 Feb 2023)
-- `'MMMM d yyyy'` (e.g. February 8 2023)
-- `'MMM d yyyy'` (e.g. Feb 8 2023)
-- `'dd MMMM yyyy'` (e.g. 08 February 2023)
-- `'dd MMM yyyy'` (e.g. 08 Feb 2023)
-- `'MMMM dd yyyy'` (e.g. February 08 2023)
-- `'MMM dd yyyy'` (e.g. Feb 08 2023)
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker
-			label="Select date"
-			value={value}
-			onChange={setValue}
 			dateFormat="d MMM yyyy"
+			allowedDateFormats={[
+				'dd/MM/yyyy', // e.g. 18/02/2023
+				'dd-MM-yyyy', // e.g. 18-02-2023
+				'dd MM yyyy',
+			]}
 		/>
 	);
 };

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -7,6 +7,13 @@ figmaGalleryNodeId: 12444%3A100327
 relatedComponents: ['date-range-picker']
 ---
 
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return <DatePicker label="Select date" value={value} onChange={setValue} />;
+};
+```
+
 Date picker is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components) which means consumers of this component need to manage the state of this component by using the `value`, `onChange` and `onInputChange` props.
 
 For an example of using this component in a form built with [react-hook-form](https://react-hook-form.com/) and [yup](https://github.com/jquense/yup), please see the [Single-page form template](/templates/single-page-form).
@@ -42,12 +49,12 @@ In this case, you can use the `onInputChange` prop to keep track of the user’s
 	const [value, setValue] = React.useState('31/1o/2020');
 
 	const onInputChange = (e) => {
-		console.log(`onInputChange`, e);
+		console.log('onInputChange', e);
 		setValue(e);
 	};
 
 	const onChange = (e) => {
-		console.log(`onChange`, e);
+		console.log('onChange', e);
 		setValue(e);
 	};
 
@@ -68,12 +75,213 @@ In this case, you can use the `onInputChange` prop to keep track of the user’s
 				invalid: true,
 				message: 'Enter a valid date',
 			})}
+		/>
+	);
+};
+```
+
+## Hint
+
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don’t use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don’t include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker
+			label="Select date"
+			hint="Hint text"
+			value={value}
+			onChange={setValue}
+		/>
+	);
+};
+```
+
+## Block
+
+Use the `block` prop to expand the component to fill the available space.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker label="Select date" value={value} onChange={setValue} block />
+	);
+};
+```
+
+## Invalid
+
+Use the `invalid` prop to indicate if the user input is invalid.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker
+			label="Invalid"
+			invalid
+			message="Enter a valid date"
+			value={value}
+			onChange={setValue}
+		/>
+	);
+};
+```
+
+## Disabled
+
+Disabled input elements are unusable and can not be clicked. This prevents a user from interacting with the input element until another action is complete.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker
+			label="Select date"
+			value={value}
+			onChange={setValue}
+			disabled
+		/>
+	);
+};
+```
+
+## Minimum and maximum dates
+
+The `minDate` property can be used to disable any days before a specific date.
+
+The `maxDate` property can be used to disable any days after a specific date.
+
+If a valid date is entered using the text input but it falls outside the constrained range, the closest valid date will be used.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+
+	const today = new Date();
+	const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+	const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+	return (
+		<DatePicker
+			label="Select date"
+			minDate={lastWeek}
+			maxDate={nextWeek}
+			value={value}
+			onChange={setValue}
+		/>
+	);
+};
+```
+
+## Custom year range
+
+The `yearRange` prop can be used to change the range of options to display in calendar year select.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	const thisYear = new Date().getFullYear();
+	const yearRange = { from: thisYear - 2, to: thisYear + 2 };
+	return (
+		<DatePicker
+			label="Select date"
+			yearRange={yearRange}
+			value={value}
+			onChange={setValue}
+		/>
+	);
+};
+```
+
+## Changing the date format
+
+The Date picker component allows users to enter dates in various formats. To select the 18th February 2023, a user could input '18/02/2023', '18 Feb 2023', '18th February 2023', or any other supported date format.
+
+When a valid date is typed, on blur, the date will be formatted using the `dateFormat` prop, which is set to `'dd/MM/yyyy'` by default.
+
+To modify the date format, you can change the `dateFormat` prop to one of these supported date formats:
+
+- `'dd/MM/yyyy'` (e.g. 18/02/2023)
+- `'dd-MM-yyyy'` (e.g. 18-02-2023)
+- `'dd MM yyyy'` (e.g. 18 02 2023)
+- `'MM/dd/yyyy'` (e.g. 02/18/2023)
+- `'MM-dd-yyyy'` (e.g. 02-18-2023)
+- `'MM dd yyyy'` (e.g. 02 18 2023)
+- `'do MMMM yyyy'` (e.g. 8th February 2023)
+- `'do MMM yyyy'` (e.g. 8th Feb 2023)
+- `'MMMM do yyyy'` (e.g. February 8th 2023)
+- `'MMM do yyyy'` (e.g. Feb 8th 2023)
+- `'d MMMM yyyy'` (e.g. 8 February 2023)
+- `'d MMM yyyy'` (e.g. 8 Feb 2023)
+- `'MMMM d yyyy'` (e.g. February 8 2023)
+- `'MMM d yyyy'` (e.g. Feb 8 2023)
+- `'dd MMMM yyyy'` (e.g. 08 February 2023)
+- `'dd MMM yyyy'` (e.g. 08 Feb 2023)
+- `'MMMM dd yyyy'` (e.g. February 08 2023)
+- `'MMM dd yyyy'` (e.g. Feb 08 2023)
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	return (
+		<DatePicker
+			label="Select date"
+			value={value}
+			onChange={setValue}
 			dateFormat="d MMM yyyy"
-			allowedDateFormats={[
-				'dd/MM/yyyy', // e.g. 18/02/2023
-				'dd-MM-yyyy', // e.g. 18-02-2023
-				'dd MM yyyy',
-			]}
+		/>
+	);
+};
+```
+
+## Changing the allowed date formats
+
+By default, all of the supported date formats are allowed, but should you need to restrict the formats that can be parsed and validated, you can pass in an array of date format strings to the `allowedDateFormats` prop.
+
+Some applications may find it useful to remove US formats, since an invalid AU date could become a valid US date and cause confusion for users.
+
+Date formats are parsed in order from first to last and stops when a valid date is found. The preferred `dateFormat` always becomes the first to check, even if omitted in `allowedDateFormats`.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+
+	const onInputChange = (e) => {
+		console.log('onInputChange', e);
+		setValue(e);
+	};
+
+	const onChange = (e) => {
+		console.log('onChange', e);
+		setValue(e);
+	};
+
+	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.
+	const invalid = React.useMemo(() => {
+		if (typeof value === 'undefined' || value == '') return false;
+		if (value instanceof Date && !isNaN(value.getTime())) return false;
+		return true;
+	}, [value]);
+
+	return (
+		<DatePicker
+			label="Select date"
+			hint="Only short AU formats allowed"
+			value={value}
+			onChange={onChange}
+			onInputChange={onInputChange}
+			{...(invalid && {
+				invalid: true,
+				message: 'Enter a valid date',
+			})}
+			allowedDateFormats={['dd MM yyyy', 'dd-MM-yyyy']}
 		/>
 	);
 };

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -48,14 +48,14 @@ In this case, you can use the `onInputChange` prop to keep track of the user’s
 	// Set the value to a value that the user might think is valid
 	const [value, setValue] = React.useState('31/1o/2020');
 
-	const onInputChange = (e) => {
-		console.log('onInputChange', e);
-		setValue(e);
+	const onInputChange = (value) => {
+		console.log('onInputChange', value);
+		setValue(value);
 	};
 
-	const onChange = (e) => {
-		console.log('onChange', e);
-		setValue(e);
+	const onChange = (date) => {
+		console.log('onChange', date);
+		setValue(date);
 	};
 
 	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.
@@ -253,14 +253,14 @@ Date formats are parsed in order from first to last and stops when a valid date 
 () => {
 	const [value, setValue] = React.useState();
 
-	const onInputChange = (e) => {
-		console.log('onInputChange', e);
-		setValue(e);
+	const onInputChange = (value) => {
+		console.log('onInputChange', value);
+		setValue(value);
 	};
 
-	const onChange = (e) => {
-		console.log('onChange', e);
-		setValue(e);
+	const onChange = (date) => {
+		console.log('onChange', date);
+		setValue(date);
 	};
 
 	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.

--- a/packages/react/src/date-picker/utils.test.ts
+++ b/packages/react/src/date-picker/utils.test.ts
@@ -86,31 +86,32 @@ describe('parseDate', () => {
 	});
 
 	describe('only parses allowed date formats', () => {
-		const testFormats = ['18 02 2023'];
+		const allowedAUFormats = [
+			'dd/MM/yyyy', // e.g. 13/10/2023
+		] as const;
 
-		const allowedDateFormats = [
-			'dd/MM/yyyy', // e.g. 18/02/2023
-			'dd-MM-yyyy', // e.g. 18-02-2023
-			'dd MM yyyy', // e.g. 18 02 2023
-		];
+		const allowedUSFormats = [
+			'MM/dd/yyyy', // e.g. 10/13/2023
+		] as const;
 
-		const disallowedDateFormats = [
-			'MMM do yyyy', // e.g. Feb 8th 2023
-			'd MMMM yyyy', // e.g. 8 February 2023
-			'd MMM yyyy', // e.g. 8 Feb 2023
-			'MMMM d yyyy', // e.g. February 8 2023
-			'MMM d yyyy', // e.g. Feb 8 2023
-			'dd MMMM yyyy', // e.g. 08 February 2023
-			'dd MMM yyyy', // e.g. 08 Feb 2023
-			'MMMM dd yyyy', // e.g. February 08 2023
-			'MMM dd yyyy', // e.g. Feb 08 2023
-		];
+		test('Formats a valid AU format', () => {
+			const formattedDate = parseDate('13/10/2023', allowedAUFormats);
+			expect(formattedDate).toEqual(new Date(2023, 9, 13));
+		});
 
-		testFormats.forEach((example) => {
-			test(`Format "${example}"`, () => {
-				const formattedDate = parseDate(example, allowedDateFormats);
-				expect(formattedDate).toEqual(new Date(2023, 1, 18));
-			});
+		test('Doesn’t format a valid AU format', () => {
+			const formattedDate = parseDate('10/13/2023', allowedAUFormats);
+			expect(formattedDate).toEqual(undefined);
+		});
+
+		test('Formats a valid US format', () => {
+			const formattedDate = parseDate('13/10/2023', allowedUSFormats);
+			expect(formattedDate).toEqual(undefined);
+		});
+
+		test('Doesn’t format a valid US format', () => {
+			const formattedDate = parseDate('10/13/2023', allowedUSFormats);
+			expect(formattedDate).toEqual(new Date(2023, 9, 13));
 		});
 	});
 });
@@ -226,17 +227,45 @@ describe('getCalendarDefaultMonth', () => {
 });
 
 describe('getDateInputButtonAriaLabel', () => {
-	it('returns `Choose date` when no date is set', () => {
-		expect(getDateInputButtonAriaLabel(undefined)).toEqual('Choose date');
-		expect(getDateInputButtonAriaLabel('')).toEqual('Choose date');
+	it('returns "Choose date" when no date is set', () => {
+		expect(getDateInputButtonAriaLabel({ value: undefined })).toEqual(
+			'Choose date'
+		);
+
+		expect(getDateInputButtonAriaLabel({ value: '' })).toEqual('Choose date');
 	});
 
-	it('returns `Change date, x` when a date is set', () => {
-		expect(getDateInputButtonAriaLabel('14/02/1990')).toEqual(
-			'Change date, 14th February 1990 (Wednesday)'
-		);
-		expect(getDateInputButtonAriaLabel('05/06/2010')).toEqual(
+	it('returns "Change date, x" when a date is set', () => {
+		expect(getDateInputButtonAriaLabel({ value: '05/06/2010' })).toEqual(
 			'Change date, 5th June 2010 (Saturday)'
 		);
+	});
+
+	it('returns "Choose start date" when no date and "start" is set', () => {
+		expect(
+			getDateInputButtonAriaLabel({ value: undefined, rangeName: 'start' })
+		).toEqual('Choose start date');
+
+		expect(
+			getDateInputButtonAriaLabel({ value: '', rangeName: 'start' })
+		).toEqual('Choose start date');
+	});
+
+	it('returns "Change start date, x" when a date and "start" is set', () => {
+		expect(
+			getDateInputButtonAriaLabel({ value: '05/06/2010', rangeName: 'start' })
+		).toEqual('Change start date, 5th June 2010 (Saturday)');
+	});
+
+	it('returns "Choose end date" when no date and "end" is set', () => {
+		expect(
+			getDateInputButtonAriaLabel({ value: '', rangeName: 'end' })
+		).toEqual('Choose end date');
+	});
+
+	it('returns "Change end date, x" when a date and "end" is set', () => {
+		expect(
+			getDateInputButtonAriaLabel({ value: '05/06/2010', rangeName: 'end' })
+		).toEqual('Change end date, 5th June 2010 (Saturday)');
 	});
 });

--- a/packages/react/src/date-picker/utils.test.ts
+++ b/packages/react/src/date-picker/utils.test.ts
@@ -99,7 +99,7 @@ describe('parseDate', () => {
 			expect(formattedDate).toEqual(new Date(2023, 9, 13));
 		});
 
-		test('Doesn’t format a valid AU format', () => {
+		test('Doesn’t format an invalid AU format', () => {
 			const formattedDate = parseDate('10/13/2023', allowedAUFormats);
 			expect(formattedDate).toEqual(undefined);
 		});
@@ -109,7 +109,7 @@ describe('parseDate', () => {
 			expect(formattedDate).toEqual(undefined);
 		});
 
-		test('Doesn’t format a valid US format', () => {
+		test('Doesn’t format an invalid US format', () => {
 			const formattedDate = parseDate('10/13/2023', allowedUSFormats);
 			expect(formattedDate).toEqual(new Date(2023, 9, 13));
 		});

--- a/packages/react/src/date-picker/utils.test.ts
+++ b/packages/react/src/date-picker/utils.test.ts
@@ -84,6 +84,35 @@ describe('parseDate', () => {
 			});
 		});
 	});
+
+	describe('only parses allowed date formats', () => {
+		const testFormats = ['18 02 2023'];
+
+		const allowedDateFormats = [
+			'dd/MM/yyyy', // e.g. 18/02/2023
+			'dd-MM-yyyy', // e.g. 18-02-2023
+			'dd MM yyyy', // e.g. 18 02 2023
+		];
+
+		const disallowedDateFormats = [
+			'MMM do yyyy', // e.g. Feb 8th 2023
+			'd MMMM yyyy', // e.g. 8 February 2023
+			'd MMM yyyy', // e.g. 8 Feb 2023
+			'MMMM d yyyy', // e.g. February 8 2023
+			'MMM d yyyy', // e.g. Feb 8 2023
+			'dd MMMM yyyy', // e.g. 08 February 2023
+			'dd MMM yyyy', // e.g. 08 Feb 2023
+			'MMMM dd yyyy', // e.g. February 08 2023
+			'MMM dd yyyy', // e.g. Feb 08 2023
+		];
+
+		testFormats.forEach((example) => {
+			test(`Format "${example}"`, () => {
+				const formattedDate = parseDate(example, allowedDateFormats);
+				expect(formattedDate).toEqual(new Date(2023, 1, 18));
+			});
+		});
+	});
 });
 
 describe('constrainDate', () => {

--- a/packages/react/src/date-picker/utils.ts
+++ b/packages/react/src/date-picker/utils.ts
@@ -38,10 +38,13 @@ export const formatDate = (date: Date, dateformat: AcceptedDateFormats) =>
 export const formatHumanReadableDate = (date: Date) =>
 	format(date, 'do MMMM yyyy (EEEE)');
 
-export const parseDate = (value: string) => {
+export const parseDate = (
+	value: string,
+	dateFormats: ReadonlyArray<AcceptedDateFormats> = acceptedDateFormats
+) => {
 	const now = new Date();
 
-	for (const displayDateFormat of acceptedDateFormats) {
+	for (const displayDateFormat of dateFormats) {
 		// Split input value by spaces, slashes and dashes
 		// e.g. '18/02/2023' => ['18', '02', '2023'], 18th February 2023 => ['18th', 'February', '2023'], 18-02-2023 => ['18', '02', '2023']
 		const splitValue = value.split(/ |\/|-/g);
@@ -117,9 +120,14 @@ export function getCalendarDefaultMonth(
 }
 
 // Gets the `aria-label` for the button that opens the calendar picker
-export function getDateInputButtonAriaLabel(value: string | undefined) {
-	if (typeof value !== 'string') return 'Choose date';
-	const parsed = parseDate(value);
-	if (!parsed) return 'Choose date';
-	return `Change date, ${formatHumanReadableDate(parsed)}`;
+export function getDateInputButtonAriaLabel(
+	value: string | undefined,
+	allowedDateFormats: ReadonlyArray<AcceptedDateFormats> | undefined,
+	rangeName: 'start' | 'end' | undefined
+) {
+	const dateStr = rangeName ? `${rangeName} date` : 'date';
+	if (typeof value !== 'string') return `Choose ${dateStr}`;
+	const parsed = parseDate(value, allowedDateFormats);
+	if (!parsed) return `Choose ${dateStr}`;
+	return `Change ${dateStr}, ${formatHumanReadableDate(parsed)}`;
 }

--- a/packages/react/src/date-picker/utils.ts
+++ b/packages/react/src/date-picker/utils.ts
@@ -1,12 +1,12 @@
 import {
-	isDate,
-	format,
-	parse,
-	isValid,
-	isBefore,
-	isAfter,
 	closestTo,
+	format,
+	isAfter,
+	isBefore,
+	isDate,
 	isMatch,
+	isValid,
+	parse,
 } from 'date-fns';
 
 export const acceptedDateFormats = [

--- a/packages/react/src/date-picker/utils.ts
+++ b/packages/react/src/date-picker/utils.ts
@@ -120,11 +120,15 @@ export function getCalendarDefaultMonth(
 }
 
 // Gets the `aria-label` for the button that opens the calendar picker
-export function getDateInputButtonAriaLabel(
-	value: string | undefined,
-	allowedDateFormats: ReadonlyArray<AcceptedDateFormats> | undefined,
-	rangeName: 'start' | 'end' | undefined
-) {
+export function getDateInputButtonAriaLabel({
+	allowedDateFormats,
+	rangeName,
+	value,
+}: {
+	allowedDateFormats?: ReadonlyArray<AcceptedDateFormats>;
+	rangeName?: 'start' | 'end';
+	value?: string;
+}) {
 	const dateStr = rangeName ? `${rangeName} date` : 'date';
 	if (typeof value !== 'string') return `Choose ${dateStr}`;
 	const parsed = parseDate(value, allowedDateFormats);

--- a/packages/react/src/date-range-picker/DateRangePicker.stories.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.stories.tsx
@@ -128,6 +128,12 @@ export const AlternativeDateFormat: Story = {
 	},
 };
 
+export const CustomAllowedDateFormats: Story = {
+	args: {
+		allowedDateFormats: ['dd/MM/yyyy', 'dd-MM-yyyy', 'dd MM yyyy'],
+	},
+};
+
 export const ScrollExample: Story = {
 	render: (props) => (
 		<Box>

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -365,11 +365,13 @@ describe('DateRangePicker', () => {
 
 	describe('allowedDateFormats', () => {
 		const onChange = jest.fn();
+		const onFromInputChange = jest.fn();
 
 		it('formats when an allowed format is entered', async () => {
 			renderDateRangePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
-				onChange: onChange,
+				onChange,
+				onFromInputChange,
 			});
 
 			const dateString = '23-05-2023';
@@ -380,26 +382,32 @@ describe('DateRangePicker', () => {
 			await userEvent.keyboard('{Tab}');
 
 			expect(onChange).toHaveBeenLastCalledWith({ from: date, to: undefined });
+			expect(onFromInputChange).not.toHaveBeenCalled();
 		});
 
 		it('doesn’t format when a disallowed format is entered', async () => {
 			renderDateRangePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
-				onChange: onChange,
+				onChange,
+				onFromInputChange,
 			});
 
+			const dateString = '05-23-2023';
+
 			// Type a valid date in the input field that isn't in the allowed format
-			await userEvent.type(await getFromInput(), '05-23-2023');
+			await userEvent.type(await getFromInput(), dateString);
 			await userEvent.keyboard('{Tab}');
 
 			expect(onChange).not.toHaveBeenCalled();
+			expect(onFromInputChange).toHaveBeenLastCalledWith(dateString);
 		});
 
 		it('adds the dateFormat to allowedDateFormats if not explicitly specificied and formats appropriately', async () => {
 			renderDateRangePicker({
 				allowedDateFormats: ['MM/dd/yyyy'],
 				dateFormat: 'dd MMMM yyyy',
-				onChange: onChange,
+				onChange,
+				onFromInputChange,
 			});
 
 			const dateString = '08 February 2023';
@@ -410,6 +418,7 @@ describe('DateRangePicker', () => {
 			await userEvent.keyboard('{Tab}');
 
 			expect(onChange).toHaveBeenLastCalledWith({ from: date, to: undefined });
+			expect(onFromInputChange).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -367,7 +367,7 @@ describe('DateRangePicker', () => {
 		const onChange = jest.fn();
 		const onFromInputChange = jest.fn();
 
-		it('formats when an allowed format is entered', async () => {
+		it('formats when a valid format is entered', async () => {
 			renderDateRangePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
 				onChange,
@@ -385,7 +385,7 @@ describe('DateRangePicker', () => {
 			expect(onFromInputChange).not.toHaveBeenCalled();
 		});
 
-		it('doesn’t format when a disallowed format is entered', async () => {
+		it('doesn’t format when an invalid format is entered', async () => {
 			renderDateRangePicker({
 				allowedDateFormats: ['dd-MM-yyyy'],
 				onChange,

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -363,6 +363,56 @@ describe('DateRangePicker', () => {
 		expect(await getToInput()).toHaveValue('10 Jun 2023');
 	});
 
+	describe('allowedDateFormats', () => {
+		const onChange = jest.fn();
+
+		it('formats when an allowed format is entered', async () => {
+			renderDateRangePicker({
+				allowedDateFormats: ['dd-MM-yyyy'],
+				onChange: onChange,
+			});
+
+			const dateString = '23-05-2023';
+			const date = parseDate(dateString) as Date;
+
+			// Type a valid date in the input field that is in the allowed format
+			await userEvent.type(await getFromInput(), dateString);
+			await userEvent.keyboard('{Tab}');
+
+			expect(onChange).toHaveBeenLastCalledWith({ from: date, to: undefined });
+		});
+
+		it('doesn’t format when a disallowed format is entered', async () => {
+			renderDateRangePicker({
+				allowedDateFormats: ['dd-MM-yyyy'],
+				onChange: onChange,
+			});
+
+			// Type a valid date in the input field that isn't in the allowed format
+			await userEvent.type(await getFromInput(), '05-23-2023');
+			await userEvent.keyboard('{Tab}');
+
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('adds the dateFormat to allowedDateFormats if not explicitly specificied and formats appropriately', async () => {
+			renderDateRangePicker({
+				allowedDateFormats: ['MM/dd/yyyy'],
+				dateFormat: 'dd MMMM yyyy',
+				onChange: onChange,
+			});
+
+			const dateString = '08 February 2023';
+			const date = parseDate(dateString) as Date;
+
+			// Type a valid date in the input field that isn't in the display format
+			await userEvent.type(await getFromInput(), dateString);
+			await userEvent.keyboard('{Tab}');
+
+			expect(onChange).toHaveBeenLastCalledWith({ from: date, to: undefined });
+		});
+	});
+
 	it('legend: renders a hidden legend by default when optional', async () => {
 		const defaultLegend = 'Date range';
 

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -260,47 +260,45 @@ describe('DateRangePicker', () => {
 		);
 
 		let inputs = container.querySelectorAll('input');
-		let calendarTriggers = container.querySelectorAll('button');
 
 		// The inputs should be a formatted display value of `initialValue`
 		expect(inputs[0]).toHaveValue(fromDateString);
 		expect(inputs[1]).toHaveValue(toDateString);
 
 		// The calendar button trigger should have an aria-label with the formatted display value of `initialValue`
-		expect(calendarTriggers[0]).toHaveAttribute(
-			'aria-label',
-			`Change start date, ${fromFormattedDate}`
-		);
-		expect(calendarTriggers[1]).toHaveAttribute(
-			'aria-label',
-			`Change end date, ${toFormattedDate}`
-		);
+		expect(
+			screen.getByRole('button', {
+				name: `Change start date, ${fromFormattedDate}`,
+			})
+		).toBeVisible();
+		expect(
+			screen.getByRole('button', {
+				name: `Change end date, ${toFormattedDate}`,
+			})
+		).toBeVisible();
 
 		// Click the `clear` button to clear the value
 		await userEvent.click(screen.getByTestId('clear'));
 
 		inputs = container.querySelectorAll('input');
-		calendarTriggers = container.querySelectorAll('button');
 
 		// The inputs should be empty
 		expect(inputs[0]).toHaveValue('');
 		expect(inputs[1]).toHaveValue('');
 
 		// The calendar button triggers aria-label should be updated
-		expect(calendarTriggers[0]).toHaveAttribute(
-			'aria-label',
-			'Choose start date'
-		);
-		expect(calendarTriggers[1]).toHaveAttribute(
-			'aria-label',
-			'Choose end date'
-		);
+		expect(
+			screen.getByRole('button', { name: 'Choose start date' })
+		).toBeVisible();
+		expect(
+			screen.getByRole('button', { name: 'Choose end date' })
+		).toBeVisible();
 	});
 
 	it('responds to an `onChange` callback when a date is valid', async () => {
 		const onChange = jest.fn();
 
-		const { container } = renderDateRangePicker({
+		renderDateRangePicker({
 			onChange,
 		});
 
@@ -322,23 +320,23 @@ describe('DateRangePicker', () => {
 
 		expect(onChange).toHaveBeenCalledTimes(2);
 
-		const calendarTriggers = container.querySelectorAll('button');
-
 		// The calendar button triggers should have an aria-label with the formatted display value
-		expect(calendarTriggers[0]).toHaveAttribute(
-			'aria-label',
-			`Change start date, ${fromFormattedDate}`
-		);
-		expect(calendarTriggers[1]).toHaveAttribute(
-			'aria-label',
-			`Change end date, ${toFormattedDate}`
-		);
+		expect(
+			screen.getByRole('button', {
+				name: `Change start date, ${fromFormattedDate}`,
+			})
+		).toBeVisible();
+		expect(
+			screen.getByRole('button', {
+				name: `Change end date, ${toFormattedDate}`,
+			})
+		).toBeVisible();
 	});
 
 	it('responds to an `onFromInputChange` callback when a date is invalid', async () => {
 		const onFromInputChange = jest.fn();
 
-		const { container } = renderDateRangePicker({
+		renderDateRangePicker({
 			onFromInputChange,
 		});
 
@@ -351,19 +349,16 @@ describe('DateRangePicker', () => {
 
 		expect(onFromInputChange).toHaveBeenCalledWith(fromDateString);
 
-		const calendarTriggers = container.querySelectorAll('button');
-
 		// The calendar button triggers should have an aria-label with the formatted display value
-		expect(calendarTriggers[0]).toHaveAttribute(
-			'aria-label',
-			`Choose start date`
-		);
+		expect(
+			screen.getByRole('button', { name: 'Choose start date' })
+		).toBeVisible();
 	});
 
 	it('responds to an `onToInputChange` callback when a date is invalid', async () => {
 		const onToInputChange = jest.fn();
 
-		const { container } = renderDateRangePicker({
+		renderDateRangePicker({
 			onToInputChange,
 		});
 
@@ -376,13 +371,10 @@ describe('DateRangePicker', () => {
 
 		expect(onToInputChange).toHaveBeenCalledWith(toDateString);
 
-		const calendarTriggers = container.querySelectorAll('button');
-
 		// The calendar button triggers should have an aria-label with the formatted display value
-		expect(calendarTriggers[1]).toHaveAttribute(
-			'aria-label',
-			`Choose end date`
-		);
+		expect(
+			screen.getByRole('button', { name: 'Choose end date' })
+		).toBeVisible();
 	});
 
 	it('formats valid dates to the default date format (dd/MM/yyyy)', async () => {

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -56,7 +56,7 @@ type DateRangePickerCalendarProps = {
 
 export type DateRangePickerProps = DateRangePickerCalendarProps & {
 	/** Specifies the date formats that can be parsed. */
-	allowedDateFormats: ReadonlyArray<AcceptedDateFormats>;
+	allowedDateFormats?: ReadonlyArray<AcceptedDateFormats>;
 	/** Describes the purpose of the group of fields. */
 	legend?: string;
 	/** Provides extra information about the group of fields. */
@@ -125,6 +125,7 @@ export const DateRangePicker = ({
 		() =>
 			Array.from(
 				new Set([
+					// We need to ensure that the dateFormat to render is included in allowedDateFormats. It should also be the preferred format.
 					dateFormat,
 					...allowedDateFormatsProp.filter((dateFormat) =>
 						acceptedDateFormats.includes(dateFormat)
@@ -380,11 +381,11 @@ export const DateRangePicker = ({
 							onChange={onFromInputChange}
 							buttonRef={fromTriggerRef}
 							buttonOnClick={onFromTriggerClick}
-							buttonAriaLabel={getDateInputButtonAriaLabel(
-								fromInputValue,
+							buttonAriaLabel={getDateInputButtonAriaLabel({
 								allowedDateFormats,
-								'start'
-							)}
+								rangeName: 'start',
+								value: fromInputValue,
+							})}
 							disabled={disabled}
 							required={required}
 							invalid={{ field: false, input: fromInvalid }}
@@ -402,11 +403,11 @@ export const DateRangePicker = ({
 							onChange={onToInputChange}
 							buttonRef={toTriggerRef}
 							buttonOnClick={onToTriggerClick}
-							buttonAriaLabel={getDateInputButtonAriaLabel(
-								toInputValue,
+							buttonAriaLabel={getDateInputButtonAriaLabel({
 								allowedDateFormats,
-								'end'
-							)}
+								rangeName: 'end',
+								value: toInputValue,
+							})}
 							disabled={disabled}
 							required={required}
 							invalid={{ field: false, input: toInvalid }}

--- a/packages/react/src/date-range-picker/docs/overview.mdx
+++ b/packages/react/src/date-range-picker/docs/overview.mdx
@@ -70,17 +70,17 @@ In this case, you can use the `onFromInputChange` and `onToInputChange` props to
 	const toInvalid = isInvalid(value.from);
 
 	const onFromInputChange = (from) => {
-		console.log(`onFromInputChange`, from);
+		console.log('onFromInputChange', from);
 		setValue({ ...value, from });
 	};
 
 	const onToInputChange = (to) => {
-		console.log(`onToInputChange`, to);
+		console.log('onToInputChange', to);
 		setValue({ ...value, to });
 	};
 
 	const onChange = (e) => {
-		console.log(`onChange`, e);
+		console.log('onChange', e);
 		setValue(e);
 	};
 
@@ -290,6 +290,61 @@ To modify the date format, you can change the `dateFormat` prop to one of these 
 			onFromInputChange={(from) => setValue({ ...value, from })}
 			onToInputChange={(to) => setValue({ ...value, to })}
 			dateFormat="d MMM yyyy"
+		/>
+	);
+};
+```
+
+## Changing the allowed date formats
+
+By default, all of the supported date formats are allowed, but should you need to restrict the formats that can be parsed and validated, you can pass in an array of date format strings to the `allowedDateFormats` prop.
+
+Some applications may find it useful to remove US formats, since an invalid AU date could become a valid US date and cause confusion for users.
+
+Date formats are parsed in order from first to last and stops when a valid date is found. The preferred `dateFormat` always becomes the first to check, even if omitted in `allowedDateFormats`.
+
+```jsx live
+() => {
+	// Set the value to a value that the user might think is valid
+	const [value, setValue] = React.useState({ from: '', to: '' });
+
+	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.
+	// See Single-page form template
+	const isInvalid = React.useCallback((value) => {
+		if (typeof value === 'undefined' || value == '') return false;
+		if (value instanceof Date && !isNaN(value.getTime())) return false;
+		return true;
+	}, []);
+
+	const fromInvalid = isInvalid(value.from);
+	const toInvalid = isInvalid(value.from);
+
+	const onFromInputChange = (from) => {
+		console.log('onFromInputChange', from);
+		setValue({ ...value, from });
+	};
+
+	const onToInputChange = (to) => {
+		console.log('onToInputChange', to);
+		setValue({ ...value, to });
+	};
+
+	const onChange = (e) => {
+		console.log('onChange', e);
+		setValue(e);
+	};
+
+	return (
+		<DateRangePicker
+			value={value}
+			onChange={onChange}
+			onFromInputChange={onFromInputChange}
+			onToInputChange={onToInputChange}
+			fromInvalid={fromInvalid}
+			toInvalid={toInvalid}
+			message={fromInvalid || toInvalid ? 'Enter a valid date' : undefined}
+			hint="Only short AU formats allowed"
+			allowedDateFormats={['dd MM yyyy', 'dd-MM-yyyy']}
 		/>
 	);
 };

--- a/packages/react/src/date-range-picker/docs/overview.mdx
+++ b/packages/react/src/date-range-picker/docs/overview.mdx
@@ -69,19 +69,19 @@ In this case, you can use the `onFromInputChange` and `onToInputChange` props to
 	const fromInvalid = isInvalid(value.from);
 	const toInvalid = isInvalid(value.from);
 
-	const onFromInputChange = (from) => {
-		console.log('onFromInputChange', from);
-		setValue({ ...value, from });
+	const onFromInputChange = (fromValue) => {
+		console.log('onFromInputChange', fromValue);
+		setValue({ ...value, fromValue });
 	};
 
-	const onToInputChange = (to) => {
-		console.log('onToInputChange', to);
-		setValue({ ...value, to });
+	const onToInputChange = (toValue) => {
+		console.log('onToInputChange', toValue);
+		setValue({ ...value, toValue });
 	};
 
-	const onChange = (e) => {
-		console.log('onChange', e);
-		setValue(e);
+	const onChange = (dateRange) => {
+		console.log('onChange', dateRange);
+		setValue(dateRange);
 	};
 
 	return (
@@ -319,19 +319,19 @@ Date formats are parsed in order from first to last and stops when a valid date 
 	const fromInvalid = isInvalid(value.from);
 	const toInvalid = isInvalid(value.from);
 
-	const onFromInputChange = (from) => {
-		console.log('onFromInputChange', from);
-		setValue({ ...value, from });
+	const onFromInputChange = (fromValue) => {
+		console.log('onFromInputChange', fromValue);
+		setValue({ ...value, fromValue });
 	};
 
-	const onToInputChange = (to) => {
-		console.log('onToInputChange', to);
-		setValue({ ...value, to });
+	const onToInputChange = (toValue) => {
+		console.log('onToInputChange', toValue);
+		setValue({ ...value, toValue });
 	};
 
-	const onChange = (e) => {
-		console.log('onChange', e);
-		setValue(e);
+	const onChange = (dateRange) => {
+		console.log('onChange', dateRange);
+		setValue(dateRange);
 	};
 
 	return (

--- a/packages/react/src/date-range-picker/utils.test.ts
+++ b/packages/react/src/date-range-picker/utils.test.ts
@@ -1,10 +1,5 @@
 import { subMonths } from 'date-fns';
-import {
-	ensureValidDateRange,
-	getCalendarDefaultMonth,
-	getFromDateInputButtonAriaLabel,
-	getToDateInputButtonAriaLabel,
-} from './utils';
+import { ensureValidDateRange, getCalendarDefaultMonth } from './utils';
 
 describe('ensureValidDateRange', () => {
 	const validDateRange = {
@@ -94,39 +89,5 @@ describe('getCalendarDefaultMonth', () => {
 				numberOfMonths
 			)?.getFullYear()
 		).toEqual(1990);
-	});
-});
-
-describe('getFromDateInputButtonAriaLabel', () => {
-	it('returns `Choose start date` when no date is set', () => {
-		expect(getFromDateInputButtonAriaLabel(undefined)).toEqual(
-			'Choose start date'
-		);
-		expect(getFromDateInputButtonAriaLabel('')).toEqual('Choose start date');
-	});
-
-	it('returns `Change start date, x` when a date is set', () => {
-		expect(getFromDateInputButtonAriaLabel('14/02/1990')).toEqual(
-			'Change start date, 14th February 1990 (Wednesday)'
-		);
-		expect(getFromDateInputButtonAriaLabel('05/06/2010')).toEqual(
-			'Change start date, 5th June 2010 (Saturday)'
-		);
-	});
-});
-
-describe('getToDateInputButtonAriaLabel', () => {
-	it('returns `Choose end date` when no date is set', () => {
-		expect(getToDateInputButtonAriaLabel(undefined)).toEqual('Choose end date');
-		expect(getToDateInputButtonAriaLabel('')).toEqual('Choose end date');
-	});
-
-	it('returns `Change end date, x` when a date is set', () => {
-		expect(getToDateInputButtonAriaLabel('14/02/1990')).toEqual(
-			'Change end date, 14th February 1990 (Wednesday)'
-		);
-		expect(getToDateInputButtonAriaLabel('05/06/2010')).toEqual(
-			'Change end date, 5th June 2010 (Saturday)'
-		);
 	});
 });

--- a/packages/react/src/date-range-picker/utils.ts
+++ b/packages/react/src/date-range-picker/utils.ts
@@ -4,7 +4,11 @@ import {
 	differenceInCalendarMonths,
 	closestTo,
 } from 'date-fns';
-import { formatHumanReadableDate, parseDate } from '../date-picker/utils';
+import {
+	type AcceptedDateFormats,
+	formatHumanReadableDate,
+	parseDate,
+} from '../date-picker/utils';
 
 // If the end date is before the start date, swap the end date with the start
 // This prevents the users from typing invalid date ranges
@@ -72,17 +76,23 @@ export function getCalendarDefaultMonth(
 }
 
 // Gets the `aria-label` for the button that opens the start date calendar picker
-export function getFromDateInputButtonAriaLabel(value: string | undefined) {
+export function getFromDateInputButtonAriaLabel(
+	value: string | undefined,
+	allowedDateFormats: ReadonlyArray<AcceptedDateFormats>
+) {
 	if (typeof value !== 'string') return 'Choose start date';
-	const parsed = parseDate(value);
+	const parsed = parseDate(value, allowedDateFormats);
 	if (!parsed) return 'Choose start date';
 	return `Change start date, ${formatHumanReadableDate(parsed)}`;
 }
 
 // Gets the `aria-label` for the button that opens the end date calendar picker
-export function getToDateInputButtonAriaLabel(value: string | undefined) {
+export function getToDateInputButtonAriaLabel(
+	value: string | undefined,
+	allowedDateFormats: ReadonlyArray<AcceptedDateFormats>
+) {
 	if (typeof value !== 'string') return 'Choose end date';
-	const parsed = parseDate(value);
+	const parsed = parseDate(value, allowedDateFormats);
 	if (!parsed) return 'Choose end date';
 	return `Change end date, ${formatHumanReadableDate(parsed)}`;
 }

--- a/packages/react/src/date-range-picker/utils.ts
+++ b/packages/react/src/date-range-picker/utils.ts
@@ -1,8 +1,8 @@
 import {
+	closestTo,
+	differenceInCalendarMonths,
 	isBefore,
 	subMonths,
-	differenceInCalendarMonths,
-	closestTo,
 } from 'date-fns';
 import {
 	type AcceptedDateFormats,


### PR DESCRIPTION
Some consumers of the date pickers complained that their apps which only wanted AU date support were causing confusion for users when they accidentally entered an invalid AU date, but a valid US one, and thus formatting to US.

The solution was to add an `allowedDateFormats` prop so consumers can customise which they support.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1708)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets