### PR TITLE
pagination: fix focus not returning to correct button when Previous button is added/removed

### DIFF
--- a/.changeset/heavy-sheep-visit.md
+++ b/.changeset/heavy-sheep-visit.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-pagination: Ensure focus is returned to the correct page number button when the previous button is added and removed.
+pagination: Ensure focus is returned to the correct page number button when the Previous button is added and removed.

--- a/.changeset/heavy-sheep-visit.md
+++ b/.changeset/heavy-sheep-visit.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+pagination: Ensure focus is returned to the correct page number button when the previous button is added and removed.

--- a/.storybook/stories/DataFiltering/components/DashboardPagination.tsx
+++ b/.storybook/stories/DataFiltering/components/DashboardPagination.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import {
 	PaginationButtons,
 	generatePaginationRangeText,
-} from '@ag.ds-next/react/pagination';
+} from '../../../../packages/react/src/pagination';
 import { useDataContext, useSortAndFilterContext } from '../lib/contexts';
 
 export const DashboardPagination = () => {
@@ -33,7 +33,7 @@ export const DashboardPagination = () => {
 			itemRangeText,
 			perPage: pagination.perPage,
 		});
-		// We only want to update update the display text once the table data has finished loading, all other deps are ignored here
+		// We only want to update the display text once the table data has finished loading, all other deps are ignored here
 	}, [loading]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	if (!data.length) return null;

--- a/packages/react/src/pagination/Pagination.tsx
+++ b/packages/react/src/pagination/Pagination.tsx
@@ -49,7 +49,7 @@ export function Pagination({
 	return (
 		<PaginationContainer hasRightArea={hasRightArea}>
 			<PaginationItemContainer aria-label={ariaLabel}>
-				{pagination.map((item, idx) => {
+				{pagination.map((item, index) => {
 					switch (item.type) {
 						case 'direction':
 							return (
@@ -62,14 +62,14 @@ export function Pagination({
 						case 'page':
 							return (
 								<PaginationItemPage
-									key={idx}
+									key={item.pageNumber}
 									href={generateHref(item.pageNumber)}
 									pageNumber={item.pageNumber}
 									isActive={item.isActive}
 								/>
 							);
 						case 'separator':
-							return <PaginationItemSeparator key={idx} />;
+							return <PaginationItemSeparator key={`${index}-separator`} />;
 						default:
 							return null;
 					}

--- a/packages/react/src/pagination/PaginationItemPage.tsx
+++ b/packages/react/src/pagination/PaginationItemPage.tsx
@@ -1,5 +1,10 @@
 import { MouseEventHandler } from 'react';
-import { boxPalette, LinkProps, useLinkComponent } from '../core';
+import {
+	boxPalette,
+	forwardRefWithAs,
+	LinkProps,
+	useLinkComponent,
+} from '../core';
 import { Flex } from '../flex';
 import { BaseButton } from '../button';
 import { BUTTON_SIZE_XS, BUTTON_SIZE_SM } from './utils';
@@ -47,11 +52,13 @@ export type PaginationItemPageButtonProps = Pick<LinkProps, 'href'> & {
 	onClick: MouseEventHandler<HTMLButtonElement>;
 };
 
-export function PaginationItemPageButton({
-	pageNumber,
-	onClick,
-	isActive,
-}: PaginationItemPageButtonProps) {
+export const PaginationItemPageButton = forwardRefWithAs<
+	'button',
+	PaginationItemPageButtonProps
+>(function PaginationItemPageButton(
+	{ pageNumber, onClick, isActive },
+	forwardedRef
+) {
 	return (
 		<li>
 			<Flex
@@ -71,9 +78,10 @@ export function PaginationItemPageButton({
 						? { color: boxPalette.foregroundText, textDecoration: 'none' }
 						: undefined
 				}
+				ref={forwardedRef}
 			>
 				{pageNumber}
 			</Flex>
 		</li>
 	);
-}
+});

--- a/packages/react/src/pagination/usePagination.ts
+++ b/packages/react/src/pagination/usePagination.ts
@@ -56,7 +56,7 @@ export function usePagination({
 		});
 	}
 
-	// If the current page is passed page 2, create the '1 ...' elements
+	// If the current page is past page 2, create the '1 ...' elements
 	if (minPage > 1) {
 		elements.push({
 			type: 'page',


### PR DESCRIPTION
Fix the focus issues when the "Previous" button is added/removed. When the "Previous" button is pressed and the component unmounts it we return focus to the `1` button rather than leaving the focus stranded. This is only for the buttons version of Pagination as the links version focus management should be handled by consuming apps.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1804)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets

**Creating new component**

- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Preconstruct entrypoint has been created (run `yarn` in the root of the repo to do this)
- [ ] Changeset file includes a minor
- [ ] Export components for docs site and Playroom (`docs/components/designSystemComponents.tsx`)
- [ ] Add component to Kitchen Sink (`.storybook/stories/KitchenSink.tsx`)
- [ ] Add snippets to Playroom (`docs/playroom/snippets.ts`)
- [ ] Add pictogram to Docs (`docs/components/pictograms/index.tsx`)
