### PR TITLE
playroom: Fix AppLayout boilerplate sidebar links & icons

### DIFF
--- a/.changeset/chatty-mugs-bathe.md
+++ b/.changeset/chatty-mugs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+playroom: Fix AppLayout boilerplate sidebar links & icons

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -82,8 +82,8 @@ const boilerplateAppTemplate = (content: string) => `
 	/>
 	<AppLayoutSidebar
 		items={[
-			[{ label: 'Label', href: '#', icon: WebsiteIcon }, { label: 'Label', href: '#', icon: WebsiteIcon } ],
-			[{ label: 'Label', icon: ExitIcon }],
+			[{ label: 'Label', href: '#', icon: WebsiteIcon }, { label: 'Label', href: '#', icon: AvatarIcon } ],
+			[{ label: 'Label', href: '#', icon: ExitIcon }],
 		]}
 	/>
 	<AppLayoutContent>


### PR DESCRIPTION
The snippet for one of the AppLayoutSidebar items didn't render the icon because it wasn't a link. Also made all the icons unique.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1738)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
