### PR TITLE
Update deprecated component and prop uses through examples

### DIFF
--- a/.changeset/real-pets-sort.md
+++ b/.changeset/real-pets-sort.md
@@ -1,0 +1,8 @@
+---
+'@ag.ds-next/react': patch
+'@ag.ds-next/example-site': patch
+'@ag.ds-next/yourgov': patch
+'@ag.ds-next/docs': patch
+---
+
+Update deprecated component and prop uses through examples

--- a/.storybook/stories/DataFiltering/components/DataTable.tsx
+++ b/.storybook/stories/DataFiltering/components/DataTable.tsx
@@ -150,12 +150,7 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 											);
 										}
 										return (
-											<TableHeader
-												key={sortKey}
-												scope="col"
-												textAlign={textAlign}
-												width={width}
-											>
+											<TableHeader key={sortKey} scope="col" width={width}>
 												{label}
 											</TableHeader>
 										);
@@ -274,7 +269,6 @@ const headers: {
 	{
 		label: 'Date registered',
 		sortKey: 'requestDate',
-		textAlign: 'right',
 		width: '12rem',
 		isSortable: true,
 	},

--- a/.storybook/stories/DataFiltering/components/DataTableRow.tsx
+++ b/.storybook/stories/DataFiltering/components/DataTableRow.tsx
@@ -30,19 +30,19 @@ export const DataTableRowAssignee = ({
 const itemStatusMap = {
 	notBooked: {
 		label: 'Not booked',
-		tone: 'neutral',
+		tone: 'notStartedLow',
 	},
 	booked: {
 		label: 'Booked',
-		tone: 'info',
+		tone: 'infoMedium',
 	},
 	completed: {
 		label: 'Completed',
-		tone: 'success',
+		tone: 'successMedium',
 	},
 	cancelled: {
 		label: 'Cancelled',
-		tone: 'error',
+		tone: 'errorMedium',
 	},
 } as const;
 
@@ -53,7 +53,7 @@ export const DataTableRowStatus = ({
 }) => {
 	return (
 		<TableCell>
-			<StatusBadge weight="subtle" {...itemStatusMap[status]} />
+			<StatusBadge appearance="subtle" {...itemStatusMap[status]} />
 		</TableCell>
 	);
 };

--- a/.storybook/stories/KitchenSink/KitchenSink.stories.tsx
+++ b/.storybook/stories/KitchenSink/KitchenSink.stories.tsx
@@ -182,11 +182,12 @@ function KitchenSink({ background }: KitchenSinkProps) {
 								activePath="#in-detail/record-keeping/incorrect-amounts"
 							/>
 							<ProgressIndicator
+								activePath="#1"
 								background={page}
 								items={[
-									{ href: '#', label: 'Introduction', status: 'doing' },
-									{ href: '#', label: 'Business Contacts', status: 'todo' },
-									{ href: '#', label: 'Case Studies', status: 'done' },
+									{ href: '#1', label: 'Introduction', status: 'started' },
+									{ href: '#2', label: 'Business Contacts', status: 'todo' },
+									{ href: '#3', label: 'Case Studies', status: 'done' },
 								]}
 							/>
 						</Stack>
@@ -437,11 +438,19 @@ function KitchenSink({ background }: KitchenSinkProps) {
 								/>
 								<Textarea label="Message" />
 								<ControlGroup label="Device">
-									<Radio checked={false}>Phone</Radio>
-									<Radio checked={false}>Tablet</Radio>
-									<Radio checked={true}>Laptop</Radio>
+									<Radio checked={false} onChange={console.log}>
+										Phone
+									</Radio>
+									<Radio checked={false} onChange={console.log}>
+										Tablet
+									</Radio>
+									<Radio checked={true} onChange={console.log}>
+										Laptop
+									</Radio>
 								</ControlGroup>
-								<Checkbox checked={true}>Label</Checkbox>
+								<Checkbox checked={true} onChange={console.log}>
+									Label
+								</Checkbox>
 								<Autocomplete
 									label="Find your country"
 									hint="Start typing to see results"
@@ -518,19 +527,125 @@ function KitchenSink({ background }: KitchenSinkProps) {
 							</div>
 
 							<Flex gap={0.5} flexWrap="wrap">
-								<StatusBadge tone="info" label="In progress" />
-								<StatusBadge tone="success" label="Resolved" />
-								<StatusBadge tone="error" label="Rejected" />
-								<StatusBadge tone="warning" label="Attention" />
-								<StatusBadge tone="neutral" label="Draft" />
+								<StatusBadge tone="successHigh" label="Success" />
+								<StatusBadge tone="errorHigh" label="Error" />
+								<StatusBadge tone="warningHigh" label="Warning" />
+								<StatusBadge tone="infoHigh" label="Info" />
 							</Flex>
 
 							<Flex gap={0.5} flexWrap="wrap">
-								<StatusBadge weight="subtle" tone="info" label="In progress" />
-								<StatusBadge weight="subtle" tone="success" label="Resolved" />
-								<StatusBadge weight="subtle" tone="error" label="Rejected" />
-								<StatusBadge weight="subtle" tone="warning" label="Attention" />
-								<StatusBadge weight="subtle" tone="neutral" label="Draft" />
+								<StatusBadge tone="successMedium" label="Success" />
+								<StatusBadge tone="errorMedium" label="Error" />
+								<StatusBadge tone="warningMedium" label="Warning" />
+								<StatusBadge tone="infoMedium" label="Info" />
+							</Flex>
+
+							<Flex gap={0.5} flexWrap="wrap">
+								<StatusBadge tone="successLow" label="Success" />
+								<StatusBadge tone="errorLow" label="Error" />
+								<StatusBadge tone="warningLow" label="Warning" />
+								<StatusBadge tone="infoLow" label="Info" />
+								<StatusBadge tone="cannotStartLow" label="Cannot start" />
+								<StatusBadge tone="inProgressLow" label="In progress" />
+								<StatusBadge tone="pausedLow" label="Paused" />
+								<StatusBadge tone="notStartedLow" label="Not started" />
+								<StatusBadge tone="unknownLow" label="Unknown" />
+							</Flex>
+
+							<Flex gap={0.5} flexWrap="wrap">
+								<Flex flexWrap="wrap" gap={2}>
+									<StatusBadge
+										appearance="subtle"
+										tone="successHigh"
+										label="Success"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="errorHigh"
+										label="Error"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="warningHigh"
+										label="Warning"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="infoHigh"
+										label="Info"
+									/>
+								</Flex>
+								<Flex flexWrap="wrap" gap={2}>
+									<StatusBadge
+										appearance="subtle"
+										tone="successMedium"
+										label="Success"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="errorMedium"
+										label="Error"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="warningMedium"
+										label="Warning"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="infoMedium"
+										label="Info"
+									/>
+								</Flex>
+								<Flex flexWrap="wrap" gap={2}>
+									<StatusBadge
+										appearance="subtle"
+										tone="successLow"
+										label="Success"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="errorLow"
+										label="Error"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="warningLow"
+										label="Warning"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="infoLow"
+										label="Info"
+									/>
+								</Flex>
+								<Flex flexWrap="wrap" gap={2}>
+									<StatusBadge
+										appearance="subtle"
+										tone="cannotStartLow"
+										label="Cannot start"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="inProgressLow"
+										label="In progress"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="pausedLow"
+										label="Paused"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="notStartedLow"
+										label="Not started"
+									/>
+									<StatusBadge
+										appearance="subtle"
+										tone="unknownLow"
+										label="Unknown"
+									/>
+								</Flex>
 							</Flex>
 
 							<Flex gap={0.5}>

--- a/docs/content/patterns/multi-task-form/index.mdx
+++ b/docs/content/patterns/multi-task-form/index.mdx
@@ -80,7 +80,7 @@ The task list supports sequential or non-sequential completion of a form.
 			</Flex>
 			<Modal
 				isOpen={isModalOpen}
-				onDismiss={closeModal}
+				onClose={closeModal}
 				title="Discard form?"
 				actions={
 					<ButtonGroup>
@@ -134,18 +134,17 @@ If a user presses on a task that’s ‘in progress’, return them to where the
 		{
 			label: 'Contact details',
 			status: 'done',
-			href: '#',
+			href: '#contact-details',
 		},
 		{
 			label: 'Address',
 			status: 'started',
-			href: '#',
-			isActive: true,
+			href: '#address',
 		},
 		{
 			label: 'Upload files',
 			status: 'todo',
-			href: '#',
+			href: '#upload-files',
 		},
 	];
 
@@ -153,7 +152,7 @@ If a user presses on a task that’s ‘in progress’, return them to where the
 		<Columns>
 			<Column columnSpan={{ xs: 12, md: 4, lg: 3 }}>
 				<ContentBleed visible={{ md: false }}>
-					<ProgressIndicator items={FORM_STEPS} />
+					<ProgressIndicator activePath="#address" items={FORM_STEPS} />
 				</ContentBleed>
 			</Column>
 			<Column columnSpan={{ xs: 12, md: 8 }} columnStart={{ lg: 5 }}>
@@ -176,7 +175,11 @@ If a user presses on a task that’s ‘in progress’, return them to where the
 
 					<Stack as="form" gap={3} onSubmit={() => {}} noValidate>
 						<Stack gap={2}>
-							<H1 tabIndex={-1} focus aria-label="Application form, Address">
+							<H1
+								tabIndex={-1}
+								focusRingFor="keyboard"
+								aria-label="Application form, Address"
+							>
 								<Text
 									display="block"
 									fontSize="sm"

--- a/docs/content/templates/content/ContentWithSideNav.tsx
+++ b/docs/content/templates/content/ContentWithSideNav.tsx
@@ -142,7 +142,7 @@ export function ContentWithSideNav() {
 
 const sideNavItems = [
 	{
-		href: '#',
+		href: '#1',
 		label: 'Content page',
 	},
 	{
@@ -150,41 +150,41 @@ const sideNavItems = [
 		label: 'Content page',
 		items: [
 			{
-				href: '#',
-				label: 'Side nav item level 3',
+				href: '#21',
+				label: 'Side nav level 2 item 1',
 			},
 			{
-				href: '#',
-				label: 'Side nav item level 3',
+				href: '#22',
+				label: 'Side nav level 2 item 2',
 			},
 		],
 	},
 	{
-		href: '#',
+		href: '#3',
 		label: 'Content page',
 	},
 	{
-		href: '#',
+		href: '#4',
 		label: 'Content page',
 	},
 	{
-		href: '#',
+		href: '#5',
 		label: 'Content page',
 	},
 	{
-		href: '#',
+		href: '#6',
 		label: 'Content page',
 	},
 	{
-		href: '#',
+		href: '#7',
 		label: 'Content page',
 	},
 	{
-		href: '#',
+		href: '#8',
 		label: 'Content page',
 	},
 	{
-		href: '#',
+		href: '#9',
 		label: 'Content page',
 	},
 ];

--- a/docs/content/templates/multi-page-form/MultiPageFormStep.tsx
+++ b/docs/content/templates/multi-page-form/MultiPageFormStep.tsx
@@ -16,10 +16,11 @@ export function MultiPageFormStep() {
 				<Column columnSpan={{ xs: 12, md: 4, lg: 3 }}>
 					<ContentBleed visible={{ md: false }}>
 						<ProgressIndicator
+							activePath="#2"
 							items={[
-								{ label: 'Step 1', status: 'done', href: '#' },
-								{ label: 'Step 2', status: 'doing', href: '#' },
-								{ label: 'Step 3', status: 'blocked', href: '#' },
+								{ label: 'Step 1', status: 'done', href: '#1' },
+								{ label: 'Step 2', status: 'started', href: '#2' },
+								{ label: 'Step 3', status: 'blocked', href: '#3' },
 							]}
 						/>
 					</ContentBleed>

--- a/docs/content/templates/multi-page-form/MultiPageFormSummary.tsx
+++ b/docs/content/templates/multi-page-form/MultiPageFormSummary.tsx
@@ -25,10 +25,11 @@ export function MultiPageFormSummary() {
 				<Column columnSpan={{ xs: 12, md: 4, lg: 3 }}>
 					<ContentBleed visible={{ md: false }}>
 						<ProgressIndicator
+							activePath="#3"
 							items={[
-								{ label: 'Step 1', status: 'done', href: '#' },
-								{ label: 'Step 2', status: 'done', href: '#' },
-								{ label: 'Step 3', status: 'doing', href: '#' },
+								{ label: 'Step 1', status: 'done', href: '#1' },
+								{ label: 'Step 2', status: 'done', href: '#2' },
+								{ label: 'Step 3', status: 'started', href: '#3' },
 							]}
 						/>
 					</ContentBleed>

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep.tsx
@@ -34,22 +34,27 @@ import {
 
 export const FORM_STEPS = [
 	{
+		href: '#conditional-fork',
 		label: 'Conditional fork',
 		component: FormExampleMultiStep0,
 	},
 	{
+		href: '#submit-evidence',
 		label: 'Submit evidence',
 		component: FormExampleMultiStep1,
 	},
 	{
+		href: '#select-date',
 		label: 'Select date',
 		component: FormExampleMultiStep2,
 	},
 	{
+		href: '#conditional-reveal',
 		label: 'Conditional reveal',
 		component: FormExampleMultiStep3,
 	},
 	{
+		href: '#confirm-and-submit',
 		label: 'Confirm and submit',
 		component: FormExampleMultiStep4,
 	},
@@ -157,7 +162,7 @@ export const FormExampleMultiStep = () => {
 
 	const getStepStatus = useCallback(
 		(idx: number) => {
-			if (idx === currentStep) return 'doing';
+			if (idx === currentStep) return 'started';
 			if (hasCompletedStep(idx)) return 'done';
 			if (idx === 0 || hasCompletedStep(idx - 1)) return 'todo';
 			return 'blocked';
@@ -191,7 +196,9 @@ export const FormExampleMultiStep = () => {
 					<Column columnSpan={{ xs: 12, md: 4, lg: 3 }}>
 						<ContentBleed visible={{ md: false }}>
 							<ProgressIndicator
-								items={FORM_STEPS.map(({ label }, idx) => ({
+								activePath={FORM_STEPS[currentStep].href}
+								items={FORM_STEPS.map(({ href, label }, idx) => ({
+									href,
 									label,
 									status: getStepStatus(idx),
 									onClick: () => setCurrentStep(idx),

--- a/example-site/components/FormStepTitle.tsx
+++ b/example-site/components/FormStepTitle.tsx
@@ -24,7 +24,7 @@ export function FormStepTitle({
 			<H1
 				ref={titleRef}
 				tabIndex={-1}
-				focus
+				focusRingFor="keyboard"
 				aria-label={`${formTitle} form, ${stepTitle}`}
 			>
 				<Text

--- a/packages/react/src/button/Button.stories.tsx
+++ b/packages/react/src/button/Button.stories.tsx
@@ -19,7 +19,6 @@ const meta: Meta<typeof Button> = {
 		block: false,
 		children: 'Button',
 		disabled: false,
-		loading: false,
 		variant: 'primary',
 	},
 };

--- a/packages/react/src/card/Card.stories.tsx
+++ b/packages/react/src/card/Card.stories.tsx
@@ -161,9 +161,9 @@ export const CardList: Story = {
 	name: 'List of Cards',
 	render: function Render() {
 		const toneMapper = {
-			Closed: 'success',
-			Open: 'warning',
-			Pending: 'info',
+			Closed: 'successMedium',
+			Open: 'warningMedium',
+			Pending: 'infoMedium',
 		} as const;
 		const listData = [
 			{

--- a/packages/react/src/drawer/Drawer.stories.tsx
+++ b/packages/react/src/drawer/Drawer.stories.tsx
@@ -160,7 +160,7 @@ export const SmallPageContentLargeDrawerContent: Story = {
 				<Button onClick={open}>Open Drawer</Button>
 				<Drawer
 					isOpen={isOpen}
-					onDismiss={close}
+					onClose={close}
 					title={props.title}
 					width={props.width}
 					actions={
@@ -194,7 +194,7 @@ export const LargePageContentLargeDrawerContent: Story = {
 				<LargeProseContent />
 				<Drawer
 					isOpen={isOpen}
-					onDismiss={close}
+					onClose={close}
 					title={props.title}
 					width={props.width}
 					actions={

--- a/packages/react/src/global-alert/GlobalAlert.stories.tsx
+++ b/packages/react/src/global-alert/GlobalAlert.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof GlobalAlert> = {
 	title: 'content/GlobalAlert',
 	component: GlobalAlert,
 	args: {
+		onDismiss: undefined,
 		tone: 'warning',
 	},
 };
@@ -41,7 +42,7 @@ export const Information: Story = {
 	},
 };
 
-export const WithDismiss: Story = {
+export const WithClose: Story = {
 	args: {
 		onClose: console.log,
 		children: (
@@ -68,7 +69,7 @@ export const WithTitle: Story = {
 	},
 };
 
-export const WithTitleAndDismiss: Story = {
+export const WithTitleAndClose: Story = {
 	args: {
 		title: 'Alert title',
 		onClose: console.log,

--- a/packages/react/src/page-alert/PageAlert.stories.tsx
+++ b/packages/react/src/page-alert/PageAlert.stories.tsx
@@ -9,6 +9,7 @@ const meta: Meta<typeof PageAlert> = {
 	title: 'content/PageAlert',
 	component: PageAlert,
 	args: {
+		onDismiss: undefined,
 		onClose: undefined,
 	},
 	render: (args) => (

--- a/packages/react/src/section-alert/SectionAlert.stories.tsx
+++ b/packages/react/src/section-alert/SectionAlert.stories.tsx
@@ -5,6 +5,7 @@ const meta: Meta<typeof SectionAlert> = {
 	title: 'Content/SectionAlert',
 	component: SectionAlert,
 	args: {
+		onDismiss: undefined,
 		onClose: undefined,
 	},
 };
@@ -42,7 +43,7 @@ export const WithDescription: Story = {
 	},
 };
 
-export const onClose: Story = {
+export const WithClose: Story = {
 	args: {
 		title: 'Your changes have been saved',
 		tone: 'success',

--- a/packages/react/src/table/Table.stories.tsx
+++ b/packages/react/src/table/Table.stories.tsx
@@ -266,7 +266,11 @@ export const Actions: Story = {
 						</TableCell>
 						<TableCell>20/06/2024</TableCell>
 						<TableCell>
-							<StatusBadge weight="subtle" tone="info" label="In progress" />
+							<StatusBadge
+								appearance="subtle"
+								tone="infoMedium"
+								label="In progress"
+							/>
 						</TableCell>
 						<TableCell>
 							<Flex gap={1}>
@@ -281,7 +285,11 @@ export const Actions: Story = {
 						</TableCell>
 						<TableCell>25/06/2024</TableCell>
 						<TableCell>
-							<StatusBadge weight="subtle" tone="info" label="In progress" />
+							<StatusBadge
+								appearance="subtle"
+								tone="infoMedium"
+								label="In progress"
+							/>
 						</TableCell>
 						<TableCell>
 							<Flex gap={1}>
@@ -296,7 +304,11 @@ export const Actions: Story = {
 						</TableCell>
 						<TableCell>02/07/2024</TableCell>
 						<TableCell>
-							<StatusBadge weight="subtle" tone="success" label="Completed" />
+							<StatusBadge
+								appearance="subtle"
+								tone="successMedium"
+								label="Completed"
+							/>
 						</TableCell>
 						<TableCell>
 							<Flex gap={1}>
@@ -311,7 +323,11 @@ export const Actions: Story = {
 						</TableCell>
 						<TableCell>05/08/2024</TableCell>
 						<TableCell>
-							<StatusBadge weight="subtle" tone="info" label="In progress" />
+							<StatusBadge
+								appearance="subtle"
+								tone="infoMedium"
+								label="In progress"
+							/>
 						</TableCell>
 						<TableCell>
 							<Flex gap={1}>
@@ -326,7 +342,11 @@ export const Actions: Story = {
 						</TableCell>
 						<TableCell>19/10/2024</TableCell>
 						<TableCell>
-							<StatusBadge weight="subtle" tone="success" label="Completed" />
+							<StatusBadge
+								appearance="subtle"
+								tone="successMedium"
+								label="Completed"
+							/>
 						</TableCell>
 						<TableCell>
 							<Flex gap={1}>

--- a/yourgov/components/FormMobileFoodVendorPermit/FormTask1Step1ChangeDetails.tsx
+++ b/yourgov/components/FormMobileFoodVendorPermit/FormTask1Step1ChangeDetails.tsx
@@ -91,7 +91,7 @@ export function FormTask1Step1ChangeDetails() {
 						Back
 					</DirectionLink>
 					<Stack gap={1.5}>
-						<H1 ref={titleRef} tabIndex={-1} focus>
+						<H1 ref={titleRef} tabIndex={-1} focusRingFor="keyboard">
 							Provide business owner details
 						</H1>
 						<Text as="p" fontSize="md" color="muted">

--- a/yourgov/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
+++ b/yourgov/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
@@ -234,7 +234,7 @@ export const FormRegisterPetPersonalDetailsStep0 = () => {
 				) : (
 					<>
 						<Stack gap={1.5} alignItems="flex-start" width="100%">
-							<H2 ref={headingRef} tabIndex={-1} focus>
+							<H2 ref={headingRef} tabIndex={-1} focusRingFor="keyboard">
 								Check personal details
 							</H2>
 							<SummaryList>

--- a/yourgov/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep1.tsx
+++ b/yourgov/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep1.tsx
@@ -211,7 +211,7 @@ export const FormRegisterPetPersonalDetailsStep1 = () => {
 				) : (
 					<>
 						<Stack gap={1.5} alignItems="flex-start" width="100%">
-							<H2 ref={headingRef} tabIndex={-1} focus>
+							<H2 ref={headingRef} tabIndex={-1} focusRingFor="keyboard">
 								Check address details
 							</H2>
 							<SummaryList>

--- a/yourgov/components/FormStepTitle.tsx
+++ b/yourgov/components/FormStepTitle.tsx
@@ -24,7 +24,7 @@ export function FormStepTitle({
 			<H1
 				ref={titleRef}
 				tabIndex={-1}
-				focus
+				focusRingFor="keyboard"
 				aria-label={`${formTitle} form, ${stepTitle}`}
 			>
 				<Text


### PR DESCRIPTION
There have been quite a few deprecations of props etc recently, but many examples weren't updated.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1721)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets