### PR TITLE
combobox: Announce loading and error states to screen readers

### DIFF
--- a/.changeset/thin-colts-appear.md
+++ b/.changeset/thin-colts-appear.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/react': patch
+---
+
+autocomplete: Announce loading and error states to screen readers.
+
+combobox: Announce loading and error states to screen readers.
+
+time-picker: Announce loading and error states to screen readers.

--- a/packages/react/src/combobox/ComboboxBase/ComboboxListError.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxListError.tsx
@@ -8,7 +8,7 @@ export function ComboboxListError() {
 		<ComboboxListItem isActiveItem={false} isInteractive={false}>
 			<Flex alignItems="center" gap={0.5}>
 				<AlertFilledIcon color="error" css={{ flexShrink: 0 }} />
-				<Text>Something went wrong.</Text>
+				<Text role="status">Something went wrong.</Text>
 			</Flex>
 		</ComboboxListItem>
 	);

--- a/packages/react/src/combobox/ComboboxBase/ComboboxListLoading.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxListLoading.tsx
@@ -7,7 +7,7 @@ export function ComboboxListLoading() {
 	return (
 		<ComboboxListItem isActiveItem={false} isInteractive={false}>
 			<Flex gap={1} alignItems="center">
-				<LoadingDots size="sm" aria-label="Loading" />
+				<LoadingDots role="status" size="sm" aria-label="Loading" />
 				<Text>Loading</Text>
 			</Flex>
 		</ComboboxListItem>

--- a/packages/react/src/time-picker/__snapshots__/TimePicker.test.tsx.snap
+++ b/packages/react/src/time-picker/__snapshots__/TimePicker.test.tsx.snap
@@ -187,6 +187,7 @@ exports[`TimePicker renders correctly when loading 1`] = `
               aria-atomic="false"
               aria-label="Loading"
               class="css-1urm0li-boxStyles"
+              role="status"
             >
               <span
                 aria-hidden="true"


### PR DESCRIPTION
The audit found that we weren't announcing the loading and error states, and to do this with `role="status"`

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1746)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
