### PR TITLE
details: Fix iOS VO announcement of expanded state

### DIFF
--- a/.changeset/thin-forks-own.md
+++ b/.changeset/thin-forks-own.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+details: Fix iOS VoiceOver not announcing the expanded state.

--- a/packages/react/src/details/Details.tsx
+++ b/packages/react/src/details/Details.tsx
@@ -32,7 +32,7 @@ export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
 			>
 				<Flex
 					as="summary"
-					css={{ width: 'min-content' }}
+					css={{ display: 'block', width: 'fit-content' }}
 					link
 					focusRingFor="keyboard"
 					alignItems="center"

--- a/packages/react/src/details/Details.tsx
+++ b/packages/react/src/details/Details.tsx
@@ -32,7 +32,11 @@ export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
 			>
 				<Flex
 					as="summary"
-					css={{ width: 'fit-content' }}
+					css={{
+						// iOS VoiceOver does not announce the expanded state of `summary` elements when they are inline.
+						// Here we're using `fit-content` to simulate the visual effect of an inline element while maintaining the correct announcement.
+						width: 'fit-content',
+					}}
 					link
 					focusRingFor="keyboard"
 					alignItems="center"

--- a/packages/react/src/details/Details.tsx
+++ b/packages/react/src/details/Details.tsx
@@ -32,7 +32,7 @@ export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
 			>
 				<Flex
 					as="summary"
-					inline
+					css={{ width: 'min-content' }}
 					link
 					focusRingFor="keyboard"
 					alignItems="center"

--- a/packages/react/src/details/Details.tsx
+++ b/packages/react/src/details/Details.tsx
@@ -32,7 +32,7 @@ export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
 			>
 				<Flex
 					as="summary"
-					css={{ display: 'block', width: 'fit-content' }}
+					css={{ width: 'fit-content' }}
 					link
 					focusRingFor="keyboard"
 					alignItems="center"

--- a/packages/react/src/details/__snapshots__/Details.test.tsx.snap
+++ b/packages/react/src/details/__snapshots__/Details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details renders correctly 1`] = `
     class="css-jx8h3p-Details"
   >
     <summary
-      class="css-1s0jr0u-boxStyles-Details"
+      class="css-1pb4m7j-boxStyles-Details"
     >
       Details
       <svg

--- a/packages/react/src/details/__snapshots__/Details.test.tsx.snap
+++ b/packages/react/src/details/__snapshots__/Details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details renders correctly 1`] = `
     class="css-jx8h3p-Details"
   >
     <summary
-      class="css-tutrjp-boxStyles-Details"
+      class="css-1s0jr0u-boxStyles-Details"
     >
       Details
       <svg

--- a/packages/react/src/details/__snapshots__/Details.test.tsx.snap
+++ b/packages/react/src/details/__snapshots__/Details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details renders correctly 1`] = `
     class="css-jx8h3p-Details"
   >
     <summary
-      class="css-1tv6yf1-boxStyles"
+      class="css-tutrjp-boxStyles-Details"
     >
       Details
       <svg


### PR DESCRIPTION
The expanded state of the `<summary>` element in our `Details` component on iOS was not being announced due to it being an inline element. This PR moves back to a block level element with updated CSS approach, `fit-content`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1773)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets

**Creating new component**

- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Preconstruct entrypoint has been created (run `yarn` in the root of the repo to do this)
- [ ] Changeset file includes a minor
- [ ] Export components for docs site and Playroom (`docs/components/designSystemComponents.tsx`)
- [ ] Add component to Kitchen Sink (`.storybook/stories/KitchenSink.tsx`)
- [ ] Add snippets to Playroom (`docs/playroom/snippets.ts`)
- [ ] Add pictogram to Docs (`docs/components/pictograms/index.tsx`)
