### PR TITLE
task-list: Change visual order of items

### DIFF
--- a/.changeset/lazy-books-cry.md
+++ b/.changeset/lazy-books-cry.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+task-list: Change visual order of items to Title, Label and Message.
+
+general: Use the correct CSS syntax for `::before` and `::after` pseudo-elements.

--- a/packages/react/src/_collapsing-side-bar/__snapshots__/CollapsingSideBar.test.tsx.snap
+++ b/packages/react/src/_collapsing-side-bar/__snapshots__/CollapsingSideBar.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CollapsingSideBar renders correctly 1`] = `
     <button
       aria-controls="collapsing-side-bar-:r0:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r0:-button"
       type="button"
     >

--- a/packages/react/src/a11y/__snapshots__/ExternalLinkCallout.test.tsx.snap
+++ b/packages/react/src/a11y/__snapshots__/ExternalLinkCallout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ExternalLinkCallout renders correctly 1`] = `
 <div>
   <a
-    class="css-ma0bjl-TextLink"
+    class="css-koqz57-TextLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/a11y/__snapshots__/VisuallyHidden.test.tsx.snap
+++ b/packages/react/src/a11y/__snapshots__/VisuallyHidden.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`VisuallyHidden renders correctly 1`] = `
 <div>
   <a
-    class="css-ma0bjl-TextLink"
+    class="css-koqz57-TextLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r0:-body"
           aria-expanded="false"
-          class="css-ira57b-BaseButton-boxStyles-AccordionTitle"
+          class="css-1om6ji7-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r0:-title"
           type="button"
         >
@@ -66,7 +66,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r1:-body"
           aria-expanded="false"
-          class="css-ira57b-BaseButton-boxStyles-AccordionTitle"
+          class="css-1om6ji7-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r1:-title"
           type="button"
         >

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -193,7 +193,7 @@ function AppLayoutSidebarNavItemInner({
 							boxPalette[
 								background === 'body' ? 'backgroundShade' : 'backgroundShadeAlt'
 							],
-						'&:before': {
+						'&::before': {
 							content: "''",
 							position: 'absolute',
 							top: 0,

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -334,7 +334,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-qmt8p8-AppLayoutSidebarNavItemInner"
+            class="css-419dm2-AppLayoutSidebarNavItemInner"
           >
             <a
               aria-current="page"
@@ -532,7 +532,7 @@ exports[`AppLayout renders correctly 1`] = `
                     class="css-79i25n-boxStyles"
                   >
                     <a
-                      class="css-ma0bjl-TextLink"
+                      class="css-koqz57-TextLink"
                       href="/"
                     >
                       Home

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -552,7 +552,7 @@ export const linkStyles = {
 
 	// Display link URLs
 	'@media print': {
-		'&[href]:after': {
+		'&[href]::after': {
 			content: '" (" attr(href) ")" !important',
 		},
 	},

--- a/packages/react/src/breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/react/src/breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
           />
         </svg>
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#home"
         >
           Home
@@ -56,7 +56,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
         <button
           aria-expanded="false"
           aria-label="Expand list"
-          class="css-1idhw1e-BaseButton-boxStyles"
+          class="css-eqfuua-BaseButton-boxStyles"
           type="button"
         >
           …
@@ -82,7 +82,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
           />
         </svg>
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#establishments"
         >
           Establishments

--- a/packages/react/src/call-to-action/__snapshots__/CallToAction.test.tsx.snap
+++ b/packages/react/src/call-to-action/__snapshots__/CallToAction.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CallToActionButton renders correctly 1`] = `
     class="css-zce95a-boxStyles-CallToAction"
   >
     <button
-      class="css-zekh05-BaseButton-boxStyles"
+      class="css-fp5x03-BaseButton-boxStyles"
       data-testid="example"
       type="button"
     >
@@ -38,7 +38,7 @@ exports[`CallToActionLink renders correctly 1`] = `
     class="css-zce95a-boxStyles-CallToAction"
   >
     <a
-      class="css-5s16cd-TextLink-boxStyles"
+      class="css-19iivh0-TextLink-boxStyles"
       data-testid="example"
       href="#"
     >

--- a/packages/react/src/card/CardLink.tsx
+++ b/packages/react/src/card/CardLink.tsx
@@ -14,7 +14,7 @@ export const CardLink = (props: CardLinkProps) => {
 					justifyContent: 'space-between',
 					// NOTE: no focus styles here because the parent Card does it.
 					'&:focus, &:focus-visible': { outline: 'none' },
-					'&:after': {
+					'&::after': {
 						content: '""',
 						position: 'absolute',
 						top: 0,

--- a/packages/react/src/card/__snapshots__/Card.test.tsx.snap
+++ b/packages/react/src/card/__snapshots__/Card.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Card With link renders correctly 1`] = `
           Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptat
         </p>
         <a
-          class="css-190821o-CardLink"
+          class="css-2leob8-CardLink"
           href="#"
         >
           Linking out

--- a/packages/react/src/date-picker/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/Calendar.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Calendar Range renders correctly 1`] = `
     data-focus-lock-disabled="false"
   >
     <div
-      class="css-pnuomw-boxStyles-CalendarRangeContainer"
+      class="css-x2ztpa-boxStyles-CalendarRangeContainer"
     >
       <div
         class="rdp "
@@ -898,7 +898,7 @@ exports[`Calendar Single renders correctly 1`] = `
     data-focus-lock-disabled="false"
   >
     <div
-      class="css-yqy9oa-boxStyles-CalendarContainer"
+      class="css-1exdz5y-boxStyles-CalendarContainer"
     >
       <div
         class="rdp "

--- a/packages/react/src/date-picker/reactDayPickerStyles.ts
+++ b/packages/react/src/date-picker/reactDayPickerStyles.ts
@@ -93,7 +93,7 @@ export const reactDayPickerStyles = {
 		'&.rdp-day_today': {
 			position: 'relative',
 			fontWeight: tokens.fontWeight.bold,
-			'&:after': {
+			'&::after': {
 				content: '""',
 				position: 'absolute',
 				bottom: '0.3rem',

--- a/packages/react/src/details/__snapshots__/Details.test.tsx.snap
+++ b/packages/react/src/details/__snapshots__/Details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details renders correctly 1`] = `
     class="css-jx8h3p-Details"
   >
     <summary
-      class="css-1k6zl6h-boxStyles"
+      class="css-1tv6yf1-boxStyles"
     >
       Details
       <svg

--- a/packages/react/src/direction-link/__snapshots__/DirectionLink.test.tsx.snap
+++ b/packages/react/src/direction-link/__snapshots__/DirectionLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DirectionButton direction: down renders correctly 1`] = `
 <div>
   <button
-    class="css-p2yjdo-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Skip to footer
@@ -33,7 +33,7 @@ exports[`DirectionButton direction: down renders correctly 1`] = `
 exports[`DirectionButton direction: left renders correctly 1`] = `
 <div>
   <button
-    class="css-p2yjdo-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     <svg
@@ -63,7 +63,7 @@ exports[`DirectionButton direction: left renders correctly 1`] = `
 exports[`DirectionButton direction: right renders correctly 1`] = `
 <div>
   <button
-    class="css-p2yjdo-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Next
@@ -93,7 +93,7 @@ exports[`DirectionButton direction: right renders correctly 1`] = `
 exports[`DirectionButton direction: up renders correctly 1`] = `
 <div>
   <button
-    class="css-p2yjdo-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Top
@@ -123,7 +123,7 @@ exports[`DirectionButton direction: up renders correctly 1`] = `
 exports[`DirectionLink direction: down renders correctly 1`] = `
 <div>
   <a
-    class="css-mpuvkh-TextLink-boxStyles-BaseDirectionLink"
+    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
   >
     Skip to footer
     <svg
@@ -152,7 +152,7 @@ exports[`DirectionLink direction: down renders correctly 1`] = `
 exports[`DirectionLink direction: left renders correctly 1`] = `
 <div>
   <a
-    class="css-mpuvkh-TextLink-boxStyles-BaseDirectionLink"
+    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
   >
     <svg
       aria-hidden="true"
@@ -181,7 +181,7 @@ exports[`DirectionLink direction: left renders correctly 1`] = `
 exports[`DirectionLink direction: right renders correctly 1`] = `
 <div>
   <a
-    class="css-mpuvkh-TextLink-boxStyles-BaseDirectionLink"
+    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
   >
     Next
     <svg
@@ -210,7 +210,7 @@ exports[`DirectionLink direction: right renders correctly 1`] = `
 exports[`DirectionLink direction: up renders correctly 1`] = `
 <div>
   <a
-    class="css-mpuvkh-TextLink-boxStyles-BaseDirectionLink"
+    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
   >
     Top
     <svg

--- a/packages/react/src/dropdown-menu/DropdownMenuItemRadio.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuItemRadio.tsx
@@ -81,7 +81,7 @@ export function DropdownMenuItemRadio({
 				...(checked && {
 					backgroundColor: boxPalette.selectedMuted,
 					position: 'relative',
-					'&:before': {
+					'&::before': {
 						content: "''",
 						position: 'absolute',
 						top: 0,

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:rv:"
       role="menuitem"
       tabindex="-1"
@@ -86,7 +86,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r10:"
       role="menuitem"
       tabindex="-1"
@@ -137,7 +137,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       class="css-1th2zfi-Divider"
     />
     <div
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r11:"
       role="menuitem"
       tabindex="-1"
@@ -226,7 +226,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     tabindex="-1"
   >
     <a
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       href="/about"
       id="dropdown-menu-:r16:-item-:r17:"
       role="menuitem"
@@ -246,7 +246,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       />
     </a>
     <a
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       href="/contact"
       id="dropdown-menu-:r16:-item-:r18:"
       role="menuitem"
@@ -350,7 +350,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
       </div>
       <div
         aria-checked="true"
-        class="css-1yrn77q-boxStyles-DropdownMenuItemRadio"
+        class="css-llmtoq-boxStyles-DropdownMenuItemRadio"
         id="item-2"
         role="menuitemradio"
       >
@@ -447,7 +447,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r1:"
       role="menuitem"
       tabindex="-1"
@@ -466,7 +466,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r2:"
       role="menuitem"
       tabindex="-1"
@@ -485,7 +485,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-17dk25j-boxStyles-DropdownMenuItem"
+      class="css-1jn0u66-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r3:"
       role="menuitem"
       tabindex="-1"

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -492,7 +492,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
                   class="css-ayz5ov-boxStyles"
                 >
                   <a
-                    class="css-ma0bjl-TextLink"
+                    class="css-koqz57-TextLink"
                     href="#"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -608,7 +608,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
                   class="css-ayz5ov-boxStyles"
                 >
                   <a
-                    class="css-ma0bjl-TextLink"
+                    class="css-koqz57-TextLink"
                     href="#"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/react/src/filter-sidebar/__snapshots__/FilterSidebar.test.tsx.snap
+++ b/packages/react/src/filter-sidebar/__snapshots__/FilterSidebar.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`FilterSidebar renders correctly 1`] = `
     <button
       aria-controls="collapsing-side-bar-:r0:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r0:-button"
       type="button"
     >

--- a/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-ma0bjl-TextLink"
+              class="css-koqz57-TextLink"
               href="#"
             >
               Home
@@ -28,7 +28,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-ma0bjl-TextLink"
+              class="css-koqz57-TextLink"
               href="#"
             >
               Terms and conditions
@@ -38,7 +38,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-ma0bjl-TextLink"
+              class="css-koqz57-TextLink"
               href="#"
             >
               Privacy policy
@@ -48,7 +48,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-ma0bjl-TextLink"
+              class="css-koqz57-TextLink"
               href="#"
             >
               A really long link title

--- a/packages/react/src/hero-banner/HeroBanner/HeroBannerImage.tsx
+++ b/packages/react/src/hero-banner/HeroBanner/HeroBannerImage.tsx
@@ -22,7 +22,7 @@ export const HeroBannerImage = ({
 				right: 0,
 				bottom: 0,
 
-				'&:after': {
+				'&::after': {
 					content: '""',
 					pointerEvents: 'none',
 					position: 'absolute',

--- a/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`HeroBanner renders correctly 1`] = `
             </button>
           </div>
           <div
-            class="css-u86tm4-boxStyles-HeroBannerImage"
+            class="css-1w4w4c9-boxStyles-HeroBannerImage"
           >
             <img
               alt=""

--- a/packages/react/src/hero-banner/HeroCategoryBanner/HeroCategoryBannerImage.tsx
+++ b/packages/react/src/hero-banner/HeroCategoryBanner/HeroCategoryBannerImage.tsx
@@ -22,7 +22,7 @@ export const HeroCategoryBannerImage = ({
 				right: 0,
 				bottom: 0,
 
-				'&:after': {
+				'&::after': {
 					content: '""',
 					pointerEvents: 'none',
 					position: 'absolute',

--- a/packages/react/src/hero-banner/HeroCategoryBanner/__snapshots__/HeroCategoryBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroCategoryBanner/__snapshots__/HeroCategoryBanner.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`HeroCategoryBanner renders correctly 1`] = `
             </p>
           </div>
           <div
-            class="css-uhwge9-boxStyles-HeroCategoryBannerImage"
+            class="css-r0htuo-boxStyles-HeroCategoryBannerImage"
           >
             <img
               alt=""

--- a/packages/react/src/hero-banner/HeroSubcategoryBanner/__snapshots__/HeroSubCategoryBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroSubcategoryBanner/__snapshots__/HeroSubCategoryBanner.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                   />
                 </svg>
                 <a
-                  class="css-ma0bjl-TextLink"
+                  class="css-koqz57-TextLink"
                   href="#"
                 >
                   Section 1
@@ -68,7 +68,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                 <button
                   aria-expanded="false"
                   aria-label="Expand list"
-                  class="css-1idhw1e-BaseButton-boxStyles"
+                  class="css-eqfuua-BaseButton-boxStyles"
                   type="button"
                 >
                   …
@@ -94,7 +94,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                   />
                 </svg>
                 <a
-                  class="css-ma0bjl-TextLink"
+                  class="css-koqz57-TextLink"
                   href="#"
                 >
                   Category page

--- a/packages/react/src/inpage-nav/__snapshots__/InpageNav.test.tsx.snap
+++ b/packages/react/src/inpage-nav/__snapshots__/InpageNav.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#section-1"
         >
           Section 1
@@ -23,7 +23,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#section-2"
         >
           Section 2
@@ -33,7 +33,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#section-3"
         >
           Section 3
@@ -43,7 +43,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#section-4"
         >
           Section 4
@@ -53,7 +53,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#section-5"
         >
           Section 5

--- a/packages/react/src/link-list/__snapshots__/LinkList.test.tsx.snap
+++ b/packages/react/src/link-list/__snapshots__/LinkList.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-ma0bjl-TextLink"
+        class="css-koqz57-TextLink"
         href="#"
       >
         Home
@@ -19,7 +19,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-ma0bjl-TextLink"
+        class="css-koqz57-TextLink"
         href="#"
       >
         Establishments
@@ -29,7 +29,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-ma0bjl-TextLink"
+        class="css-koqz57-TextLink"
         href="#"
       >
         Applications
@@ -39,7 +39,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-ma0bjl-TextLink"
+        class="css-koqz57-TextLink"
         href="https://design-system.agriculture.gov.au"
         rel="noopener"
         target="_blank"

--- a/packages/react/src/main-nav/MainNavListItem.tsx
+++ b/packages/react/src/main-nav/MainNavListItem.tsx
@@ -42,7 +42,7 @@ export function MainNavListItem({
 					// Active styles
 					...(active && {
 						color: boxPalette.foregroundText,
-						'&:after': {
+						'&::after': {
 							content: '""',
 							height: mapSpacing(0.5),
 							position: 'absolute',
@@ -59,7 +59,7 @@ export function MainNavListItem({
 						...focusStyles[':focus-visible'],
 						// Make sure the outline is not cut off by the pseudo element
 						zIndex: 1,
-						'&:after': { zIndex: -1 },
+						'&::after': { zIndex: -1 },
 					},
 
 					// Hover styles

--- a/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`MainNav renders correctly 1`] = `
           class="css-1jhrbpg-boxStyles"
         >
           <li
-            class="css-1e0n7jq-boxStyles-MainNavListItem"
+            class="css-1fvix7x-boxStyles-MainNavListItem"
           >
             <a
               href="/"
@@ -57,7 +57,7 @@ exports[`MainNav renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1e0n7jq-boxStyles-MainNavListItem"
+            class="css-1fvix7x-boxStyles-MainNavListItem"
           >
             <a
               href="/content"
@@ -68,7 +68,7 @@ exports[`MainNav renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1e0n7jq-boxStyles-MainNavListItem"
+            class="css-1fvix7x-boxStyles-MainNavListItem"
           >
             <a
               href="/form"
@@ -79,7 +79,7 @@ exports[`MainNav renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1nz3t6v-boxStyles-MainNavListItem"
+            class="css-1mfistu-boxStyles-MainNavListItem"
           >
             <a
               aria-current="page"
@@ -100,7 +100,7 @@ exports[`MainNav renders correctly 1`] = `
           class="css-1jhrbpg-boxStyles"
         >
           <li
-            class="css-1cp7t2w-boxStyles-MainNavListItem"
+            class="css-r39s9d-boxStyles-MainNavListItem"
           >
             <a
               href="#sign-in"

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`PageAlert tone: error renders correctly 1`] = `
             class="css-1sudq1l-boxStyles-ListItem"
           >
             <a
-              class="css-ma0bjl-TextLink"
+              class="css-koqz57-TextLink"
               href="#"
             >
               Full name must not be empty

--- a/packages/react/src/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react/src/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Pagination renders correctly 1`] = `
         >
           <a
             aria-label="Go to previous page"
-            class="css-png6p8-TextLink-boxStyles-BaseDirectionLink"
+            class="css-1g4vex8-TextLink-boxStyles-BaseDirectionLink"
             href="page-4"
           >
             <svg
@@ -48,7 +48,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 1"
-            class="css-3n883g-boxStyles"
+            class="css-uwmdrc-boxStyles"
             href="page-1"
           >
             1
@@ -66,7 +66,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 4"
-            class="css-3n883g-boxStyles"
+            class="css-uwmdrc-boxStyles"
             href="page-4"
           >
             4
@@ -76,7 +76,7 @@ exports[`Pagination renders correctly 1`] = `
           <a
             aria-current="page"
             aria-label="Go to page 5"
-            class="css-8bhquh-boxStyles-PaginationItemPage"
+            class="css-1m003dh-boxStyles-PaginationItemPage"
             href="page-5"
           >
             5
@@ -85,7 +85,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 6"
-            class="css-3n883g-boxStyles"
+            class="css-uwmdrc-boxStyles"
             href="page-6"
           >
             6
@@ -103,7 +103,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 10"
-            class="css-3n883g-boxStyles"
+            class="css-uwmdrc-boxStyles"
             href="page-10"
           >
             10
@@ -114,7 +114,7 @@ exports[`Pagination renders correctly 1`] = `
         >
           <a
             aria-label="Go to next page"
-            class="css-png6p8-TextLink-boxStyles-BaseDirectionLink"
+            class="css-1g4vex8-TextLink-boxStyles-BaseDirectionLink"
             href="page-6"
           >
             <span

--- a/packages/react/src/pagination/__snapshots__/PaginationButtons.test.tsx.snap
+++ b/packages/react/src/pagination/__snapshots__/PaginationButtons.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         >
           <button
             aria-label="Go to previous page"
-            class="css-rs8ftg-BaseButton-boxStyles-BaseDirectionLink"
+            class="css-1svh3o-BaseButton-boxStyles-BaseDirectionLink"
             type="button"
           >
             <svg
@@ -48,7 +48,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 1"
-            class="css-1yifu8x-BaseButton-boxStyles"
+            class="css-12wo8us-BaseButton-boxStyles"
             type="button"
           >
             1
@@ -66,7 +66,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 4"
-            class="css-1yifu8x-BaseButton-boxStyles"
+            class="css-12wo8us-BaseButton-boxStyles"
             type="button"
           >
             4
@@ -76,7 +76,7 @@ exports[`PaginationButtons renders correctly 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 5"
-            class="css-1gs1cx7-BaseButton-boxStyles-PaginationItemPageButton"
+            class="css-1rvez9h-BaseButton-boxStyles-PaginationItemPageButton"
             type="button"
           >
             5
@@ -85,7 +85,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 6"
-            class="css-1yifu8x-BaseButton-boxStyles"
+            class="css-12wo8us-BaseButton-boxStyles"
             type="button"
           >
             6
@@ -103,7 +103,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 10"
-            class="css-1yifu8x-BaseButton-boxStyles"
+            class="css-12wo8us-BaseButton-boxStyles"
             type="button"
           >
             10
@@ -114,7 +114,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="css-rs8ftg-BaseButton-boxStyles-BaseDirectionLink"
+            class="css-1svh3o-BaseButton-boxStyles-BaseDirectionLink"
             type="button"
           >
             <span

--- a/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
@@ -72,7 +72,7 @@ export const ProgressIndicatorItem = ({
 					gridTemplateColumns: 'min-content 1fr',
 					textDecoration: 'none',
 					width: '100%',
-					[`[${progressIndicatorItemRingDataAttr}]:before`]: {
+					[`[${progressIndicatorItemRingDataAttr}]::before`]: {
 						backgroundColor: backgroundColorMap[background],
 					},
 				}}
@@ -202,7 +202,7 @@ const ProgressIndicatorItemIcon = ({
 					paddingLeft: ringInset,
 					paddingRight: ringInset,
 					...(isActive && {
-						':before': {
+						'::before': {
 							position: 'absolute',
 							top: -ringInset,
 							bottom: -ringInset,

--- a/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
     <button
       aria-controls="collapsing-side-bar-:r0:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r0:-button"
       type="button"
     >
@@ -59,7 +59,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -97,7 +97,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -119,7 +119,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -155,7 +155,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -177,7 +177,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -187,7 +187,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -229,7 +229,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
               </span>
               <a
                 aria-current="true"
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -251,7 +251,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -293,7 +293,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -315,7 +315,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -354,7 +354,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -376,7 +376,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -427,7 +427,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -449,7 +449,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -486,7 +486,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -533,7 +533,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
     <button
       aria-controls="collapsing-side-bar-:r2:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r2:-button"
       type="button"
     >
@@ -570,7 +570,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -630,7 +630,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -688,7 +688,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -698,7 +698,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -762,7 +762,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -826,7 +826,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -887,7 +887,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -960,7 +960,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1044,7 +1044,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
     <button
       aria-controls="collapsing-side-bar-:r5:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r5:-button"
       type="button"
     >
@@ -1081,7 +1081,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1141,7 +1141,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1151,7 +1151,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -1200,7 +1200,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1273,7 +1273,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1337,7 +1337,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1398,7 +1398,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1471,7 +1471,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1555,7 +1555,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
     <button
       aria-controls="collapsing-side-bar-:r4:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r4:-button"
       type="button"
     >
@@ -1592,7 +1592,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1630,7 +1630,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1652,7 +1652,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1662,7 +1662,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -1689,7 +1689,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
               </span>
               <a
                 aria-current="true"
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1711,7 +1711,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1762,7 +1762,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1784,7 +1784,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1826,7 +1826,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1848,7 +1848,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1887,7 +1887,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1909,7 +1909,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -1960,7 +1960,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1982,7 +1982,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2019,7 +2019,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2066,7 +2066,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
     <button
       aria-controls="collapsing-side-bar-:r7:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r7:-button"
       type="button"
     >
@@ -2103,7 +2103,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2163,7 +2163,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2221,7 +2221,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2231,7 +2231,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -2295,7 +2295,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2359,7 +2359,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2420,7 +2420,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2493,7 +2493,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2577,7 +2577,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
     <button
       aria-controls="collapsing-side-bar-:r6:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r6:-button"
       type="button"
     >
@@ -2614,7 +2614,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2652,7 +2652,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2674,7 +2674,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2710,7 +2710,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2732,7 +2732,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2742,7 +2742,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -2784,7 +2784,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
               </span>
               <a
                 aria-current="true"
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2806,7 +2806,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2848,7 +2848,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2870,7 +2870,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2909,7 +2909,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2931,7 +2931,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -2982,7 +2982,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3004,7 +3004,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3041,7 +3041,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3088,7 +3088,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
     <button
       aria-controls="collapsing-side-bar-:r9:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r9:-button"
       type="button"
     >
@@ -3125,7 +3125,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3185,7 +3185,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3243,7 +3243,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3316,7 +3316,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3380,7 +3380,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3441,7 +3441,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3451,7 +3451,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -3515,7 +3515,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3599,7 +3599,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
     <button
       aria-controls="collapsing-side-bar-:r8:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r8:-button"
       type="button"
     >
@@ -3636,7 +3636,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3674,7 +3674,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3696,7 +3696,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3732,7 +3732,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3754,7 +3754,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3805,7 +3805,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3827,7 +3827,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3869,7 +3869,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3891,7 +3891,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3930,7 +3930,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3952,7 +3952,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -3962,7 +3962,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
-                  class="css-liqiuw-ProgressIndicatorItemIcon"
+                  class="css-1b68qsy-ProgressIndicatorItemIcon"
                   data-agds-progress-indicator-item-ring=""
                 >
                   <svg
@@ -4004,7 +4004,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
               </span>
               <a
                 aria-current="true"
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4026,7 +4026,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
             class="css-10qlzin-boxStyles-ProgressIndicatorItem"
           >
             <span
-              class="css-sx8ayf-boxStyles-ProgressIndicatorItem"
+              class="css-hy9ygk-boxStyles-ProgressIndicatorItem"
             >
               <span
                 class="css-11emnjx-boxStyles"
@@ -4063,7 +4063,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-amnlrl-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >

--- a/packages/react/src/prose/Prose.tsx
+++ b/packages/react/src/prose/Prose.tsx
@@ -359,11 +359,11 @@ export const proseClass = css({
 	 */
 	'@media print': {
 		// Display link URLs
-		'a[href]:after': {
+		'a[href]::after': {
 			content: '" (" attr(href) ")" !important',
 		},
 		// Expand abbreviations
-		'abbr[title]:after': {
+		'abbr[title]::after': {
 			content: '" (" attr(title) ")"',
 		},
 		// Page breaks

--- a/packages/react/src/side-nav/SideNavLink.tsx
+++ b/packages/react/src/side-nav/SideNavLink.tsx
@@ -59,7 +59,7 @@ export const SideNavLink = ({
 					color: boxPalette.foregroundText,
 					backgroundColor: collapsingSideBarLocalPalette.hover,
 					fontWeight: tokens.fontWeight.bold,
-					':before': {
+					'::before': {
 						content: '""',
 						position: 'absolute',
 						top: 0,

--- a/packages/react/src/side-nav/SideNavListItem.tsx
+++ b/packages/react/src/side-nav/SideNavListItem.tsx
@@ -14,7 +14,7 @@ export function SideNavListItem({ children, isActive }: SideNavLinkProps) {
 				depth === 1 && isActive
 					? {
 							position: 'relative',
-							':before': {
+							'::before': {
 								borderLeftColor: boxPalette.borderMuted,
 								borderLeftStyle: 'solid',
 								borderLeftWidth: tokens.borderWidth.xl,

--- a/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`SideNav renders correctly 1`] = `
     <button
       aria-controls="collapsing-side-bar-:r1:-body"
       aria-expanded="false"
-      class="css-15g5ot9-BaseButton-boxStyles-SideBarCollapseButton"
+      class="css-1eu6n4a-BaseButton-boxStyles-SideBarCollapseButton"
       id="collapsing-side-bar-:r1:-button"
       type="button"
     >
@@ -145,11 +145,11 @@ exports[`SideNav renders correctly 1`] = `
               </a>
             </li>
             <li
-              class="css-u3jbms-SideNavListItem"
+              class="css-1bonpgi-SideNavListItem"
             >
               <a
                 aria-current="page"
-                class="css-mqbg66-boxStyles-SideNavLink"
+                class="css-johbbs-boxStyles-SideNavLink"
                 href="/in-detail"
               >
                 <span

--- a/packages/react/src/skeleton/SkeletonBox.tsx
+++ b/packages/react/src/skeleton/SkeletonBox.tsx
@@ -38,7 +38,7 @@ export const SkeletonBox = ({
 				animation: `${animateFadeOut} 1200ms ${tokens.transition.timingFunction} infinite alternate`,
 				backgroundColor: boxPalette.border,
 				cursor: 'progress',
-				'&:before': {
+				'&::before': {
 					content: '"\\00a0"',
 				},
 			}}

--- a/packages/react/src/skeleton/__snapshots__/SkeletonBox.test.tsx.snap
+++ b/packages/react/src/skeleton/__snapshots__/SkeletonBox.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SkeletonBox renders correctly 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="css-dhmzqr-boxStyles-SkeletonBox"
+    class="css-b9v6g8-boxStyles-SkeletonBox"
   />
 </div>
 `;

--- a/packages/react/src/skeleton/__snapshots__/SkeletonHeading.test.tsx.snap
+++ b/packages/react/src/skeleton/__snapshots__/SkeletonHeading.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SkeletonHeading renders correctly 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="css-1mckm34-boxStyles-SkeletonBox"
+    class="css-y1hpjl-boxStyles-SkeletonBox"
   />
 </div>
 `;

--- a/packages/react/src/skeleton/__snapshots__/SkeletonText.test.tsx.snap
+++ b/packages/react/src/skeleton/__snapshots__/SkeletonText.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SkeletonText renders correctly 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="css-1yf6wyz-boxStyles-SkeletonBox"
+    class="css-qswdp3-boxStyles-SkeletonBox"
   />
 </div>
 `;

--- a/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
+++ b/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-1jhrbpg-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#"
         >
           Change
@@ -46,7 +46,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-1jhrbpg-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#"
         >
           Change
@@ -72,7 +72,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-1jhrbpg-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#"
         >
           Change
@@ -96,7 +96,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-1jhrbpg-boxStyles"
       >
         <a
-          class="css-ma0bjl-TextLink"
+          class="css-koqz57-TextLink"
           href="#"
         >
           Change

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -30,7 +30,7 @@ export function TableRow({
 						backgroundColor: boxPalette.selectedMuted,
 
 						// Add outline
-						'&:after': {
+						'&::after': {
 							content: '""',
 							pointerEvents: 'none',
 							position: 'absolute',
@@ -41,17 +41,17 @@ export function TableRow({
 						},
 
 						// Remove the border top (if next table row is selected)
-						":has(+ tr[aria-selected='true']):after": {
+						":has(+ tr[aria-selected='true'])::after": {
 							borderBottomWidth: 0,
 						},
 
 						// Remove the border top from the next table row (if next table row is selected)
-						'+ tr:after': {
+						'+ tr::after': {
 							borderTopWidth: 0,
 						},
 					}),
 
-					// Chrome and Firefox doesn't support :after elements in fixed table layouts
+					// Chrome and Firefox doesn't support ::after elements in fixed table layouts
 					// FIXME Once Chrome Firefox fixes this issue, these alternative styles should be removed
 					...(tableLayout === 'fixed' && alternativeSelectedStyles),
 
@@ -71,12 +71,12 @@ export function TableRow({
 	);
 }
 
-// Use an outline instead of an :after element
+// Use an outline instead of an ::after element
 const alternativeSelectedStyles = {
 	backgroundColor: boxPalette.selectedMuted,
 	outlineWidth: '2px',
 	outlineStyle: 'solid',
 	outlineColor: boxPalette.selected,
 	outlineOffset: '-3px',
-	'&:after': { display: 'none' },
+	'&::after': { display: 'none' },
 };

--- a/packages/react/src/tabs/TabButton.tsx
+++ b/packages/react/src/tabs/TabButton.tsx
@@ -129,7 +129,7 @@ export function TabButton({ children, endElement }: TabButtonProps) {
 						borderBottomWidth: tokens.borderWidth.sm,
 					},
 
-					':before': {
+					'::before': {
 						content: "''",
 						position: 'absolute',
 						top: 0,
@@ -150,7 +150,7 @@ export function TabButton({ children, endElement }: TabButtonProps) {
 					borderColor: boxPalette.border,
 					borderRadius: `${tokens.borderRadius}px ${tokens.borderRadius}px 0 0`,
 					...(isSelected && {
-						':before': {
+						'::before': {
 							content: "''",
 							position: 'absolute',
 							top: 0,
@@ -159,7 +159,7 @@ export function TabButton({ children, endElement }: TabButtonProps) {
 							height: tokens.borderWidth.xl,
 							background: boxPalette.selected,
 						},
-						':after': {
+						'::after': {
 							content: "''",
 							position: 'absolute',
 							bottom: -1,

--- a/packages/react/src/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react/src/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Tabs renders correctly 1`] = `
       <button
         aria-controls="tabs-:r0:-tab-panel-0"
         aria-selected="true"
-        class="css-mt14g7-BaseButton-boxStyles-TabButton"
+        class="css-cmofij-BaseButton-boxStyles-TabButton"
         id="tabs-:r0:-tab-button-0"
         role="tab"
         tabindex="0"
@@ -27,7 +27,7 @@ exports[`Tabs renders correctly 1`] = `
       <button
         aria-controls="tabs-:r0:-tab-panel-1"
         aria-selected="false"
-        class="css-zu3sbg-BaseButton-boxStyles-TabButton"
+        class="css-16a6lnh-BaseButton-boxStyles-TabButton"
         id="tabs-:r0:-tab-button-1"
         role="tab"
         tabindex="-1"
@@ -40,7 +40,7 @@ exports[`Tabs renders correctly 1`] = `
       <button
         aria-controls="tabs-:r0:-tab-panel-2"
         aria-selected="false"
-        class="css-zu3sbg-BaseButton-boxStyles-TabButton"
+        class="css-16a6lnh-BaseButton-boxStyles-TabButton"
         id="tabs-:r0:-tab-button-2"
         role="tab"
         tabindex="-1"

--- a/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
+++ b/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-k8ctd8-boxStyles"
         >
           <a
-            class="css-oplj7x-TextLink-boxStyles"
+            class="css-1qb2lpt-TextLink-boxStyles"
             href="#"
           >
             Foo
@@ -34,7 +34,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-k8ctd8-boxStyles"
         >
           <a
-            class="css-oplj7x-TextLink-boxStyles"
+            class="css-1qb2lpt-TextLink-boxStyles"
             href="#"
           >
             Bar
@@ -48,7 +48,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-k8ctd8-boxStyles"
         >
           <a
-            class="css-oplj7x-TextLink-boxStyles"
+            class="css-1qb2lpt-TextLink-boxStyles"
             href="#"
           >
             Baz
@@ -80,7 +80,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-198oft9-boxStyles"
         >
           <a
-            class="css-oplj7x-TextLink-boxStyles"
+            class="css-1qb2lpt-TextLink-boxStyles"
             href="#"
           >
             Foo
@@ -125,7 +125,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-198oft9-boxStyles"
         >
           <a
-            class="css-oplj7x-TextLink-boxStyles"
+            class="css-1qb2lpt-TextLink-boxStyles"
             href="#"
           >
             Bar
@@ -170,7 +170,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-198oft9-boxStyles"
         >
           <a
-            class="css-oplj7x-TextLink-boxStyles"
+            class="css-1qb2lpt-TextLink-boxStyles"
             href="#"
           >
             Baz

--- a/packages/react/src/task-list/TaskListItem.tsx
+++ b/packages/react/src/task-list/TaskListItem.tsx
@@ -100,7 +100,7 @@ const TaskListItem = ({
 					}),
 
 					...(status === 'doing' && {
-						'&:before': {
+						'&::before': {
 							content: '""',
 							background: boxPalette.foregroundAction,
 							position: 'absolute',
@@ -143,20 +143,21 @@ const TaskListItem = ({
 							lineHeight="heading"
 							fontWeight="bold"
 							color="action"
-							css={{
-								order: 2,
-								...(ordered && {
-									'&:before': {
-										content: 'counter(task-count)',
-									},
-								}),
-							}}
+							css={
+								ordered
+									? {
+											'&::before': {
+												content: 'counter(task-count)',
+											},
+									  }
+									: undefined
+							}
 						>
 							{ordered && <span aria-hidden="true">. </span>}
 							{children}
 							<VisuallyHidden>.</VisuallyHidden>
 						</Text>
-						<Flex as="span" gap={0.25} alignItems="center" css={{ order: 1 }}>
+						<Flex as="span" gap={0.25} alignItems="center">
 							<Icon
 								size="md"
 								color={iconColor}
@@ -169,7 +170,7 @@ const TaskListItem = ({
 								<VisuallyHidden>.</VisuallyHidden>
 							</Text>
 						</Flex>
-						<Text color="muted" fontSize="sm" css={{ order: 3 }}>
+						<Text color="muted" fontSize="sm">
 							{message}
 						</Text>
 					</Flex>

--- a/packages/react/src/task-list/__snapshots__/TaskList.test.tsx.snap
+++ b/packages/react/src/task-list/__snapshots__/TaskList.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-1wty9lg-TextLink-boxStyles-TaskListItem"
+          class="css-1htue7x-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -61,7 +61,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Check eligibility
@@ -72,7 +72,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -104,7 +104,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               />
             </span>
           </span>
@@ -133,7 +133,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-1wty9lg-TextLink-boxStyles-TaskListItem"
+          class="css-1htue7x-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -165,7 +165,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Lorem ipsum dolor sit amet
@@ -176,7 +176,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -208,7 +208,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               />
             </span>
           </span>
@@ -237,7 +237,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-140kbik-TextLink-boxStyles-TaskListItem"
+          class="css-1992mal-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -282,7 +282,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Case Studies
@@ -293,7 +293,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -338,7 +338,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               />
             </span>
           </span>
@@ -367,7 +367,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-1wty9lg-TextLink-boxStyles-TaskListItem"
+          class="css-1htue7x-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -398,7 +398,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Review and submit
@@ -409,7 +409,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -440,7 +440,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               >
                 Not available until previous tasks are done
               </span>
@@ -533,7 +533,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Check eligibility
@@ -544,7 +544,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -576,7 +576,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               />
             </span>
           </span>
@@ -637,7 +637,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Lorem ipsum dolor sit amet
@@ -648,7 +648,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -680,7 +680,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               />
             </span>
           </span>
@@ -709,7 +709,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <button
-          class="css-jub5ot-BaseButton-boxStyles-TaskListItem"
+          class="css-uy7mdj-BaseButton-boxStyles-TaskListItem"
           type="button"
         >
           <span
@@ -754,7 +754,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Case Studies
@@ -765,7 +765,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -810,7 +810,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               />
             </span>
           </span>
@@ -870,7 +870,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                class="css-1dl24o0-boxStyles-TaskListItem"
+                class="css-84frxs-boxStyles"
                 data-agds-task-list-item-text=""
               >
                 Review and submit
@@ -881,7 +881,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1heyt4z-boxStyles-TaskListItem"
+                class="css-q6tqn6-boxStyles"
               >
                 <svg
                   aria-hidden="true"
@@ -912,7 +912,7 @@ exports[`TaskList With buttons renders correctly 1`] = `
                 </span>
               </span>
               <span
-                class="css-1lb8bbj-boxStyles-TaskListItem"
+                class="css-axuon-boxStyles"
               >
                 Not available until previous tasks are done
               </span>

--- a/packages/react/src/text-link/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/react/src/text-link/__snapshots__/TextLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextLink renders correctly 1`] = `
 <div>
   <a
-    class="css-ma0bjl-TextLink"
+    class="css-koqz57-TextLink"
     data-testid="example"
     href="/example"
   >

--- a/packages/react/src/text-link/__snapshots__/TextLinkExternal.test.tsx.snap
+++ b/packages/react/src/text-link/__snapshots__/TextLinkExternal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextLinkExternal renders correctly 1`] = `
 <div>
   <a
-    class="css-ma0bjl-TextLink"
+    class="css-koqz57-TextLink"
     data-testid="example"
     href="https://design-system.agriculture.gov.au"
     rel="noopener"


### PR DESCRIPTION
The visual order of the task list items now matches the source order: https://www.figma.com/file/MivOblJvHi3nJ4bQMDfnf3/AgDS---gallery?node-id=12444%3A100628

Also changed all `:before` and `:after` to `::before` and `::after`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1710)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
