### PR TITLE
table: Add `display` support to `TableHeaderSortable`.

### DIFF
--- a/.changeset/silent-radios-hug.md
+++ b/.changeset/silent-radios-hug.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+table: Add `display` support to `TableHeaderSortable`.

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -33,16 +33,14 @@ export const TableHeaderSortable = ({
 	const sortLabel = getSortLabel(sort);
 	return (
 		<Box
+			aria-sort={sortLabel}
 			as="th"
+			borderBottom
+			borderColor="selected"
+			borderBottomWidth={sort ? 'xl' : 'none'}
 			display={display}
 			scope="col"
-			aria-sort={sortLabel}
 			width={width}
-			{...(sort && {
-				borderColor: 'selected',
-				borderBottom: true,
-				borderBottomWidth: 'xl',
-			})}
 		>
 			<Flex
 				alignItems="center"

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -2,16 +2,17 @@ import { PropsWithChildren } from 'react';
 import { Box } from '../box';
 import { Flex } from '../flex';
 import { BaseButton } from '../button';
-import { boxPalette, packs, ResponsiveProp } from '../core';
+import { boxPalette, packs, type ResponsiveProp } from '../core';
 import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon } from '../icon';
 
 export type TableSortDirection = 'ASC' | 'DESC';
 
 export type TableHeaderSortableProps = {
-	/** The active direction this column is being sorted by. */
-	sort?: TableSortDirection;
+	display?: ResponsiveProp<'none' | 'table-cell'>;
 	/** Callback function for when the column header is clicked. */
 	onClick?: () => void;
+	/** The active direction this column is being sorted by. */
+	sort?: TableSortDirection;
 	/** Sets the horizontal alignment of the content. */
 	textAlign?: 'left' | 'center' | 'right';
 	/** Sets the width of the column. */
@@ -22,8 +23,9 @@ export type TableHeaderSortableProps = {
  * sort the table. */
 export const TableHeaderSortable = ({
 	children,
-	sort,
+	display,
 	onClick,
+	sort,
 	textAlign = 'left',
 	width,
 }: PropsWithChildren<TableHeaderSortableProps>) => {
@@ -32,6 +34,7 @@ export const TableHeaderSortable = ({
 	return (
 		<Box
 			as="th"
+			display={display}
 			scope="col"
 			aria-sort={sortLabel}
 			width={width}

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`TableHeaderSortable with sort direction: undefined renders correctly 1`
         class="css-1tx0oac-TableRow"
       >
         <th
-          class="css-79i25n-boxStyles"
+          class="css-m6eg6e-boxStyles"
           scope="col"
         >
           <button


### PR DESCRIPTION
table: Add `display` support to `TableHeaderSortable`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1732)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
