### PR TITLE
pagination/filters: Announce changes to screen readers

### DIFF
--- a/.changeset/rude-cobras-suffer.md
+++ b/.changeset/rude-cobras-suffer.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+pagination: Announce itemRangeText to screen readers.

--- a/.storybook/stories/DataFiltering/ListFiltering.tsx
+++ b/.storybook/stories/DataFiltering/ListFiltering.tsx
@@ -1,3 +1,4 @@
+import { visuallyHiddenStyles } from '../../../packages/react/src/a11y';
 import { Box } from '../../../packages/react/src/box';
 import { tokens } from '../../../packages/react/src/core';
 import { Column, Columns } from '../../../packages/react/src/columns';
@@ -107,6 +108,9 @@ export const ListFiltering = () => {
 						>
 							{tableCaption}
 						</Text>
+						<div role="status" css={visuallyHiddenStyles}>
+							{loading ? 'Loading audits' : ''}
+						</div>
 						<SortBySelect />
 					</Flex>
 					<DataList data={data} loading={loading} />

--- a/.storybook/stories/DataFiltering/components/DataTable.tsx
+++ b/.storybook/stories/DataFiltering/components/DataTable.tsx
@@ -96,6 +96,9 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 						Table column headers with buttons are sortable.
 					</div>
 				) : null}
+				<div role="status" css={visuallyHiddenStyles}>
+					{loading ? 'Loading audits' : ''}
+				</div>
 				<TableWrapper>
 					<Table
 						aria-rowcount={totalItems}

--- a/docs/content/patterns/search-filters/index.mdx
+++ b/docs/content/patterns/search-filters/index.mdx
@@ -61,7 +61,7 @@ The dataset should be displayed in a [Table](/components/table) or a list of [Ca
 		<Divider />
 	</Stack>
 	<Stack gap={1}>
-		<H2>25 results</H2>
+		<H2 role="status">25 results</H2>
 		{Array.from(Array(5).keys()).map((idx) => (
 			<Card key={idx} shadow clickable>
 				<CardInner>

--- a/packages/react/src/pagination/Pagination.tsx
+++ b/packages/react/src/pagination/Pagination.tsx
@@ -1,26 +1,22 @@
 import { Text } from '../text';
 import { usePagination } from './usePagination';
-import { PaginationItemDirection } from './PaginationItemDirection';
-import { PaginationItemSeparator } from './PaginationItemSeparator';
-import { PaginationItemPage } from './PaginationItemPage';
-import { PaginationItemsPerPageSelect } from './PaginationItemsPerPageSelect';
 import {
 	PaginationItemContainer,
 	PaginationContainer,
 	PaginationSecondaryControlContainer,
 } from './PaginationContainer';
+import { PaginationItemDirection } from './PaginationItemDirection';
+import { PaginationItemPage } from './PaginationItemPage';
+import { PaginationItemSeparator } from './PaginationItemSeparator';
+import { PaginationItemsPerPageSelect } from './PaginationItemsPerPageSelect';
 
 export type PaginationProps = {
 	/** Describes the navigation element to assistive technologies. */
 	'aria-label'?: string;
-	/** Function to generate a href for each list item. */
-	generateHref: (pageNumber: number) => string;
 	/** The current page number. */
 	currentPage: number;
-	/** Controls how many list items are shown. */
-	windowLimit?: number;
-	/** The total number of pages. */
-	totalPages: number;
+	/** Function to generate a href for each list item. */
+	generateHref: (pageNumber: number) => string;
 	/** Text to describe the range of items shown. */
 	itemRangeText?: string;
 	/** The selected number of items per page. */
@@ -29,18 +25,22 @@ export type PaginationProps = {
 	itemsPerPageOptions?: number[];
 	/** Callback when the items per page is changed. */
 	onItemsPerPageChange?: (itemsPerPage: number) => void;
+	/** The total number of pages. */
+	totalPages: number;
+	/** Controls how many list items are shown. */
+	windowLimit?: number;
 };
 
 export function Pagination({
 	'aria-label': ariaLabel = 'Pagination',
-	generateHref,
-	windowLimit = 3,
 	currentPage,
-	totalPages,
+	generateHref,
 	itemRangeText,
 	itemsPerPage,
 	itemsPerPageOptions,
 	onItemsPerPageChange,
+	totalPages,
+	windowLimit = 3,
 }: PaginationProps) {
 	const pagination = usePagination({ currentPage, windowLimit, totalPages });
 	const hasRightArea = Boolean(
@@ -75,18 +75,18 @@ export function Pagination({
 					}
 				})}
 			</PaginationItemContainer>
-			{hasRightArea ? (
+			{hasRightArea && (
 				<PaginationSecondaryControlContainer>
-					{itemRangeText ? <Text>{itemRangeText}</Text> : null}
-					{itemsPerPage && onItemsPerPageChange ? (
+					{itemRangeText && <Text role="status">{itemRangeText}</Text>}
+					{itemsPerPage && onItemsPerPageChange && (
 						<PaginationItemsPerPageSelect
 							value={itemsPerPage}
 							options={itemsPerPageOptions}
 							onChange={onItemsPerPageChange}
 						/>
-					) : null}
+					)}
 				</PaginationSecondaryControlContainer>
-			) : null}
+			)}
 		</PaginationContainer>
 	);
 }

--- a/packages/react/src/pagination/PaginationButtons.tsx
+++ b/packages/react/src/pagination/PaginationButtons.tsx
@@ -7,41 +7,41 @@ import {
 	PaginationSecondaryControlContainer,
 } from './PaginationContainer';
 import { PaginationItemDirectionButton } from './PaginationItemDirection';
-import { PaginationItemSeparator } from './PaginationItemSeparator';
 import { PaginationItemPageButton } from './PaginationItemPage';
+import { PaginationItemSeparator } from './PaginationItemSeparator';
 import { PaginationItemsPerPageSelect } from './PaginationItemsPerPageSelect';
 
 export type PaginationButtonsProps = {
 	/** Describes the navigation element to assistive technologies. */
 	'aria-label'?: string;
-	/** Callback for when a list item is pressed. */
-	onChange: (pageNumber: number) => void;
 	/** The current page number. */
 	currentPage: number;
-	/** Controls how many list items are shown. */
-	windowLimit?: number;
-	/** The total number of pages. */
-	totalPages: number;
 	/** Text to describe the range of items shown. */
 	itemRangeText?: string;
 	/** The selected number of items per page. */
 	itemsPerPage?: number;
 	/** The options for the items per page select. */
 	itemsPerPageOptions?: number[];
+	/** Callback for when a list item is pressed. */
+	onChange: (pageNumber: number) => void;
 	/** Callback when the items per page is changed. */
 	onItemsPerPageChange?: (itemsPerPage: number) => void;
+	/** The total number of pages. */
+	totalPages: number;
+	/** Controls how many list items are shown. */
+	windowLimit?: number;
 };
 
 export function PaginationButtons({
 	'aria-label': ariaLabel = 'Pagination',
-	onChange,
 	currentPage,
-	totalPages,
-	windowLimit = 3,
 	itemRangeText,
 	itemsPerPage,
 	itemsPerPageOptions,
+	onChange,
 	onItemsPerPageChange,
+	totalPages,
+	windowLimit = 3,
 }: PaginationButtonsProps) {
 	const [isRemovingPreviousButton, setIsRemovingPreviousButton] =
 		useState(false);
@@ -96,7 +96,7 @@ export function PaginationButtons({
 			</PaginationItemContainer>
 			{hasRightArea && (
 				<PaginationSecondaryControlContainer>
-					{itemRangeText && <Text>{itemRangeText}</Text>}
+					{itemRangeText && <Text role="status">{itemRangeText}</Text>}
 					{itemsPerPage && onItemsPerPageChange && (
 						<PaginationItemsPerPageSelect
 							value={itemsPerPage}

--- a/packages/react/src/pagination/utils.test.ts
+++ b/packages/react/src/pagination/utils.test.ts
@@ -8,7 +8,7 @@ describe('generatePaginationRangeText', () => {
 				itemsPerPage: 10,
 				currentPage: 1,
 			})
-		).toEqual('1 - 10 of 50 items');
+		).toEqual('1 – 10 of 50 items');
 
 		expect(
 			generatePaginationRangeText({
@@ -16,7 +16,7 @@ describe('generatePaginationRangeText', () => {
 				itemsPerPage: 10,
 				currentPage: 2,
 			})
-		).toEqual('11 - 20 of 50 items');
+		).toEqual('11 – 20 of 50 items');
 
 		expect(
 			generatePaginationRangeText({
@@ -24,7 +24,7 @@ describe('generatePaginationRangeText', () => {
 				itemsPerPage: 10,
 				currentPage: 1,
 			})
-		).toEqual('1 - 1 of 1 item');
+		).toEqual('1 – 1 of 1 item');
 	});
 
 	test('handles last page correctly', () => {
@@ -34,7 +34,7 @@ describe('generatePaginationRangeText', () => {
 				itemsPerPage: 10,
 				currentPage: 5,
 			})
-		).toEqual('41 - 45 of 45 items');
+		).toEqual('41 – 45 of 45 items');
 	});
 
 	test('handles singular items correctly ', () => {
@@ -44,7 +44,7 @@ describe('generatePaginationRangeText', () => {
 				itemsPerPage: 10,
 				currentPage: 1,
 			})
-		).toEqual('1 - 1 of 1 item');
+		).toEqual('1 – 1 of 1 item');
 
 		expect(
 			generatePaginationRangeText({
@@ -54,7 +54,7 @@ describe('generatePaginationRangeText', () => {
 				singularNoun: 'audit',
 				pluralNoun: 'audits',
 			})
-		).toEqual('1 - 1 of 1 audit');
+		).toEqual('1 – 1 of 1 audit');
 	});
 
 	test('handles alternative nouns correctly', () => {
@@ -66,7 +66,7 @@ describe('generatePaginationRangeText', () => {
 				singularNoun: 'audit',
 				pluralNoun: 'audits',
 			})
-		).toEqual('1 - 10 of 50 audits');
+		).toEqual('1 – 10 of 50 audits');
 
 		expect(
 			generatePaginationRangeText({
@@ -76,6 +76,6 @@ describe('generatePaginationRangeText', () => {
 				singularNoun: 'audit',
 				pluralNoun: 'audits',
 			})
-		).toEqual('1 - 1 of 1 audit');
+		).toEqual('1 – 1 of 1 audit');
 	});
 });

--- a/packages/react/src/pagination/utils.ts
+++ b/packages/react/src/pagination/utils.ts
@@ -31,5 +31,5 @@ export function generatePaginationRangeText({
 		totalItems
 	);
 
-	return `${firstItem} - ${lastItem} of ${totalItems} ${noun}`;
+	return `${firstItem} – ${lastItem} of ${totalItems} ${noun}`;
 }


### PR DESCRIPTION
The a11y audit highlighted that we weren't announcing changes from filters etc.

This PR:

1. Announces pangination's `itemRangeText` to screen readers.
2. Also announces "Audits loading" text for storybook examples
3. Updates the search filter pattern to use `role="status"` on the heading since it has no `itemRangeText`

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1809)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets