### PR TITLE
checkbox radio: Use :focus for focus rings

### DIFF
--- a/.changeset/calm-cougars-scream.md
+++ b/.changeset/calm-cougars-scream.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/react': minor
+---
+
+checkbox: Change focus ring to use `:focus` instead of `:focus-visible`.
+
+field: Update `useScrollToField` hook to also find elements by name.
+
+radio: Change focus ring to use `:focus` instead of `:focus-visible`.

--- a/packages/react/src/checkbox/CheckboxInput.tsx
+++ b/packages/react/src/checkbox/CheckboxInput.tsx
@@ -12,8 +12,8 @@ export const CheckboxInput = forwardRef<HTMLInputElement, ControlInputProps>(
 				css={{
 					...visuallyHiddenStyles,
 					// When this component is focused, outline the `CheckboxIndicator`
-					'&:focus-visible ~ span:first-of-type': packs.outline,
-					// When this component is checked or indeterminate, show the indicators active state
+					'&:focus ~ span:first-of-type': packs.outline,
+					// When this component is checked or indeterminate, show the indicator's active state
 					'~ span > svg': { opacity: 0 },
 					'&:checked ~ span > svg, &:indeterminate ~ span > svg': {
 						opacity: 1,

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Checkbox renders correctly 1`] = `
     class="css-hp3wbe-boxStyles-CheckboxContainer"
   >
     <input
-      class="css-rw5u1c-CheckboxInput"
+      class="css-142kh0r-CheckboxInput"
       data-testid="example"
       name="my-checkbox"
       type="checkbox"

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-a"
               name=":r1:"
               type="checkbox"
@@ -71,7 +71,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-b"
               name=":r1:"
               type="checkbox"
@@ -107,7 +107,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-c"
               name=":r1:"
               type="checkbox"
@@ -143,7 +143,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-d"
               name=":r1:"
               type="checkbox"
@@ -258,7 +258,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
               aria-describedby="control-group-:r6:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-a"
               name=":r7:"
               type="checkbox"
@@ -296,7 +296,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
               aria-describedby="control-group-:r6:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-b"
               name=":r7:"
               type="checkbox"
@@ -334,7 +334,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
               aria-describedby="control-group-:r6:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-c"
               name=":r7:"
               type="checkbox"
@@ -372,7 +372,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
               aria-describedby="control-group-:r6:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-d"
               name=":r7:"
               type="checkbox"
@@ -446,7 +446,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-a"
               name=":r5:"
               type="checkbox"
@@ -482,7 +482,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-b"
               name=":r5:"
               type="checkbox"
@@ -518,7 +518,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-c"
               name=":r5:"
               type="checkbox"
@@ -554,7 +554,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-rw5u1c-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-d"
               name=":r5:"
               type="checkbox"
@@ -627,7 +627,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-a"
               name=":rd:"
               type="radio"
@@ -650,7 +650,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-b"
               name=":rd:"
               type="radio"
@@ -673,7 +673,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-c"
               name=":rd:"
               type="radio"
@@ -696,7 +696,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
           >
             <input
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-d"
               name=":rd:"
               type="radio"
@@ -798,7 +798,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               aria-describedby="control-group-:ri:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-a"
               name=":rj:"
               type="radio"
@@ -823,7 +823,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               aria-describedby="control-group-:ri:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-b"
               name=":rj:"
               type="radio"
@@ -848,7 +848,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               aria-describedby="control-group-:ri:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-c"
               name=":rj:"
               type="radio"
@@ -873,7 +873,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               aria-describedby="control-group-:ri:-message"
               aria-invalid="true"
               aria-required="false"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-d"
               name=":rj:"
               type="radio"
@@ -934,7 +934,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-a"
               name=":rh:"
               type="radio"
@@ -957,7 +957,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-b"
               name=":rh:"
               type="radio"
@@ -980,7 +980,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-c"
               name=":rh:"
               type="radio"
@@ -1003,7 +1003,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
           >
             <input
               aria-required="true"
-              class="css-yl6hsu-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-d"
               name=":rh:"
               type="radio"

--- a/packages/react/src/field/useScrollToField.ts
+++ b/packages/react/src/field/useScrollToField.ts
@@ -6,12 +6,14 @@ export function useScrollToField() {
 			const targetId = getScrollTargetId(eventOrTargetId);
 			if (!targetId) return;
 
-			const targetEl = document.getElementById(targetId);
+			const targetEl =
+				document.getElementById(targetId) ||
+				document.getElementsByName(targetId)[0];
 			if (!targetEl) return;
 
 			scrollAndFocusTarget(targetId, targetEl);
 
-			// Prevent default browser behaviour if user clicked on a lin
+			// Prevent default browser behaviour if user clicked on a link
 			if (typeof eventOrTargetId !== 'string') {
 				eventOrTargetId.preventDefault();
 			}

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`PasswordInput renders correctly 1`] = `
     >
       <input
         aria-controls="password-input-:r0:"
-        class="css-rw5u1c-CheckboxInput"
+        class="css-142kh0r-CheckboxInput"
         type="checkbox"
       />
       <span

--- a/packages/react/src/radio/RadioInput.tsx
+++ b/packages/react/src/radio/RadioInput.tsx
@@ -11,9 +11,9 @@ export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
 				ref={ref}
 				css={{
 					...visuallyHiddenStyles,
-					// When this component is focused, outline the indicator (`RadioIndicator` and `CheckboxIndicator`)
-					'&:focus-visible ~ span:first-of-type': packs.outline,
-					// When this component is checked, show the indicators active state
+					// When this component is focused, outline the `RadioIndicator`
+					'&:focus ~ span:first-of-type': packs.outline,
+					// When this component is checked, show the indicator's active state
 					'~ span > span': { opacity: 0 },
 					'&:checked ~ span > span': { opacity: 1 },
 				}}

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Radio renders correctly 1`] = `
     class="css-6pplfb-boxStyles-RadioContainer"
   >
     <input
-      class="css-yl6hsu-RadioInput"
+      class="css-o6md8t-RadioInput"
       data-testid="example"
       name="my-radio"
       type="radio"


### PR DESCRIPTION
radios and checkboxes didn't display focus rings when focused programatically. Since all other form inputs display focus rings always, radios and checkboxes should to.

The programmatic focusing also didn't work because react hook form doesn't actually give us a reference to the radio/checkbox ids

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1743)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.