### PR TITLE
tags: Make remove button hit target 24x24

### DIFF
--- a/.changeset/silly-games-drop.md
+++ b/.changeset/silly-games-drop.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+tags: Make remove button hit target 24x24.

--- a/packages/react/src/tags/Tag.tsx
+++ b/packages/react/src/tags/Tag.tsx
@@ -52,6 +52,10 @@ const TagRemoveButton = ({
 			aria-label={ariaLabel}
 			as={BaseButton}
 			css={{
+				marginBottom: `-0.125rem`,
+				marginLeft: '-0.25rem',
+				marginRight: '-0.25rem',
+				marginTop: `-0.125rem`,
 				svg: {
 					color: boxPalette.foregroundAction,
 					display: 'block',
@@ -63,10 +67,10 @@ const TagRemoveButton = ({
 				},
 			}}
 			focusRingFor="keyboard"
-			height="1rem"
+			height="1.5rem"
 			justifyContent="center"
 			onClick={onClick}
-			width="1rem"
+			width="1.5rem"
 		>
 			<CloseIcon size="sm" />
 		</Flex>

--- a/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
+++ b/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           </a>
           <button
             aria-label="Remove Foo"
-            class="css-9t1jls-BaseButton-boxStyles-TagRemoveButton"
+            class="css-1krg97w-BaseButton-boxStyles-TagRemoveButton"
             type="button"
           >
             <svg
@@ -132,7 +132,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           </a>
           <button
             aria-label="Remove Bar"
-            class="css-9t1jls-BaseButton-boxStyles-TagRemoveButton"
+            class="css-1krg97w-BaseButton-boxStyles-TagRemoveButton"
             type="button"
           >
             <svg
@@ -177,7 +177,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           </a>
           <button
             aria-label="Remove Baz"
-            class="css-9t1jls-BaseButton-boxStyles-TagRemoveButton"
+            class="css-1krg97w-BaseButton-boxStyles-TagRemoveButton"
             type="button"
           >
             <svg


### PR DESCRIPTION
The audit highlighted that our removable tag touch target was too small and they need to be 24 x 24.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1750)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.