### PR TITLE
combobox: iOS a11y & UX fixes

### DIFF
--- a/.changeset/nervous-kangaroos-admire.md
+++ b/.changeset/nervous-kangaroos-admire.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+combobox: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options.
+
+combobox-multi: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options.

--- a/.changeset/nervous-kangaroos-admire.md
+++ b/.changeset/nervous-kangaroos-admire.md
@@ -2,6 +2,6 @@
 '@ag.ds-next/react': patch
 ---
 
-combobox: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options. Fix accessing options in Android TalkBack.
+combobox: Prevent iOS Done button from closing dropdown. Fix iOS VoiceOver’s announcement of options. Fix accessing options in Android TalkBack.
 
-combobox-multi: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options. Fix accessing options in Android TalkBack.
+combobox-multi: Prevent iOS Done button from closing dropdown. Fix iOS VoiceOver’s announcement of options. Fix accessing options in Android TalkBack.

--- a/.changeset/nervous-kangaroos-admire.md
+++ b/.changeset/nervous-kangaroos-admire.md
@@ -2,6 +2,6 @@
 '@ag.ds-next/react': patch
 ---
 
-combobox: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options.
+combobox: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options. Fix accessing options in Android TalkBack.
 
-combobox-multi: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options.
+combobox-multi: Prevent iOS Done button from closing keyboard. Fix iOS VoiceOver’s announcement of options. Fix accessing options in Android TalkBack.

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ const config = {
 		'!**/dist/**',
 		'!**/{*.stories.tsx,index.ts,types.ts}',
 	],
+	setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };
 
 module.exports = config;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,10 +1,7 @@
 Object.defineProperty(window, 'CSS', {
 	value: {
 		supports: jest.fn().mockImplementation((property, value) => {
-			if (property === '-webkit-tap-highlight-color' && value === 'black') {
-				return true;
-			}
-			return false; // Fallback for unsupported properties
+			return property === '-webkit-tap-highlight-color' && value === 'black';
 		}),
 	},
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,7 @@
 Object.defineProperty(window, 'CSS', {
 	value: {
 		supports: jest.fn().mockImplementation((property, value) => {
-			return property === '-webkit-tap-highlight-color' && value === 'black';
+			return property === '-webkit-overflow-scrolling' && value === 'auto';
 		}),
 	},
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,10 @@
+Object.defineProperty(window, 'CSS', {
+	value: {
+		supports: jest.fn().mockImplementation((property, value) => {
+			if (property === '-webkit-tap-highlight-color' && value === 'black') {
+				return true;
+			}
+			return false; // Fallback for unsupported properties
+		}),
+	},
+});

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -59,7 +59,7 @@ describe('Combobox', () => {
 			user.type(input, 'capital');
 
 			const option = screen.getByRole('option', {
-				name: 'A u s t r a l i a n C a p i t a l T e r r i t o r y',
+				name: 'Australian Capital Territory',
 			});
 
 			// userEvent.click(option) does not fire the change event in downshift - using direct click method on the option as a workaround

--- a/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
@@ -213,7 +213,7 @@ describe('ComboboxAsyncMulti', () => {
 			await user.type(input, 'qld');
 
 			const option = await screen.findByRole('option', {
-				name: 'Q u e e n s l a n d',
+				name: 'Queensland',
 			});
 			option.click();
 
@@ -239,7 +239,7 @@ describe('ComboboxAsyncMulti', () => {
 			await user.type(input, 'qld');
 
 			const option = await screen.findByRole('option', {
-				name: 'Q u e e n s l a n d',
+				name: 'Queensland',
 			});
 			await user.click(option);
 

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -1,5 +1,6 @@
 import {
 	Fragment,
+	type FocusEvent,
 	type FocusEventHandler,
 	type ReactNode,
 	type Ref,
@@ -13,6 +14,7 @@ import {
 	generateHighlightStyles,
 	type ComboboxMaxWidthValues,
 	type DefaultComboboxOption,
+	useIsIos,
 	validateMaxWidth,
 } from '../utils';
 import { ComboboxRenderItem } from '../ComboboxRenderItem';
@@ -89,6 +91,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	const showClearButton = clearable && combobox.selectedItem;
 	const hasButtons = showDropdownTrigger || showClearButton;
 	const hasBothButtons = showDropdownTrigger && showClearButton;
+	const isIos = useIsIos();
 
 	validateMaxWidth('ComboBox', maxWidthProp);
 
@@ -111,6 +114,15 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	});
 
 	const { id: labelId } = combobox.getLabelProps();
+
+	const handleOnBlur = (event: FocusEvent<HTMLInputElement>) => {
+		// If a user presses the Done button on the iOS keyboard, we shouldn't close the keyboard
+		if (isIos && !event.nativeEvent?.relatedTarget) {
+			// @ts-expect-error: Property 'preventDownshiftDefault' does not exist on type 'FocusEvent'
+			event.nativeEvent.preventDownshiftDefault = true;
+		}
+		onBlur?.(event);
+	};
 
 	return (
 		<Field
@@ -152,7 +164,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 							ref: inputRefProp,
 							type: 'text',
 							name: inputName,
-							onBlur,
+							onBlur: handleOnBlur,
 							onFocus,
 						})}
 					/>

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -116,7 +116,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	const { id: labelId } = combobox.getLabelProps();
 
 	const handleOnBlur = (event: FocusEvent<HTMLInputElement>) => {
-		// If a user presses the Done button on the iOS keyboard, we shouldn't close the keyboard
+		// If a user presses the Done button on the iOS keyboard, we shouldn't close the dropdown
 		if (isIos && !event.nativeEvent?.relatedTarget) {
 			// @ts-expect-error: Property 'preventDownshiftDefault' does not exist on type 'FocusEvent'
 			event.nativeEvent.preventDownshiftDefault = true;

--- a/packages/react/src/combobox/ComboboxBase/ComboboxListItem.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxListItem.tsx
@@ -50,7 +50,7 @@ export const ComboboxListItem = forwardRef<
 			// Required for Android TalkBack to be able to access the list items
 			// See https://issues.chromium.org/issues/40260928
 			// But stops iOS from being able to access them ◔_◔
-			// tabIndex={isIos ? undefined : -1}
+			tabIndex={isIos ? undefined : -1}
 			{...props}
 		>
 			{children}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxListItem.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxListItem.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, HTMLAttributes } from 'react';
 import { boxPalette, mapSpacing, packs, tokens } from '../../core';
+import { useIsIos } from '../utils';
 
 type ComboboxListItemProps = Omit<HTMLAttributes<HTMLLIElement>, 'color'> & {
 	isActiveItem: boolean;
@@ -19,6 +20,7 @@ export const ComboboxListItem = forwardRef<
 	{ children, isActiveItem, isInteractive = true, ...props },
 	ref
 ) {
+	const isIos = useIsIos();
 	return (
 		<li
 			ref={ref}
@@ -45,6 +47,10 @@ export const ComboboxListItem = forwardRef<
 
 				'&:last-of-type': { borderBottom: 'none' },
 			}}
+			// Required for Android TalkBack to be able to access the list items
+			// See https://issues.chromium.org/issues/40260928
+			// But stops iOS from being able to access them ◔_◔
+			// tabIndex={isIos ? undefined : -1}
 			{...props}
 		>
 			{children}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -28,6 +28,7 @@ import {
 	generateHighlightStyles,
 	type ComboboxMaxWidthValues,
 	type DefaultComboboxOption,
+	useIsIos,
 	validateMaxWidth,
 } from '../utils';
 import { ComboboxRenderItem } from '../ComboboxRenderItem';
@@ -104,6 +105,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 	...props
 }: ComboboxMultiBaseProps<Option>) {
 	const inputRef = useRef<HTMLInputElement>(null);
+	const isIos = useIsIos();
 
 	validateMaxWidth('ComboboxMulti', maxWidthProp);
 
@@ -155,6 +157,16 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 		: inputRef;
 
 	const { id: labelId } = combobox.getLabelProps();
+
+	const handleOnBlur = (event: FocusEvent<HTMLInputElement>) => {
+		// If a user presses the Done button on the iOS keyboard, we shouldn't close the keyboard
+		if (isIos && !event.nativeEvent?.relatedTarget) {
+			// @ts-expect-error: Property 'preventDownshiftDefault' does not exist on type 'FocusEvent'
+			event.nativeEvent.preventDownshiftDefault = true;
+		}
+		onBlur?.(event);
+		setInputBlurred();
+	};
 
 	return (
 		<Field
@@ -214,10 +226,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 											onFocus?.(event);
 											setInputFocused();
 										},
-										onBlur: (event: FocusEvent<HTMLInputElement>) => {
-											onBlur?.(event);
-											setInputBlurred();
-										},
+										onBlur: handleOnBlur,
 									})
 								)}
 								css={styles.input}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -159,7 +159,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 	const { id: labelId } = combobox.getLabelProps();
 
 	const handleOnBlur = (event: FocusEvent<HTMLInputElement>) => {
-		// If a user presses the Done button on the iOS keyboard, we shouldn't close the keyboard
+		// If a user presses the Done button on the iOS keyboard, we shouldn't close the dropdown
 		if (isIos && !event.nativeEvent?.relatedTarget) {
 			// @ts-expect-error: Property 'preventDownshiftDefault' does not exist on type 'FocusEvent'
 			event.nativeEvent.preventDownshiftDefault = true;

--- a/packages/react/src/combobox/ComboboxRenderItem.tsx
+++ b/packages/react/src/combobox/ComboboxRenderItem.tsx
@@ -46,7 +46,7 @@ export function ComboboxRenderItem({
 					flexDirection: 'column',
 				}}
 			>
-				<span aria-label={itemLabel}>{renderedLabel}</span>
+				{renderedLabel}
 				{secondaryText ? (
 					isValidElement(secondaryText) ? (
 						secondaryText
@@ -90,6 +90,7 @@ export function ComboboxRenderItem({
 function renderItemLabel(itemLabel: string) {
 	return (
 		<span
+			aria-label={itemLabel}
 			css={{
 				color: 'inherit',
 				fontFamily: tokens.font.body,
@@ -98,7 +99,7 @@ function renderItemLabel(itemLabel: string) {
 			}}
 		>
 			{itemLabel.split('').map((character, index) => (
-				<span data-char={character.toLowerCase()} key={index}>
+				<span data-char={character} key={index}>
 					{character}
 				</span>
 			))}

--- a/packages/react/src/combobox/ComboboxRenderItem.tsx
+++ b/packages/react/src/combobox/ComboboxRenderItem.tsx
@@ -46,7 +46,7 @@ export function ComboboxRenderItem({
 					flexDirection: 'column',
 				}}
 			>
-				<span>{renderedLabel}</span>
+				<span aria-label={itemLabel}>{renderedLabel}</span>
 				{secondaryText ? (
 					isValidElement(secondaryText) ? (
 						secondaryText

--- a/packages/react/src/combobox/utils.test.ts
+++ b/packages/react/src/combobox/utils.test.ts
@@ -45,7 +45,7 @@ describe('generateHighlightStyles', () => {
 
 	test('it returns one selector object for single character inputValue', () => {
 		expect(generateHighlightStyles('a')).toEqual({
-			'[data-char="a"]': {
+			'[data-char="a" i]': {
 				fontWeight: 'bold',
 			},
 		});
@@ -53,22 +53,22 @@ describe('generateHighlightStyles', () => {
 
 	test('it returns has and sibling selector objects for multi character inputValue', () => {
 		expect(generateHighlightStyles('ab')).toEqual({
-			'[data-char="a"] + [data-char="b"]': {
+			'[data-char="a" i] + [data-char="b" i]': {
 				fontWeight: 'bold',
 			},
-			'[data-char="a"]:has(+ [data-char="b"])': {
+			'[data-char="a" i]:has(+ [data-char="b" i])': {
 				fontWeight: 'bold',
 			},
 		});
 
 		expect(generateHighlightStyles('abc')).toEqual({
-			'[data-char="a"] + [data-char="b"] + [data-char="c"]': {
+			'[data-char="a" i] + [data-char="b" i] + [data-char="c" i]': {
 				fontWeight: 'bold',
 			},
-			'[data-char="a"] + [data-char="b"]:has(+ [data-char="c"])': {
+			'[data-char="a" i] + [data-char="b" i]:has(+ [data-char="c" i])': {
 				fontWeight: 'bold',
 			},
-			'[data-char="a"]:has(+ [data-char="b"] + [data-char="c"])': {
+			'[data-char="a" i]:has(+ [data-char="b" i] + [data-char="c" i])': {
 				fontWeight: 'bold',
 			},
 		});

--- a/packages/react/src/combobox/utils.ts
+++ b/packages/react/src/combobox/utils.ts
@@ -95,7 +95,8 @@ export function useIsIos() {
 	const [isIos, setIsIos] = useState(false);
 
 	useEffect(() => {
-		if (CSS.supports('-webkit-tap-highlight-color', 'black')) {
+		// See https://github.com/stowball/Layout-Engine/blob/master/layout.engine.js#L86
+		if (CSS.supports('-webkit-overflow-scrolling', 'auto')) {
 			setIsIos(true);
 		}
 	}, []);

--- a/packages/react/src/combobox/utils.ts
+++ b/packages/react/src/combobox/utils.ts
@@ -1,4 +1,4 @@
-import { type CSSProperties } from 'react';
+import { type CSSProperties, useEffect, useState } from 'react';
 import { useId } from '../core';
 
 export function useComboboxInputId(idProp?: string) {
@@ -89,4 +89,16 @@ export function generateHighlightStyles(
 	});
 
 	return styles;
+}
+
+export function useIsIos() {
+	const [isIos, setIsIos] = useState(false);
+
+	useEffect(() => {
+		if (CSS.supports('-webkit-tap-highlight-color', 'black')) {
+			setIsIos(true);
+		}
+	}, []);
+
+	return isIos;
 }

--- a/packages/react/src/combobox/utils.ts
+++ b/packages/react/src/combobox/utils.ts
@@ -1,4 +1,4 @@
-import { type CSSProperties, useEffect, useState } from 'react';
+import { type CSSProperties, useMemo } from 'react';
 import { useId } from '../core';
 
 export function useComboboxInputId(idProp?: string) {
@@ -92,17 +92,13 @@ export function generateHighlightStyles(
 }
 
 export function useIsIos() {
-	const [isIos, setIsIos] = useState(false);
-
-	useEffect(() => {
-		// See https://github.com/stowball/Layout-Engine/blob/master/layout.engine.js#L86
-		if (
+	const isIos = useMemo(
+		() =>
+			// See https://github.com/stowball/Layout-Engine/blob/master/layout.engine.js#L86
 			CSS.supports('-webkit-appearance', '-apple-pay-button') &&
-			CSS.supports('-webkit-overflow-scrolling', 'auto')
-		) {
-			setIsIos(true);
-		}
-	}, []);
+			CSS.supports('-webkit-overflow-scrolling', 'auto'),
+		[]
+	);
 
 	return isIos;
 }

--- a/packages/react/src/combobox/utils.ts
+++ b/packages/react/src/combobox/utils.ts
@@ -96,7 +96,10 @@ export function useIsIos() {
 
 	useEffect(() => {
 		// See https://github.com/stowball/Layout-Engine/blob/master/layout.engine.js#L86
-		if (CSS.supports('-webkit-overflow-scrolling', 'auto')) {
+		if (
+			CSS.supports('-webkit-appearance', '-apple-pay-button') &&
+			CSS.supports('-webkit-overflow-scrolling', 'auto')
+		) {
 			setIsIos(true);
 		}
 	}, []);

--- a/packages/react/src/combobox/utils.ts
+++ b/packages/react/src/combobox/utils.ts
@@ -65,18 +65,18 @@ export function generateHighlightStyles(
 
 	characters.forEach((_, index) => {
 		// When typing "abc"
-		// This generates things like [data-char="a"] + [data-char="b"] + [data-char="c"]
+		// This generates things like [data-char="a" i] + [data-char="b" i] + [data-char="c" i]
 		// to ensure we select consecutive elements
 		const baseSelector = characters
 			.slice(0, index + 1)
-			.map((char) => `[data-char="${char}"]`)
+			.map((char) => `[data-char="${char}" i]`)
 			.join(' + ');
 
-		// This generates things like [data-char="a"]:has(+ [data-char="b"] + [data-char="c"])
+		// This generates things like [data-char="a" i]:has(+ [data-char="b" i] + [data-char="c" i])
 		// to ensure we select earlier elements whose later siblings match
 		const hasSelector = characters
 			.slice(index + 1)
-			.map((char) => `+ [data-char="${char}"]`)
+			.map((char) => `+ [data-char="${char}" i]`)
 			.join(' ');
 
 		const fullSelector = hasSelector

--- a/packages/react/src/time-picker/__snapshots__/TimePicker.test.tsx.snap
+++ b/packages/react/src/time-picker/__snapshots__/TimePicker.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`TimePicker renders correctly when loading 1`] = `
       >
         <li
           class="css-13t89e4-ComboboxListItem"
+          tabindex="-1"
         >
           <div
             class="css-4cj67k-boxStyles"


### PR DESCRIPTION
The a11y audit and our own testing found:

1. The options were being announced as indivdual letters in iOS VoiceOver.
2. The options weren't reachable at all in Android TalkBack
3. The Done button on the iOS keyboard should not close the dropdown
4. We could further improve perf by using case-insensitive attribute selectors

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1783)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
