### PR TITLE
collapsing-sidebar: Reduce verbosity of collapsible announcements for screen readers

### DIFF
--- a/.changeset/chatty-pumpkins-flash.md
+++ b/.changeset/chatty-pumpkins-flash.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/react': patch
+---
+
+filter-sidebar: Reduce verbosity of collapsible announcements for screen readers.
+
+progress-indicator: Reduce verbosity of collapsible announcements for screen readers.
+
+side-nav: Reduce verbosity of collapsible announcements for screen readers.

--- a/packages/react/src/_collapsing-side-bar/CollapsingSideBar.tsx
+++ b/packages/react/src/_collapsing-side-bar/CollapsingSideBar.tsx
@@ -21,6 +21,8 @@ import {
 } from './utils';
 
 export type CollapsingSideBarProps = PropsWithChildren<{
+	/* The specific label of the root element, otherwise falls back to title + subtitle. */
+	ariaLabel?: string;
 	/** The HTML element to render the CollapsingSideBar as. */
 	as?: CollapsingSideBarContainerElementType;
 	/** If CollapsingSideBar is placed on 'bodyAlt' background, please set this to 'bodyAlt'. */
@@ -36,6 +38,7 @@ export type CollapsingSideBarProps = PropsWithChildren<{
 }>;
 
 export function CollapsingSideBar({
+	ariaLabel,
 	as = 'section',
 	background = 'body',
 	children,
@@ -72,7 +75,8 @@ export function CollapsingSideBar({
 	return (
 		<Stack
 			as={as}
-			aria-labelledby={headingId}
+			aria-label={ariaLabel}
+			aria-labelledby={ariaLabel ? undefined : headingId}
 			background={background}
 			css={{
 				[collapsingSideBarHoverProp]: hoverColorMap[background],
@@ -115,9 +119,8 @@ export function CollapsingSideBar({
 				</Stack>
 				<Box
 					aria-controls={bodyId}
-					aria-describedby={headingId}
 					aria-expanded={isOpen}
-					aria-label={`${title} (Expand/Collapse)`}
+					aria-label={title}
 					as={BaseButton}
 					background={background}
 					borderBottom

--- a/packages/react/src/_collapsing-side-bar/__snapshots__/CollapsingSideBar.test.tsx.snap
+++ b/packages/react/src/_collapsing-side-bar/__snapshots__/CollapsingSideBar.test.tsx.snap
@@ -26,9 +26,8 @@ exports[`CollapsingSideBar renders correctly 1`] = `
       </div>
       <button
         aria-controls="collapsing-side-bar-:r0:-body"
-        aria-describedby="collapsing-side-bar-:r0:-heading"
         aria-expanded="false"
-        aria-label="Title (Expand/Collapse)"
+        aria-label="Title"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -102,9 +101,8 @@ exports[`CollapsingSideBar renders customTitleElement correctly 1`] = `
       </div>
       <button
         aria-controls="collapsing-side-bar-:r1:-body"
-        aria-describedby="collapsing-side-bar-:r1:-heading"
         aria-expanded="false"
-        aria-label="Title (Expand/Collapse)"
+        aria-label="Title"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >

--- a/packages/react/src/filter-sidebar/FilterSidebar.tsx
+++ b/packages/react/src/filter-sidebar/FilterSidebar.tsx
@@ -40,6 +40,9 @@ export function FilterSidebar({
 
 	return (
 		<CollapsingSideBar
+			ariaLabel={`Filters${
+				activeFiltersCount ? ` (${activeFiltersCount} active)` : ''
+			}`}
 			title={`Filters${activeFiltersCount ? ` (${activeFiltersCount})` : ''}`}
 		>
 			<Box

--- a/packages/react/src/filter-sidebar/__snapshots__/FilterSidebar.test.tsx.snap
+++ b/packages/react/src/filter-sidebar/__snapshots__/FilterSidebar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FilterSidebar renders correctly 1`] = `
 <div>
   <section
-    aria-labelledby="collapsing-side-bar-:r0:-heading"
+    aria-label="Filters (1 active)"
     class="css-1dkbvi7-boxStyles-CollapsingSideBar"
   >
     <div
@@ -21,9 +21,8 @@ exports[`FilterSidebar renders correctly 1`] = `
       </div>
       <button
         aria-controls="collapsing-side-bar-:r0:-body"
-        aria-describedby="collapsing-side-bar-:r0:-heading"
         aria-expanded="false"
-        aria-label="Filters (1) (Expand/Collapse)"
+        aria-label="Filters (1)"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >

--- a/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -26,9 +26,8 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
       </div>
       <button
         aria-controls="collapsing-side-bar-:r0:-body"
-        aria-describedby="collapsing-side-bar-:r0:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -561,9 +560,8 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
       </div>
       <button
         aria-controls="collapsing-side-bar-:r2:-body"
-        aria-describedby="collapsing-side-bar-:r2:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -1096,9 +1094,8 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
       </div>
       <button
         aria-controls="collapsing-side-bar-:r5:-body"
-        aria-describedby="collapsing-side-bar-:r5:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -1631,9 +1628,8 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
       </div>
       <button
         aria-controls="collapsing-side-bar-:r4:-body"
-        aria-describedby="collapsing-side-bar-:r4:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -2166,9 +2162,8 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
       </div>
       <button
         aria-controls="collapsing-side-bar-:r7:-body"
-        aria-describedby="collapsing-side-bar-:r7:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -2701,9 +2696,8 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
       </div>
       <button
         aria-controls="collapsing-side-bar-:r6:-body"
-        aria-describedby="collapsing-side-bar-:r6:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -3236,9 +3230,8 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
       </div>
       <button
         aria-controls="collapsing-side-bar-:r9:-body"
-        aria-describedby="collapsing-side-bar-:r9:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -3771,9 +3764,8 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
       </div>
       <button
         aria-controls="collapsing-side-bar-:r8:-body"
-        aria-describedby="collapsing-side-bar-:r8:-heading"
         aria-expanded="false"
-        aria-label="Progress (Expand/Collapse)"
+        aria-label="Progress"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -89,7 +89,7 @@ describe('SideNav', () => {
 
 					user.click(
 						screen.getByRole('button', {
-							name: `${defaultTestingProps.title} (Expand/Collapse)`,
+							name: `${defaultTestingProps.title}`,
 						})
 					);
 				});
@@ -132,7 +132,7 @@ describe('SideNav', () => {
 
 					user.click(
 						screen.getByRole('button', {
-							name: `${defaultTestingProps.title} (Expand/Collapse)`,
+							name: `${defaultTestingProps.title}`,
 						})
 					);
 				});
@@ -179,7 +179,7 @@ describe('SideNav', () => {
 
 					user.click(
 						screen.getByRole('button', {
-							name: `${defaultTestingProps.title} (Expand/Collapse)`,
+							name: `${defaultTestingProps.title}`,
 						})
 					);
 				});
@@ -252,7 +252,7 @@ describe('SideNav', () => {
 
 					user.click(
 						screen.getByRole('button', {
-							name: `${defaultTestingProps.title} (Expand/Collapse)`,
+							name: `${defaultTestingProps.title}`,
 						})
 					);
 				});
@@ -310,7 +310,7 @@ describe('SideNav', () => {
 					const user = userEvent.setup();
 					user.click(
 						screen.getByRole('button', {
-							name: `${defaultTestingProps.title} (Expand/Collapse)`,
+							name: `${defaultTestingProps.title}`,
 						})
 					);
 
@@ -345,7 +345,7 @@ describe('SideNav', () => {
 					const user = userEvent.setup();
 					user.click(
 						screen.getByRole('button', {
-							name: `${defaultTestingProps.title} (Expand/Collapse)`,
+							name: `${defaultTestingProps.title}`,
 						})
 					);
 

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -39,37 +39,78 @@ describe('SideNav', () => {
 	});
 
 	describe('renders the title correctly', () => {
-		test('with link', () => {
-			renderSideNav(defaultTestingProps);
+		describe('when `titleLink` is defined', () => {
+			test('renders valid HTML with no a11y violations', async () => {
+				const { container } = renderSideNav(defaultTestingProps);
 
-			const el = screen.getByRole('link', {
-				name: defaultTestingProps.title,
-				hidden: true,
+				expect(container).toHTMLValidate({
+					extends: ['html-validate:recommended'],
+					rules: {
+						'no-inline-style': 'off',
+						// react 18s `useId` break this rule
+						'valid-id': 'off',
+					},
+				});
+				expect(await axe(container)).toHaveNoViolations();
 			});
 
-			expect(el).toBeInTheDocument();
-			expect(el).toHaveAttribute('href', defaultTestingProps.titleLink);
+			test('there is a link with that title text', async () => {
+				renderSideNav(defaultTestingProps);
+
+				const user = userEvent.setup();
+				const button = screen.getByRole('button', {
+					name: defaultTestingProps.title,
+				});
+				await user.click(button);
+
+				const titleAsLink = await screen.findByRole('link', {
+					name: defaultTestingProps.title,
+				});
+
+				expect(titleAsLink).toBeVisible();
+				expect(screen.getAllByText(defaultTestingProps.title).length).toEqual(
+					3
+				);
+			});
 		});
 
-		test('without link', async () => {
-			const { container } = renderSideNav({
-				...defaultTestingProps,
-				titleLink: undefined,
-			});
-			expect(container).toHTMLValidate({
-				extends: ['html-validate:recommended'],
-				rules: {
-					'no-inline-style': 'off',
-					// react 18s `useId` break this rule
-					'valid-id': 'off',
-				},
+		describe('when `titleLink` is undefined', () => {
+			test('renders valid HTML with no a11y violations', async () => {
+				const { container } = renderSideNav({
+					...defaultTestingProps,
+					titleLink: undefined,
+				});
+
+				expect(container).toHTMLValidate({
+					extends: ['html-validate:recommended'],
+					rules: {
+						'no-inline-style': 'off',
+						// react 18s `useId` break this rule
+						'valid-id': 'off',
+					},
+				});
+				expect(await axe(container)).toHaveNoViolations();
 			});
 
-			const nav = screen.getByRole('navigation', { hidden: true });
-			const els = within(nav).getAllByText(defaultTestingProps.title);
-			expect(els.length).toEqual(3);
+			test('there is no link with that title text', async () => {
+				renderSideNav({
+					...defaultTestingProps,
+					titleLink: undefined,
+				});
 
-			expect(await axe(container)).toHaveNoViolations();
+				const user = userEvent.setup();
+				const button = screen.getByRole('button', {
+					name: defaultTestingProps.title,
+				});
+				await user.click(button);
+
+				expect(
+					screen.queryByRole('link', { name: defaultTestingProps.title })
+				).toBeNull();
+				expect(screen.getAllByText(defaultTestingProps.title).length).toEqual(
+					3
+				);
+			});
 		});
 	});
 
@@ -94,7 +135,7 @@ describe('SideNav', () => {
 					);
 				});
 
-				test('then no sub-level items should be visible', async () => {
+				test('no sub-level items should be visible', async () => {
 					const levelOneItemHrefs = defaultTestingProps.items.map(
 						({ href }) => href
 					);
@@ -109,7 +150,7 @@ describe('SideNav', () => {
 					expect(navItemPathnames).toEqual(levelOneItemHrefs);
 				});
 
-				test('then icons indicating hidden sub-level items should be visible', async () => {
+				test('icons indicating hidden sub-level items should be visible', async () => {
 					expect(
 						await screen.findAllByRole('img', {
 							name: /. Has [2-9] sub-level links.|. Has 1 sub-level link./,
@@ -137,7 +178,7 @@ describe('SideNav', () => {
 					);
 				});
 
-				test('then its sub-level items should be visible to one level and no other sub-level items', async () => {
+				test('its sub-level items should be visible to one level and no other sub-level items', async () => {
 					const levelOneItems = defaultTestingProps.items;
 					const levelTwoInDetailItems =
 						defaultTestingProps.items.find(({ href }) => href === '/in-detail')
@@ -156,7 +197,7 @@ describe('SideNav', () => {
 					expect(navItemPathnames).toEqual(itemHrefs);
 				});
 
-				test('then an icon indicating visible sub-level items should be visible', async () => {
+				test('an icon indicating visible sub-level items should be visible', async () => {
 					expect(
 						await screen.findByRole('img', {
 							name: '. Sub-level links below.',
@@ -184,7 +225,7 @@ describe('SideNav', () => {
 					);
 				});
 
-				test('then its sub-level items should be visible to one level', async () => {
+				test('its sub-level items should be visible to one level', async () => {
 					const levelOneItems = defaultTestingProps.items;
 					const levelTwoInDetailItems =
 						defaultTestingProps.items.find(({ href }) => href === '/in-detail')
@@ -212,7 +253,7 @@ describe('SideNav', () => {
 				});
 
 				// Skipping because this is failing only in CI
-				test.skip('then an icon indicating visible sub-level items should be visible', async () => {
+				test.skip('an icon indicating visible sub-level items should be visible', async () => {
 					const link = await screen.findByRole('link', {
 						name: 'Record keeping. Sub-level links below.',
 					});
@@ -225,7 +266,7 @@ describe('SideNav', () => {
 				});
 
 				// Skipping because this is failing only in CI
-				test.skip('then its parent should have an icon indicating visible sub-level items', async () => {
+				test.skip('its parent should have an icon indicating visible sub-level items', async () => {
 					const link = await screen.findByRole('link', {
 						name: 'In detail. Sub-level links below.',
 					});
@@ -258,7 +299,7 @@ describe('SideNav', () => {
 				});
 
 				// Skipping because this is failing only in CI
-				test.skip('then no icon indicating visible sub-level items should be visible', async () => {
+				test.skip('no icon indicating visible sub-level items should be visible', async () => {
 					const link = await screen.findByRole('link', {
 						name: 'Keeping your tax records',
 					});
@@ -269,7 +310,7 @@ describe('SideNav', () => {
 				});
 
 				// Skipping because this is failing only in CI
-				test.skip('then its parent should have an icon indicating visible sub-level items', async () => {
+				test.skip('its parent should have an icon indicating visible sub-level items', async () => {
 					const link = await screen.findByRole('link', {
 						name: 'Record keeping. Sub-level links below.',
 					});
@@ -282,7 +323,7 @@ describe('SideNav', () => {
 				});
 
 				// Skipping because this is failing only in CI
-				test.skip('then its grandparent should have an icon indicating visible sub-level items', async () => {
+				test.skip('its grandparent should have an icon indicating visible sub-level items', async () => {
 					const link = await screen.findByRole('link', {
 						name: 'In detail. Sub-level links below.',
 					});
@@ -298,7 +339,7 @@ describe('SideNav', () => {
 
 		describe('when subLevelVisible is "always"', () => {
 			describe('when the active item has no sub-level items', () => {
-				test('then all sub-level items should be visible', async () => {
+				test('all sub-level items should be visible', async () => {
 					render(
 						<SideNav
 							{...defaultTestingProps}
@@ -333,7 +374,7 @@ describe('SideNav', () => {
 			});
 
 			describe('when the active item is level one and has sub-level items', () => {
-				test('then all sub-level items should be visible', async () => {
+				test('all sub-level items should be visible', async () => {
 					render(
 						<SideNav
 							{...defaultTestingProps}

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -66,8 +66,8 @@ describe('SideNav', () => {
 			});
 
 			const nav = screen.getByRole('navigation', { hidden: true });
-			const el = within(nav).getByText(defaultTestingProps.title);
-			expect(el).toBeInTheDocument();
+			const els = within(nav).getAllByText(defaultTestingProps.title);
+			expect(els.length).toEqual(3);
 
 			expect(await axe(container)).toHaveNoViolations();
 		});

--- a/packages/react/src/side-nav/SideNav.tsx
+++ b/packages/react/src/side-nav/SideNav.tsx
@@ -6,7 +6,7 @@ import {
 	CollapsingSideBarBackground,
 } from '../_collapsing-side-bar';
 import { SideNavTitle } from './SideNavTitle';
-import { findBestMatch, useSideNavIds } from './utils';
+import { findBestMatch } from './utils';
 import { SideNavLinkList } from './SideNavLinkList';
 
 type SideNavMenuItem = Omit<LinkProps, 'children'> & {
@@ -45,11 +45,11 @@ export function SideNav({
 		console.warn('SideNav: The `collapseTitle` prop is now unused.');
 	}
 
-	const { titleId } = useSideNavIds();
 	const bestMatch = findBestMatch(items, activePath);
 
 	return (
 		<CollapsingSideBar
+			as="nav"
 			background={background}
 			customTitleElement={
 				<SideNavTitle
@@ -57,7 +57,6 @@ export function SideNav({
 					css={{
 						[tokens.mediaQuery.min.md]: visuallyHiddenStyles,
 					}}
-					id={titleId}
 				>
 					{title}
 				</SideNavTitle>
@@ -65,13 +64,7 @@ export function SideNav({
 			gap={0}
 			title={title}
 		>
-			<Box
-				aria-labelledby={titleId}
-				as="nav"
-				fontFamily="body"
-				fontSize="sm"
-				lineHeight="default"
-			>
+			<Box fontFamily="body" fontSize="sm" lineHeight="default">
 				<SideNavTitle
 					as="span"
 					// Don't render the title on small screen if there is no link as it's unnecessary double-up of headings

--- a/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`SideNav renders correctly 1`] = `
 <div>
-  <section
-    aria-labelledby="collapsing-side-bar-:r1:-heading"
+  <nav
+    aria-labelledby="collapsing-side-bar-:r0:-heading"
     class="css-2yhndx-boxStyles-CollapsingSideBar"
   >
     <div
@@ -11,11 +11,10 @@ exports[`SideNav renders correctly 1`] = `
     >
       <div
         class="css-lr9d04-boxStyles-CollapsingSideBar"
-        id="collapsing-side-bar-:r1:-heading"
+        id="collapsing-side-bar-:r0:-heading"
       >
         <h2
           class="css-m2oixi-boxStyles-SideNav"
-          id="sideNav-:r0:-title"
         >
           <span
             class="css-1jga52b-boxStyles"
@@ -25,10 +24,9 @@ exports[`SideNav renders correctly 1`] = `
         </h2>
       </div>
       <button
-        aria-controls="collapsing-side-bar-:r1:-body"
-        aria-describedby="collapsing-side-bar-:r1:-heading"
+        aria-controls="collapsing-side-bar-:r0:-body"
         aria-expanded="false"
-        aria-label="Lodging your tax return (Expand/Collapse)"
+        aria-label="Lodging your tax return"
         class="css-1c4meu7-BaseButton-boxStyles-CollapsingSideBar"
         type="button"
       >
@@ -65,14 +63,13 @@ exports[`SideNav renders correctly 1`] = `
     </div>
     <div
       class="css-3b4a55-CollapsingSideBar"
-      id="collapsing-side-bar-:r1:-body"
+      id="collapsing-side-bar-:r0:-body"
       style="display: none; height: 0px;"
     >
       <div
         class="css-79i25n-boxStyles"
       >
-        <nav
-          aria-labelledby="sideNav-:r0:-title"
+        <div
           class="css-zipzg2-boxStyles"
         >
           <span
@@ -286,9 +283,9 @@ exports[`SideNav renders correctly 1`] = `
               </ul>
             </li>
           </ul>
-        </nav>
+        </div>
       </div>
     </div>
-  </section>
+  </nav>
 </div>
 `;

--- a/packages/react/src/side-nav/utils.ts
+++ b/packages/react/src/side-nav/utils.ts
@@ -1,4 +1,3 @@
-import { useId } from '../core';
 import { SideNavProps } from './SideNav';
 
 export function findBestMatch(
@@ -44,11 +43,4 @@ export function hasSubLevelActiveItem(
 			item.href === bestMatch ||
 			(item.items?.length && hasSubLevelActiveItem(item.items, bestMatch))
 	);
-}
-
-export function useSideNavIds() {
-	const autoId = useId();
-	return {
-		titleId: `sideNav-${autoId}-title`,
-	};
 }


### PR DESCRIPTION
The a11y audit found the the components that used collapsing sidebar were very verbose in their descriptions of the collapsible versions. This makes it so much better.

Recommendations:

* Remove the “(Expand/Collapse)" text from the button's aria-label. The expanded/collapsed state is already being communicated via the aria-expanded attribute.
* Consider removing the <section> landmark. The side nav region is already adequately identified via the heading and label for the <nav> landmark.
* Alternatively, name the <nav> by what type of navigation it is, e.g. Sub-categories or In-page navigation, rather than by the name of the page or section it belongs to.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1762)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.