### PR TITLE
date-picker, time-input: Remove onBlur validaton. Update error messages

### DIFF
--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -43,10 +43,13 @@ As we do not have any sort of input masking due to accessibility and user experi
 
 In this case, you can use the `onInputChange` prop to keep track of the user’s input. The `value` prop can also be set to a string, which represents the value of the text input.
 
+Due to accessibility concerns with certain screen reader and browser combinations, do not mark the DatePicker as `invalid` `onInputChange()`.
+
 ```jsx live
 () => {
 	// Set the value to a value that the user might think is valid
 	const [value, setValue] = React.useState('31/1o/2020');
+	const [invalid, setInvalid] = React.useState(true);
 
 	const onInputChange = (value) => {
 		console.log('onInputChange', value);
@@ -55,15 +58,9 @@ In this case, you can use the `onInputChange` prop to keep track of the user’s
 
 	const onChange = (date) => {
 		console.log('onChange', date);
+		setInvalid(false);
 		setValue(date);
 	};
-
-	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.
-	const invalid = React.useMemo(() => {
-		if (typeof value === 'undefined' || value == '') return false;
-		if (value instanceof Date && !isNaN(value.getTime())) return false;
-		return true;
-	}, [value]);
 
 	return (
 		<DatePicker
@@ -263,13 +260,6 @@ Date formats are parsed in order from first to last and stops when a valid date 
 		setValue(date);
 	};
 
-	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.
-	const invalid = React.useMemo(() => {
-		if (typeof value === 'undefined' || value == '') return false;
-		if (value instanceof Date && !isNaN(value.getTime())) return false;
-		return true;
-	}, [value]);
-
 	return (
 		<DatePicker
 			label="Select date"
@@ -277,10 +267,6 @@ Date formats are parsed in order from first to last and stops when a valid date 
 			value={value}
 			onChange={onChange}
 			onInputChange={onInputChange}
-			{...(invalid && {
-				invalid: true,
-				message: 'Enter a valid date',
-			})}
 			allowedDateFormats={['dd MM yyyy', 'dd-MM-yyyy']}
 		/>
 	);

--- a/packages/react/src/date-range-picker/docs/overview.mdx
+++ b/packages/react/src/date-range-picker/docs/overview.mdx
@@ -50,6 +50,8 @@ Since we do not have any sort of input masking due to accessibility and user exp
 
 In this case, you can use the `onFromInputChange` and `onToInputChange` props to keep track of the user’s input. The `value.from` and `value.to` props can also be set to a string, which represents the value of the text inputs.
 
+Due to accessibility concerns with certain screen reader and browser combinations, do not mark the DateRangerPicker as `fromInvalid` or `toInvalid` with `onFromInputChange()` and `onToInputChange()` respectively.
+
 ```jsx live
 () => {
 	// Set the value to a value that the user might think is valid
@@ -57,17 +59,7 @@ In this case, you can use the `onFromInputChange` and `onToInputChange` props to
 		from: '30/1o/2020',
 		to: '31/1o/2020',
 	});
-
-	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.
-	// See Single-page form template
-	const isInvalid = React.useCallback((value) => {
-		if (typeof value === 'undefined' || value == '') return false;
-		if (value instanceof Date && !isNaN(value.getTime())) return false;
-		return true;
-	}, []);
-
-	const fromInvalid = isInvalid(value.from);
-	const toInvalid = isInvalid(value.from);
+	const [invalid, setInvalid] = React.useState(true);
 
 	const onFromInputChange = (fromValue) => {
 		console.log('onFromInputChange', fromValue);
@@ -81,6 +73,7 @@ In this case, you can use the `onFromInputChange` and `onToInputChange` props to
 
 	const onChange = (dateRange) => {
 		console.log('onChange', dateRange);
+		setInvalid(false);
 		setValue(dateRange);
 	};
 
@@ -90,9 +83,9 @@ In this case, you can use the `onFromInputChange` and `onToInputChange` props to
 			onChange={onChange}
 			onFromInputChange={onFromInputChange}
 			onToInputChange={onToInputChange}
-			fromInvalid={fromInvalid}
-			toInvalid={toInvalid}
-			message={fromInvalid || toInvalid ? 'Enter a valid date' : undefined}
+			fromInvalid={invalid}
+			toInvalid={invalid}
+			message={invalid ? 'Enter valid start and end dates' : undefined}
 		/>
 	);
 };
@@ -158,7 +151,7 @@ Use the `fromInvalid` and `toInvalid` props to indicate if the user input is inv
 				fromInvalid={true}
 				toInvalid={true}
 				legend="Date period"
-				message="Enter a valid date"
+				message="Enter valid start and end dates"
 			/>
 			<DateRangePicker
 				value={value}
@@ -168,7 +161,7 @@ Use the `fromInvalid` and `toInvalid` props to indicate if the user input is inv
 				fromInvalid={true}
 				toInvalid={false}
 				legend="Date period"
-				message="Enter a valid date"
+				message="Enter a valid start date"
 			/>
 			<DateRangePicker
 				value={value}
@@ -178,7 +171,7 @@ Use the `fromInvalid` and `toInvalid` props to indicate if the user input is inv
 				fromInvalid={false}
 				toInvalid={true}
 				legend="Date period"
-				message="Enter a valid date"
+				message="Enter a valid end date"
 			/>
 		</FormStack>
 	);
@@ -308,17 +301,6 @@ Date formats are parsed in order from first to last and stops when a valid date 
 	// Set the value to a value that the user might think is valid
 	const [value, setValue] = React.useState({ from: '', to: '' });
 
-	// This logic is for documentation purposes only. This should be done with `yup` or `zod`.
-	// See Single-page form template
-	const isInvalid = React.useCallback((value) => {
-		if (typeof value === 'undefined' || value == '') return false;
-		if (value instanceof Date && !isNaN(value.getTime())) return false;
-		return true;
-	}, []);
-
-	const fromInvalid = isInvalid(value.from);
-	const toInvalid = isInvalid(value.from);
-
 	const onFromInputChange = (fromValue) => {
 		console.log('onFromInputChange', fromValue);
 		setValue({ ...value, fromValue });
@@ -340,9 +322,6 @@ Date formats are parsed in order from first to last and stops when a valid date 
 			onChange={onChange}
 			onFromInputChange={onFromInputChange}
 			onToInputChange={onToInputChange}
-			fromInvalid={fromInvalid}
-			toInvalid={toInvalid}
-			message={fromInvalid || toInvalid ? 'Enter a valid date' : undefined}
 			hint="Only short AU formats allowed"
 			allowedDateFormats={['dd MM yyyy', 'dd-MM-yyyy']}
 		/>

--- a/packages/react/src/time-input/docs/overview.mdx
+++ b/packages/react/src/time-input/docs/overview.mdx
@@ -16,11 +16,8 @@ relatedComponents: ['text-input', 'time-picker']
 		setValue(timeValue);
 	};
 
-	const invalid = value && !isValidTime(value.value);
-
 	return (
 		<TimeInput
-			invalid={invalid}
 			label="Time"
 			message="Enter a valid time"
 			onChange={onChange}
@@ -49,16 +46,20 @@ The `onChange` handler provides an object with both a `value` and `formatted` ve
 
 Use the `invalid` prop to indicate if the user input is invalid. The `isValidTime()` function can be used to help identify whether the input is valid.
 
+Due to accessibility concerns with certain screen reader and browser combinations, do not mark the TimeInput as `invalid` `onChange()`.
+
 ```jsx live
 () => {
 	const [value, setValue] = React.useState({ value: '9:66' });
+	const [invalid, setInvalid] = React.useState(true);
 
 	const onChange = (timeValue) => {
 		console.log('onChange', timeValue);
+		if (invalid && isValidTime(timeValue.value)) {
+			setInvalid(false);
+		}
 		setValue(timeValue);
 	};
-
-	const invalid = value && !isValidTime(value.value);
 
 	return (
 		<TimeInput


### PR DESCRIPTION
The a11y audit was not happy with our validation happening onBlur in TimeInput and the DatePickers due to JAWS announcing them immediately.

They also didn't like our "vague" error messages.

While I think removing the validation has made the examples worse, and is against what the spec and JAWS are specifically doing for a reason, I'm doing as I'm told.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1784)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets