### PR TITLE
docs: Icons - markup as ordered list

### DIFF
--- a/.changeset/tidy-swans-argue.md
+++ b/.changeset/tidy-swans-argue.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+docs: Icons - markup as ordered list.

--- a/docs/components/AllIconsPlayground.tsx
+++ b/docs/components/AllIconsPlayground.tsx
@@ -41,22 +41,23 @@ export function AllIconsPlayground() {
 					]}
 				/>
 			</Columns>
-			<Columns cols={{ xs: 1, sm: 2, md: 3 }} gap={1}>
+			<Columns as="ol" cols={{ xs: 1, sm: 2, md: 3 }} gap={1}>
 				{Object.keys(allIcons)
 					.sort()
 					.map((iconName) => {
 						const Icon = allIcons[iconName as keyof typeof allIcons];
 						return (
 							<Flex
-								key={iconName}
-								flexDirection="column"
 								alignItems="center"
-								justifyContent="center"
-								flexShrink={0}
-								rounded
-								gap={1}
-								padding={2}
+								as="li"
 								background="shade"
+								flexDirection="column"
+								flexShrink={0}
+								gap={1}
+								justifyContent="center"
+								key={iconName}
+								padding={2}
+								rounded
 							>
 								<Icon size={size} weight={weight} />
 								<Text>{iconName}</Text>


### PR DESCRIPTION
The audit reported that our list of icons in the docs wasn't correctly marked up as an `ol`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1748)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets