### PR TITLE
date-picker: Make hover, selected and today cells visible in high contrast mode

### DIFF
--- a/.changeset/smart-gifts-bathe.md
+++ b/.changeset/smart-gifts-bathe.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+date-picker: Make hover, selected and today cells visible in high contrast mode.
+
+date-range-picker: Make hover, selected and today cells visible in high contrast mode.

--- a/packages/react/src/date-picker/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/Calendar.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Calendar Range renders correctly 1`] = `
     data-focus-lock-disabled="false"
   >
     <div
-      class="css-x2ztpa-boxStyles-CalendarRangeContainer"
+      class="css-1bb0woa-boxStyles-CalendarRangeContainer"
     >
       <div
         class="rdp "
@@ -898,7 +898,7 @@ exports[`Calendar Single renders correctly 1`] = `
     data-focus-lock-disabled="false"
   >
     <div
-      class="css-1exdz5y-boxStyles-CalendarContainer"
+      class="css-16fenf-boxStyles-CalendarContainer"
     >
       <div
         class="rdp "

--- a/packages/react/src/date-picker/reactDayPickerStyles.ts
+++ b/packages/react/src/date-picker/reactDayPickerStyles.ts
@@ -76,31 +76,37 @@ export const reactDayPickerStyles = {
 		display: 'flex',
 		height: cellSizeSmall,
 		justifyContent: 'center',
+		position: 'relative',
 		width: cellSizeSmall,
 		'&[disabled]': {
 			color: boxPalette.foregroundText,
 			opacity: 0.3,
 			cursor: 'not-allowed',
 		},
-		'&:not([disabled]):hover': {
+		'&:not([disabled], :focus):hover': {
 			backgroundColor: boxPalette.backgroundShade,
 			color: boxPalette.foregroundText,
 			textDecoration: 'underline',
+			zIndex: tokens.zIndex.elevated,
+			...highContrastOutlineStyles,
+		},
+		'&:focus': {
+			zIndex: tokens.zIndex.elevated,
 		},
 		'@media(min-width: 375px)': { height: cellSizeLarge, width: cellSizeLarge },
 		...focusStyles,
 		// Today's button
 		'&.rdp-day_today': {
-			position: 'relative',
 			fontWeight: tokens.fontWeight.bold,
 			'&::after': {
-				content: '""',
-				position: 'absolute',
-				bottom: '0.3rem',
-				height: '0.5rem',
-				width: '0.5rem',
-				borderRadius: '0.25rem',
 				backgroundColor: 'currentColor',
+				borderRadius: '0.25rem',
+				bottom: '0.3rem',
+				content: '""',
+				height: '0.5rem',
+				position: 'absolute',
+				width: '0.5rem',
+				...highContrastOutlineStyles
 			},
 		},
 	},
@@ -132,10 +138,16 @@ export const reactDayPickerStyles = {
 	},
 	'.rdp-day_selected:not([disabled]), .rdp-day_selected:focus:not([disabled]), .rdp-day_selected:active:not([disabled]), .rdp-day_selected:hover:not([disabled]), .rdp-day_selected:hover:not([disabled])':
 		{
-			'&:not(:focus)': highContrastOutlineStyles,
 			backgroundColor: boxPalette.selected,
 			color: boxPalette.backgroundBody,
 			fontWeight: tokens.fontWeight.bold,
+			'&::before': {
+				content: '""',
+				inset: 0,
+				pointerEvents: 'none',
+				position: 'absolute',
+				...highContrastOutlineStyles
+			}
 		},
 } as const;
 
@@ -164,8 +176,10 @@ export const reactDayRangePickerStyles = (dateRange?: {
 		},
 		// Start day of date range
 		'.rdp-day_range_start:not(.rdp-day_range_end)': startStyles,
+		'.rdp-day_range_start:not(.rdp-day_range_end)::before': startStyles,
 		// End day of date range
 		'.rdp-day_range_end:not(.rdp-day_range_start)': endStyles,
+		'.rdp-day_range_end:not(.rdp-day_range_start)::before': endStyles,
 		// Start and end days of date range
 		'.rdp-day_range_start.rdp-day_range_end': {
 			...(from && startStyles),

--- a/packages/react/src/date-picker/reactDayPickerStyles.ts
+++ b/packages/react/src/date-picker/reactDayPickerStyles.ts
@@ -106,7 +106,7 @@ export const reactDayPickerStyles = {
 				height: '0.5rem',
 				position: 'absolute',
 				width: '0.5rem',
-				...highContrastOutlineStyles
+				...highContrastOutlineStyles,
 			},
 		},
 	},
@@ -146,8 +146,8 @@ export const reactDayPickerStyles = {
 				inset: 0,
 				pointerEvents: 'none',
 				position: 'absolute',
-				...highContrastOutlineStyles
-			}
+				...highContrastOutlineStyles,
+			},
 		},
 } as const;
 


### PR DESCRIPTION
The accessibility audit found that the selected, hover and today's date weren't visible in WHCM or `forced-colors: active`

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1747)

<img width="411" alt="image" src="https://github.com/user-attachments/assets/84774b57-7455-4b29-a0f8-bd3b3f9d02b2">


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
