### PR TITLE
table: TableScroller a11y fixes

### DIFF
--- a/.changeset/cold-spoons-drop.md
+++ b/.changeset/cold-spoons-drop.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+table: TableWrapper. Change to `section` with `aria-label`, and make it keyboard focusable only when it is scrollable. Change scrollbar border colour to `'border'`.

--- a/packages/react/src/table/TableScroller.tsx
+++ b/packages/react/src/table/TableScroller.tsx
@@ -2,7 +2,6 @@ import {
 	type ReactNode,
 	useCallback,
 	useEffect,
-	useLayoutEffect,
 	useRef,
 	useState,
 } from 'react';
@@ -18,9 +17,9 @@ export function TableScroller({ children }: TableScrollerProps) {
 	const trackRef = useRef<HTMLDivElement>(null);
 	const thumbRef = useRef<HTMLButtonElement>(null);
 	const scrollerRef = useRef<HTMLDivElement>(null);
-	const scrollerAriaLabel = useRef('');
 	const mousePos = useRef({ x: 0, y: 0 });
 
+	const [scrollerLabel, setScrollerLabel] = useState('');
 	const [isDraggingThumb, setIsDraggingThumb] = useState(false);
 	const [thumbPosition, setThumbPosition] = useState(0);
 	const [thumbWidthRatio, setThumbWidthRatio] = useState(0);
@@ -208,10 +207,12 @@ export function TableScroller({ children }: TableScrollerProps) {
 
 	const hasScroll = thumbWidthRatio !== 1;
 
-	useLayoutEffect(() => {
-		scrollerAriaLabel.current = `Table ${
-			scrollerRef.current?.querySelector('caption')?.textContent || ''
-		}`;
+	useEffect(() => {
+		setScrollerLabel(
+			`Table ${
+				scrollerRef.current?.querySelector('caption')?.textContent || ''
+			}`
+		);
 	}, [scrollerRef]);
 
 	return (
@@ -223,7 +224,7 @@ export function TableScroller({ children }: TableScrollerProps) {
 			}}
 		>
 			<Box
-				aria-label={scrollerAriaLabel.current}
+				aria-label={scrollerLabel}
 				as="section"
 				css={{
 					msOverflowStyle: 'none',

--- a/packages/react/src/table/TableScroller.tsx
+++ b/packages/react/src/table/TableScroller.tsx
@@ -2,6 +2,7 @@ import {
 	type ReactNode,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from 'react';
@@ -17,9 +18,9 @@ export function TableScroller({ children }: TableScrollerProps) {
 	const trackRef = useRef<HTMLDivElement>(null);
 	const thumbRef = useRef<HTMLButtonElement>(null);
 	const scrollerRef = useRef<HTMLDivElement>(null);
+	const scrollerAriaLabel = useRef('');
 	const mousePos = useRef({ x: 0, y: 0 });
 
-	const [scrollerLabel, setScrollerLabel] = useState('');
 	const [isDraggingThumb, setIsDraggingThumb] = useState(false);
 	const [thumbPosition, setThumbPosition] = useState(0);
 	const [thumbWidthRatio, setThumbWidthRatio] = useState(0);
@@ -207,12 +208,10 @@ export function TableScroller({ children }: TableScrollerProps) {
 
 	const hasScroll = thumbWidthRatio !== 1;
 
-	useEffect(() => {
-		setScrollerLabel(
-			`Table ${
-				scrollerRef.current?.querySelector('caption')?.textContent || ''
-			}`
-		);
+	useLayoutEffect(() => {
+		scrollerAriaLabel.current = `Table ${
+			scrollerRef.current?.querySelector('caption')?.textContent || ''
+		}`;
 	}, [scrollerRef]);
 
 	return (
@@ -224,7 +223,7 @@ export function TableScroller({ children }: TableScrollerProps) {
 			}}
 		>
 			<Box
-				aria-label={scrollerLabel}
+				aria-label={scrollerAriaLabel.current}
 				as="section"
 				css={{
 					msOverflowStyle: 'none',

--- a/packages/react/src/table/TableScroller.tsx
+++ b/packages/react/src/table/TableScroller.tsx
@@ -311,6 +311,10 @@ export function TableScroller({ children }: TableScrollerProps) {
 							position: 'absolute',
 							top: 0,
 							touchAction: 'none', // Prevent default touch actions
+							// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+							'@media (forced-colors: active)': {
+								backgroundColor: 'CaptionText',
+							},
 						}}
 						style={{
 							left: thumbPosition,

--- a/packages/react/src/table/TableScroller.tsx
+++ b/packages/react/src/table/TableScroller.tsx
@@ -19,7 +19,7 @@ export function TableScroller({ children }: TableScrollerProps) {
 	const scrollerRef = useRef<HTMLDivElement>(null);
 	const mousePos = useRef({ x: 0, y: 0 });
 
-	const [scrollerLabel, setScrollerLabel] = useState('');
+	const [scrollerAriaLabel, setScrollerAriaLabel] = useState('');
 	const [isDraggingThumb, setIsDraggingThumb] = useState(false);
 	const [thumbPosition, setThumbPosition] = useState(0);
 	const [thumbWidthRatio, setThumbWidthRatio] = useState(0);
@@ -208,7 +208,7 @@ export function TableScroller({ children }: TableScrollerProps) {
 	const hasScroll = thumbWidthRatio !== 1;
 
 	useEffect(() => {
-		setScrollerLabel(
+		setScrollerAriaLabel(
 			`Table ${
 				scrollerRef.current?.querySelector('caption')?.textContent || ''
 			}`
@@ -224,7 +224,7 @@ export function TableScroller({ children }: TableScrollerProps) {
 			}}
 		>
 			<Box
-				aria-label={scrollerLabel}
+				aria-label={scrollerAriaLabel}
 				as="section"
 				css={{
 					msOverflowStyle: 'none',

--- a/packages/react/src/table/TableScroller.tsx
+++ b/packages/react/src/table/TableScroller.tsx
@@ -19,6 +19,7 @@ export function TableScroller({ children }: TableScrollerProps) {
 	const scrollerRef = useRef<HTMLDivElement>(null);
 	const mousePos = useRef({ x: 0, y: 0 });
 
+	const [scrollerLabel, setScrollerLabel] = useState('');
 	const [isDraggingThumb, setIsDraggingThumb] = useState(false);
 	const [thumbPosition, setThumbPosition] = useState(0);
 	const [thumbWidthRatio, setThumbWidthRatio] = useState(0);
@@ -204,6 +205,16 @@ export function TableScroller({ children }: TableScrollerProps) {
 		}
 	};
 
+	const hasScroll = thumbWidthRatio !== 1;
+
+	useEffect(() => {
+		setScrollerLabel(
+			`Table ${
+				scrollerRef.current?.querySelector('caption')?.textContent || ''
+			}`
+		);
+	}, [scrollerRef]);
+
 	return (
 		<Stack
 			gap={0.5}
@@ -213,6 +224,8 @@ export function TableScroller({ children }: TableScrollerProps) {
 			}}
 		>
 			<Box
+				aria-label={scrollerLabel}
+				as="section"
 				css={{
 					msOverflowStyle: 'none',
 					overflowX: 'auto',
@@ -227,16 +240,16 @@ export function TableScroller({ children }: TableScrollerProps) {
 				focusRingFor="keyboard"
 				onScroll={repositionThumb}
 				ref={scrollerRef}
-				tabIndex={0}
+				tabIndex={hasScroll ? 0 : -1}
 			>
 				{children}
 			</Box>
 			<Flex
-				background="body"
 				alignItems="center"
+				background="body"
 				css={{
 					bottom: 0,
-					display: thumbWidthRatio === 1 ? 'none' : undefined,
+					display: hasScroll ? undefined : 'none',
 					left: 0,
 					position: 'sticky',
 					right: 0,
@@ -273,7 +286,6 @@ export function TableScroller({ children }: TableScrollerProps) {
 					aria-hidden
 					background="shade"
 					border
-					borderColor="muted"
 					css={{
 						borderRadius: 999,
 						height: pxToRem(12),

--- a/packages/react/src/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/Table.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
       >
         <button
           aria-hidden="true"
-          class="css-np8p1e-boxStyles-TableScroller"
+          class="css-k24nkr-boxStyles-TableScroller"
           style="left: 0px; width: 0%;"
           tabindex="-1"
           type="button"

--- a/packages/react/src/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/Table.test.tsx.snap
@@ -5,7 +5,8 @@ exports[`Table with TableCaption renders correctly 1`] = `
   <div
     class="css-h6dj2w-boxStyles-TableScroller"
   >
-    <div
+    <section
+      aria-label="Table Population of Australian states and territories, December 2015"
       class="css-x9kx5j-boxStyles-TableScroller"
       tabindex="0"
     >
@@ -255,7 +256,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </tr>
         </tbody>
       </table>
-    </div>
+    </section>
     <div
       class="css-67252i-boxStyles-TableScroller"
     >
@@ -284,7 +285,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
       </button>
       <div
         aria-hidden="true"
-        class="css-1ne0yec-boxStyles-TableScroller"
+        class="css-rr47rr-boxStyles-TableScroller"
         tabindex="-1"
       >
         <button


### PR DESCRIPTION
Various things were raised about scrolling tables in the a11y audit:

1. Non-scrolling tables shouldn't have a tabstop
2. Scrolling tables should be announced as a labelled region
3. Scrollbar border didn't have enough contrast

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1744)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.