### PR TITLE
docs - patterns: Fix heading hierarchy in Search filters page

### DIFF
--- a/.changeset/blue-shirts-push.md
+++ b/.changeset/blue-shirts-push.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+patterns: Fix heading hierarchy in Search filters page.

--- a/docs/content/patterns/search-filters/index.mdx
+++ b/docs/content/patterns/search-filters/index.mdx
@@ -61,7 +61,7 @@ The dataset should be displayed in a [Table](/components/table) or a list of [Ca
 		<Divider />
 	</Stack>
 	<Stack gap={1}>
-		<H3>25 results</H3>
+		<H2>25 results</H2>
 		{Array.from(Array(5).keys()).map((idx) => (
 			<Card key={idx} shadow clickable>
 				<CardInner>


### PR DESCRIPTION
The a11y audit highlighted that our example should have been using an H2 for the search results heading

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1800)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
