### PR TITLE
callout: Add title section with link to semantic headings

### DIFF
--- a/.changeset/good-penguins-breathe.md
+++ b/.changeset/good-penguins-breathe.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+callout: Add title section with link to semantic headings.

--- a/packages/react/src/callout/docs/overview.mdx
+++ b/packages/react/src/callout/docs/overview.mdx
@@ -107,8 +107,8 @@ import { CalloutTitle } from '@ag.ds-next/react/callout';
 <Callout
 	tone="info"
 	variant="feature"
-	title={<CalloutTitle as="h3">Submission successful</CalloutTitle>}
+	title={<CalloutTitle as="h3">Callout heading</CalloutTitle>}
 >
-	<Text as="p">Your application has been successfully submitted.</Text>
+	<Text as="p">Description of the callout.</Text>
 </Callout>;
 ```

--- a/packages/react/src/callout/docs/overview.mdx
+++ b/packages/react/src/callout/docs/overview.mdx
@@ -97,7 +97,7 @@ The feature variant of the callout can be used to draw even more emphasis to the
 </Callout>
 ```
 
-## Title
+## Customising the title
 
 By default, `Callout` renders `CalloutTitle` as an `h2`. If you need to change the title’s semantic tag to an `h3`, for instance, you can use the `CalloutTitle` component in the `title` prop to explicitly set it. For information on maintaining proper heading levels refer to [Structuring headings and labels](/content/content-structure#structuring-headings-and-labels).
 

--- a/packages/react/src/callout/docs/overview.mdx
+++ b/packages/react/src/callout/docs/overview.mdx
@@ -96,3 +96,19 @@ The feature variant of the callout can be used to draw even more emphasis to the
 	<Text as="p">Description of the callout.</Text>
 </Callout>
 ```
+
+## Title
+
+By default, `Callout` renders `CalloutTitle` as an `h2`. If you need to change the title’s semantic tag to an `h3`, for instance, you can use the `CalloutTitle` component in the `title` prop to explicitly set it. For information on maintaining proper heading levels refer to [Structuring headings and labels](/content/content-structure#structuring-headings-and-labels).
+
+```jsx
+import { CalloutTitle } from '@ag.ds-next/react/callout';
+
+<Callout
+	tone="info"
+	variant="feature"
+	title={<CalloutTitle as="h3">Submission successful</CalloutTitle>}
+>
+	<Text as="p">Your application has been successfully submitted.</Text>
+</Callout>;
+```

--- a/packages/react/src/callout/docs/overview.mdx
+++ b/packages/react/src/callout/docs/overview.mdx
@@ -99,7 +99,7 @@ The feature variant of the callout can be used to draw even more emphasis to the
 
 ## Customising the title
 
-By default, `Callout` renders `CalloutTitle` as an `h2`. If you need to change the title’s semantic tag to an `h3`, for instance, you can use the `CalloutTitle` component in the `title` prop to explicitly set it. For information on maintaining proper heading levels refer to [Structuring headings and labels](/content/content-structure#structuring-headings-and-labels).
+By default, `Callout` renders its title as an `h2`. However, should the need arise, you can change the title’s semantic tag to an `h3`, for example, by passing the `CalloutTitle` component to the `title` prop. For information on maintaining proper heading levels, refer to [Structuring headings and labels](/content/content-structure#structuring-headings-and-labels).
 
 ```jsx
 import { CalloutTitle } from '@ag.ds-next/react/callout';


### PR DESCRIPTION
Add the title section to Callout

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1811)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
