### PR TITLE
date-range-picker: Remove date swapping logic. Set from as to

### DIFF
--- a/.changeset/modern-panthers-swim.md
+++ b/.changeset/modern-panthers-swim.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+date-range-picker: Remove date swapping logic and update so if the `to` date is before the `from` date, then `to` becomes the new `from`.

--- a/packages/react/src/date-range-picker/utils.test.ts
+++ b/packages/react/src/date-range-picker/utils.test.ts
@@ -15,7 +15,10 @@ describe('ensureValidDateRange', () => {
 		to: new Date(1999, 0, 0), // `to` is after `from`
 	};
 	test('fixes invalid date ranges', () => {
-		expect(ensureValidDateRange(invalidDateRange)).toEqual(validDateRange);
+		expect(ensureValidDateRange(invalidDateRange)).toEqual({
+			from: validDateRange.from,
+			to: undefined,
+		});
 	});
 });
 

--- a/packages/react/src/date-range-picker/utils.ts
+++ b/packages/react/src/date-range-picker/utils.ts
@@ -10,8 +10,7 @@ import {
 	parseDate,
 } from '../date-picker/utils';
 
-// If the end date is before the start date, swap the end date with the start
-// This prevents the users from typing invalid date ranges
+// If the end date is before the start date, unset the end date and make the start date the end date provided
 export function ensureValidDateRange(dateRange: {
 	from: Date | undefined;
 	to: Date | undefined;
@@ -19,7 +18,7 @@ export function ensureValidDateRange(dateRange: {
 	const { to, from } = dateRange;
 
 	if (from && to && isBefore(to, from)) {
-		return { from: to, to: from };
+		return { from: to, to: undefined };
 	}
 
 	return dateRange;


### PR DESCRIPTION
Our users (and ourselves) were puzzled when we swapped dates if you picked an end (`to`) date that was earlier than the start (`from`) date.

This PR removes that swapping logic and instead sets `from` to the `to` value, and unsets `to`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1785)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
