### PR TITLE
content: Make uncontrolled checkboxes & radio buttons function

### DIFF
--- a/.changeset/eleven-pugs-search.md
+++ b/.changeset/eleven-pugs-search.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+content: Make uncontrolled checkboxes & radio buttons function.

--- a/docs/content/content/content-styles.mdx
+++ b/docs/content/content/content-styles.mdx
@@ -402,12 +402,12 @@ Use a capital letter on the first word of listed items next to radio buttons or 
 		hint="Select all that apply"
 		block
 	>
-		<Checkbox checked={false}>Meat and/or meat products</Checkbox>
-		<Checkbox checked={false}>Plant and/or plant products</Checkbox>
-		<Checkbox checked={false}>Poultry and/or poultry products</Checkbox>
-		<Checkbox checked={false}>Rabbit and/or rabbit products</Checkbox>
-		<Checkbox checked={false}>Ratite and/or ratite products</Checkbox>
-		<Checkbox checked={false}>Wild game and/or wild game products</Checkbox>
+		<Checkbox>Meat and/or meat products</Checkbox>
+		<Checkbox>Plant and/or plant products</Checkbox>
+		<Checkbox>Poultry and/or poultry products</Checkbox>
+		<Checkbox>Rabbit and/or rabbit products</Checkbox>
+		<Checkbox>Ratite and/or ratite products</Checkbox>
+		<Checkbox>Wild game and/or wild game products</Checkbox>
 	</ControlGroup>
 </Fieldset>
 ```

--- a/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
+++ b/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
@@ -139,9 +139,9 @@ Where guidance is relevant to all users, you can provide concise guidance above 
 	<Text>All fields are required unless marked optional.</Text>
 
 	<ControlGroup label="Label 1" hint="Hint text" block>
-		<Radio checked={false}>Phone</Radio>
-		<Radio checked={false}>Tablet</Radio>
-		<Radio checked={true}>Laptop</Radio>
+		<Radio>Phone</Radio>
+		<Radio>Tablet</Radio>
+		<Radio>Laptop</Radio>
 	</ControlGroup>
 </Stack>
 ```
@@ -372,33 +372,33 @@ A user must select the checkbox to confirm their consent and continue to move th
 		Select each checkbox to confirm that you understand and agree with the
 		following statements.
 	</Text>
-	<Checkbox checked={false}>
+	<Checkbox>
 		I declare that the information I’ve provided is true and correct.
 	</Checkbox>
-	<Checkbox checked={false}>
+	<Checkbox>
 		I understand that it’s a criminal offence under the Criminal Code Act 1995
 		to knowingly give false or misleading information to a Commonwealth officer
 		exercising powers under Commonwealth law.
 	</Checkbox>
-	<Checkbox checked={false}>
+	<Checkbox>
 		I understand that I may commit an offence or be liable to a civil penalty if
 		I make a false or misleading statement in an application or provide false or
 		misleading information or documents. (See sections 136.1, 137.1 and 137.2 of
 		the Criminal Code Act 1995 and sections 367, 368, 369 of the Export Control
 		Act 2020.)
 	</Checkbox>
-	<Checkbox checked={false}>
+	<Checkbox>
 		I declare that I’ve read and understood the{' '}
 		<TextLinkExternal href="https://exports.agriculture.gov.au/about/privacy">
 			Privacy notice
 		</TextLinkExternal>
 	</Checkbox>
-	<Checkbox checked={false}>
+	<Checkbox>
 		I consent to the collection, use and disclosure of my information to the
 		relevant authorities in the importing country as outlined in the privacy
 		notice.
 	</Checkbox>
-	<Checkbox checked={false}>
+	<Checkbox>
 		I understand that checking these boxes has the same legal status as signing
 		a paper or PDF form.
 	</Checkbox>


### PR DESCRIPTION
The a11y audit complained that we had uncontrolled checkboxes and radio buttons that didn't function because their `checked` prop was hardcoded.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1797)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
