### PR TITLE
page-alert: Make title default to H2 instead of H3. Add focus docs

### DIFF
--- a/.changeset/quiet-chairs-lick.md
+++ b/.changeset/quiet-chairs-lick.md
@@ -1,0 +1,8 @@
+---
+'@ag.ds-next/react': minor
+'@ag.ds-next/example-site': minor
+'@ag.ds-next/yourgov': minor
+'@ag.ds-next/docs': minor
+---
+
+page-alert: Make title default to H2 instead of H3.

--- a/docs/content/templates/multi-page-form/MultiPageFormSuccess.tsx
+++ b/docs/content/templates/multi-page-form/MultiPageFormSuccess.tsx
@@ -42,11 +42,7 @@ export function MultiPageFormSuccess() {
 							ref={successPageAlertRef}
 							tabIndex={-1}
 							tone="success"
-							title={
-								<PageAlertTitle as="h2">
-									Descriptive success message (H2)
-								</PageAlertTitle>
-							}
+							title="Descriptive success message (H2)"
 						>
 							<Text as="p">Supporting paragraph for the success message</Text>
 							<Text as="p" fontWeight="bold">

--- a/docs/content/templates/single-page-form/SinglePageFormSuccess.tsx
+++ b/docs/content/templates/single-page-form/SinglePageFormSuccess.tsx
@@ -35,11 +35,7 @@ export function SinglePageFormSuccess() {
 							ref={successPageAlertRef}
 							tabIndex={-1}
 							tone="success"
-							title={
-								<PageAlertTitle as="h2">
-									Descriptive success message (H2)
-								</PageAlertTitle>
-							}
+							title="Descriptive success message (H2)"
 						>
 							<Text as="p">Supporting paragraph for the success message</Text>
 							<Text as="p" fontWeight="bold">

--- a/docs/content/templates/single-page-form/index.mdx
+++ b/docs/content/templates/single-page-form/index.mdx
@@ -89,9 +89,7 @@ When a form is successfully completed, return the user to the entry point of the
 <PageAlert
 	tabIndex={-1}
 	tone="success"
-	title={
-		<PageAlertTitle as="h2">Descriptive success message (H2)</PageAlertTitle>
-	}
+	title="Descriptive success message (H2)"
 >
 	<Text as="p">Supporting paragraph for the success message</Text>
 	<Text as="p" fontWeight="bold">

--- a/example-site/pages/category/subcategory/multi-page-form/success.tsx
+++ b/example-site/pages/category/subcategory/multi-page-form/success.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { Breadcrumbs } from '@ag.ds-next/react/breadcrumbs';
 import { Column, Columns } from '@ag.ds-next/react/columns';
-import { PageAlert, PageAlertTitle } from '@ag.ds-next/react/page-alert';
+import { PageAlert } from '@ag.ds-next/react/page-alert';
 import { PageContent } from '@ag.ds-next/react/content';
 import { Prose } from '@ag.ds-next/react/prose';
 import { Text } from '@ag.ds-next/react/text';
@@ -49,11 +49,7 @@ export default function FormMultiPageFormPage() {
 									ref={successPageAlertRef}
 									tabIndex={-1}
 									tone="success"
-									title={
-										<PageAlertTitle as="h2">
-											Descriptive success message (H2)
-										</PageAlertTitle>
-									}
+									title="Descriptive success message (H2)"
 								>
 									<Text as="p">
 										Supporting paragraph for the success message

--- a/example-site/pages/category/subcategory/single-page-form-success.tsx
+++ b/example-site/pages/category/subcategory/single-page-form-success.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@ag.ds-next/react/stack';
 import { Breadcrumbs } from '@ag.ds-next/react/breadcrumbs';
 import { PageContent } from '@ag.ds-next/react/content';
 import { Columns, Column } from '@ag.ds-next/react/columns';
-import { PageAlert, PageAlertTitle } from '@ag.ds-next/react/page-alert';
+import { PageAlert } from '@ag.ds-next/react/page-alert';
 import { Prose } from '@ag.ds-next/react/prose';
 import { Text } from '@ag.ds-next/react/text';
 import { PageTitle } from '../../../components/PageTitle';
@@ -46,11 +46,7 @@ export default function SinglePageFormSuccessPage() {
 									ref={successPageAlertRef}
 									tabIndex={-1}
 									tone="success"
-									title={
-										<PageAlertTitle as="h2">
-											Descriptive success message (H2)
-										</PageAlertTitle>
-									}
+									title="Descriptive success message (H2)"
 								>
 									<Text as="p">
 										Supporting paragraph for the success message

--- a/packages/react/src/badge/docs/overview.mdx
+++ b/packages/react/src/badge/docs/overview.mdx
@@ -5,12 +5,7 @@ group: Content
 deprecated: true
 ---
 
-<PageAlert
-	tone="info"
-	title={
-		<PageAlertTitle as="h2">This component has been renamed</PageAlertTitle>
-	}
->
+<PageAlert tone="info" title="This component has been renamed">
 	<Text as="p">
 		{'Badge has been split into separate three components: '}
 		<TextLink href="/components/indicator-dot">{'Indicator dot'}</TextLink>

--- a/packages/react/src/control-input/docs/overview.mdx
+++ b/packages/react/src/control-input/docs/overview.mdx
@@ -5,12 +5,7 @@ group: Forms
 deprecated: true
 ---
 
-<PageAlert
-	tone="info"
-	title={
-		<PageAlertTitle as="h2">This component has been renamed</PageAlertTitle>
-	}
->
+<PageAlert tone="info" title="This component has been renamed">
 	<Text as="p">
 		{'Control input has been split into separate three components: '}
 		<TextLink href="/components/checkbox">{'Checkbox'}</TextLink>

--- a/packages/react/src/filter-drawer/docs/overview.mdx
+++ b/packages/react/src/filter-drawer/docs/overview.mdx
@@ -5,12 +5,7 @@ group: Layout
 deprecated: true
 ---
 
-<PageAlert
-	tone="info"
-	title={
-		<PageAlertTitle as="h2">This component has been renamed</PageAlertTitle>
-	}
->
+<PageAlert tone="info" title="This component has been renamed">
 	<Text as="p">
 		{'Filter drawer has been renamed to '}
 		<TextLink href="/components/drawer">{'Drawer'}</TextLink>

--- a/packages/react/src/global-alert/docs/overview.mdx
+++ b/packages/react/src/global-alert/docs/overview.mdx
@@ -42,6 +42,8 @@ Global alerts can be dismissed by a user if they have understood the message and
 
 Use the `onClose` prop to make the alert dismissable. Ensure Global alerts that are closed by the user are never seen again. You could do this through a feature flag in a database, or by setting a value in the browser.
 
+When a user dismisses an alert, it’s important to manage their focus appropriately to help them continue their task or journey. In some cases, there may not be an obvious (or any) element to send focus to, such as when the alert was triggered by an action on a previous page or from a drawer that is now closed. Always carefully consider the context and previous user actions before moving their focus to ensure a smooth and accessible experience.
+
 ```jsx live
 <GlobalAlert title="Alert title" onClose={console.log}>
 	<Text as="p">

--- a/packages/react/src/page-alert/PageAlert.stories.tsx
+++ b/packages/react/src/page-alert/PageAlert.stories.tsx
@@ -59,7 +59,7 @@ export const WithTitleElement: Story = {
 	args: {
 		tone: 'success',
 		title: (
-			<PageAlertTitle as="h2">Descriptive success message (H2)</PageAlertTitle>
+			<PageAlertTitle as="h3">Descriptive success message (H3)</PageAlertTitle>
 		),
 	},
 };
@@ -115,7 +115,7 @@ export const WithCloseAndChildTitle: Story = {
 	),
 	args: {
 		tone: 'success',
-		title: <PageAlertTitle as="h2">Page Alert title as H2</PageAlertTitle>,
+		title: <PageAlertTitle as="h3">Page Alert title as H3</PageAlertTitle>,
 		onClose: () => console.log('Closed'),
 	},
 };

--- a/packages/react/src/page-alert/PageAlert.test.tsx
+++ b/packages/react/src/page-alert/PageAlert.test.tsx
@@ -74,11 +74,11 @@ describe('PageAlert', () => {
 	it('can render a different heading level', () => {
 		renderPageAlert({
 			tone: 'info',
-			title: <PageAlertTitle as="h2">Title</PageAlertTitle>,
+			title: <PageAlertTitle as="h3">Title</PageAlertTitle>,
 		});
 		const el = screen.getByText('Title');
 		expect(el).toBeInTheDocument();
-		expect(el.tagName).toBe('H2');
+		expect(el.tagName).toBe('H3');
 	});
 
 	describe('with a close button', () => {

--- a/packages/react/src/page-alert/PageAlertTitle.tsx
+++ b/packages/react/src/page-alert/PageAlertTitle.tsx
@@ -10,7 +10,7 @@ export type PageAlertTitleProps = PropsWithChildren<{
 }>;
 
 export const PageAlertTitle = ({
-	as = 'h3',
+	as = 'h2',
 	children,
 	hasDismissButton,
 	hasCloseButton,

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -34,11 +34,11 @@ exports[`PageAlert tone: error renders correctly 1`] = `
       <div
         class="css-g6k1ma-boxStyles"
       >
-        <h3
+        <h2
           class="css-1at50fi-boxStyles-PageAlertTitle"
         >
           There is a problem
-        </h3>
+        </h2>
         <ul
           class="css-1qfj7jm-UnorderedList"
         >
@@ -93,11 +93,11 @@ exports[`PageAlert tone: info renders correctly 1`] = `
       <div
         class="css-g6k1ma-boxStyles"
       >
-        <h3
+        <h2
           class="css-1at50fi-boxStyles-PageAlertTitle"
         >
           Notice
-        </h3>
+        </h2>
         <p
           class="css-dbscsh-boxStyles"
         >
@@ -143,11 +143,11 @@ exports[`PageAlert tone: success renders correctly 1`] = `
       <div
         class="css-g6k1ma-boxStyles"
       >
-        <h3
+        <h2
           class="css-1at50fi-boxStyles-PageAlertTitle"
         >
           Submission successful
-        </h3>
+        </h2>
         <p
           class="css-dbscsh-boxStyles"
         >
@@ -193,11 +193,11 @@ exports[`PageAlert tone: warning renders correctly 1`] = `
       <div
         class="css-g6k1ma-boxStyles"
       >
-        <h3
+        <h2
           class="css-1at50fi-boxStyles-PageAlertTitle"
         >
           Browser out of date
-        </h3>
+        </h2>
         <p
           class="css-dbscsh-boxStyles"
         >
@@ -243,11 +243,11 @@ exports[`PageAlert with a close button renders correctly 1`] = `
       <div
         class="css-g6k1ma-boxStyles"
       >
-        <h3
+        <h2
           class="css-16u1tz7-boxStyles-PageAlertTitle"
         >
           PageAlert with close button
-        </h3>
+        </h2>
         <p
           class="css-dbscsh-boxStyles"
         >

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -231,7 +231,7 @@ Press the "Focus the alert" button below to set focus on the alert. To achieve t
 
 ## Customising the title
 
-By default, `PageAlert` render its title as an `h2`. However, should the need arise, you can change the title’s semantic tag to an `h3`, for example, by passing the `PageAlertTitle` component to the `title` prop.
+By default, `PageAlert` renders its title as an `h2`. However, should the need arise, you can change the title’s semantic tag to an `h3`, for example, by passing the `PageAlertTitle` component to the `title` prop.
 
 ```jsx
 import { PageAlertTitle } from '@ag.ds-next/react/page-alert';

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -84,26 +84,13 @@ Use warning page alerts (orange) to tell the user how to avoid a problem. Only u
 </PageAlert>
 ```
 
-## Title
-
-By default, `PageAlert` renders `PageAlertTitle` as an `h3`. If you need to change the title’s semantic tag to an `h2`, for instance, you can use the `PageAlertTitle` component in the `title` prop to explicitly set it.
-
-```jsx
-import { PageAlertTitle } from '@ag.ds-next/react/page-alert';
-
-<PageAlert
-	tone="success"
-	title={<PageAlertTitle as="h2">Submission successful</PageAlertTitle>}
->
-	<Text as="p">Your application has been successfully submitted.</Text>
-</PageAlert>;
-```
-
 ## Dismissable
 
 Page alerts can be dismissed by a user if they have understood the message and no longer need to see it.
 
 Use the `onClose` prop to make the alert dismissable. Ensure Page alerts that are closed by the user are never seen again. You could do this through a feature flag in a database, or by setting a value in the browser.
+
+When a user dismisses an alert, it’s important to manage their focus appropriately to help them continue their task or journey. In some cases, there may not be an obvious (or any) element to send focus to, such as when the alert was triggered by an action on a previous page or from a drawer that is now closed. Always carefully consider the context and previous user actions before moving their focus to ensure a smooth and accessible experience.
 
 ```jsx live
 <PageAlert tone="info" title="New update" onClose={console.log}>
@@ -240,4 +227,19 @@ Press the "Focus the alert" button below to set focus on the alert. To achieve t
 		</Stack>
 	);
 };
+```
+
+## Customising the title
+
+By default, `PageAlert` render its title as an `h2`. However, should the need arise, you can change the title’s semantic tag to an `h3`, for example, by passing the `PageAlertTitle` component to the `title` prop.
+
+```jsx
+import { PageAlertTitle } from '@ag.ds-next/react/page-alert';
+
+<PageAlert
+	tone="success"
+	title={<PageAlertTitle as="h3">Submission successful (H3)</PageAlertTitle>}
+>
+	<Text as="p">Your application has been successfully submitted.</Text>
+</PageAlert>;
 ```

--- a/packages/react/src/section-alert/docs/overview.mdx
+++ b/packages/react/src/section-alert/docs/overview.mdx
@@ -65,14 +65,28 @@ Use warning section alerts (orange) to tell the user something urgent. Only use 
 <SectionAlert title="A warning message for this section" tone="warning" />
 ```
 
-## Composition
-
-Section alerts are composed of an icon, heading, description, action and close action.
-
-The icon and heading are mandatory and achieve a compact alert, but we encourage the use of description when more information might be helpful to the user.
+## Dismissable
 
 Section alerts can be dismissed by a user if they have understood the message and no longer need to see it. Only use the close action when the alert does not impact the user’s available actions.
 Avoid dismissing error messages which block the user from completing a task. Instead, provide a way for the user to fix the error, then dismiss the alert once the error has been resolved.
+
+Use the `onClose` prop to make the alert dismissable.
+
+When a user dismisses an alert, it’s important to manage their focus appropriately to help them continue their task or journey. In some cases, there may not be an obvious (or any) element to send focus to, such as when the alert was triggered by an action on a previous page or from a drawer that is now closed. Always carefully consider the context and previous user actions before moving their focus to ensure a smooth and accessible experience.
+
+```jsx live
+<SectionAlert
+	title="Section alert title"
+	tone="success"
+	onClose={console.log}
+/>
+```
+
+## Composition
+
+Section alerts are composed of an icon, title, description, action and close action.
+
+The icon and title are mandatory and achieve a compact alert, but we encourage the use of description when additional information might be helpful to the user.
 
 ```jsx live
 <Stack gap={1}>
@@ -90,8 +104,8 @@ Avoid dismissing error messages which block the user from completing a task. Ins
 		<Stack gap={0.5} alignItems="flex-start">
 			<Text as="p">Description</Text>
 			<ButtonGroup>
-				<Button variant="text">Action</Button>
-				<Button variant="text">Action</Button>
+				<Button variant="text">Action 1</Button>
+				<Button variant="text">Action 2</Button>
 			</ButtonGroup>
 		</Stack>
 	</SectionAlert>

--- a/yourgov/components/FormMobileFoodVendorPermit/FormTask1Step3.tsx
+++ b/yourgov/components/FormMobileFoodVendorPermit/FormTask1Step3.tsx
@@ -9,7 +9,7 @@ import { FormStack } from '@ag.ds-next/react/form-stack';
 import { Select } from '@ag.ds-next/react/select';
 import { TextInput } from '@ag.ds-next/react/text-input';
 import { TextLink } from '@ag.ds-next/react/text-link';
-import { PageAlert, PageAlertTitle } from '@ag.ds-next/react/page-alert';
+import { PageAlert } from '@ag.ds-next/react/page-alert';
 import { useScrollToField } from '@ag.ds-next/react/field';
 import { Text } from '@ag.ds-next/react/text';
 import { FormRequiredFieldsMessage } from '../FormRequiredFieldsMessage';
@@ -93,7 +93,7 @@ export function FormTask1Step3() {
 						ref={errorRef}
 						tabIndex={-1}
 						tone="error"
-						title={<PageAlertTitle as="h2">There is a problem</PageAlertTitle>}
+						title="There is a problem"
 					>
 						<Text as="p">
 							Please correct the following fields and try again

--- a/yourgov/components/FormMobileFoodVendorPermit/FormTask1Step5.tsx
+++ b/yourgov/components/FormMobileFoodVendorPermit/FormTask1Step5.tsx
@@ -6,7 +6,7 @@ import { TextLink } from '@ag.ds-next/react/text-link';
 import { UnorderedList, ListItem } from '@ag.ds-next/react/list';
 import { Stack } from '@ag.ds-next/react/stack';
 import { FormStack } from '@ag.ds-next/react/form-stack';
-import { PageAlert, PageAlertTitle } from '@ag.ds-next/react/page-alert';
+import { PageAlert } from '@ag.ds-next/react/page-alert';
 import { TextInput } from '@ag.ds-next/react/text-input';
 import { useScrollToField } from '@ag.ds-next/react/field';
 import { DateRangePicker } from '@ag.ds-next/react/date-range-picker';
@@ -102,9 +102,7 @@ export function FormTask1Step5() {
 						<PageAlert
 							ref={errorRef}
 							tone="error"
-							title={
-								<PageAlertTitle as="h2">There is a problem</PageAlertTitle>
-							}
+							title="There is a problem"
 							tabIndex={-1}
 						>
 							<Text as="p">


### PR DESCRIPTION
The a11y audit highlighted that PageAlert should be used after the H1, but it's heading by default was an H2. This PR updates that so we only need to use the simple `title` throughout.

They also told us that we need to managed user's focus when all alerts are dismissed, but I questioned that, and they are happy with a paragraph describing the importance of focus management.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1793)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
