### PR TITLE
search-input: Improve guidance/examples to include a search landmark

### DIFF
--- a/.changeset/tall-toys-kneel.md
+++ b/.changeset/tall-toys-kneel.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/react': minor
+'@ag.ds-next/docs': minor
+---
+
+search-input: Improve guidance/examples to include a search landmark.

--- a/.storybook/stories/DataFiltering/components/FilterSearchInput.tsx
+++ b/.storybook/stories/DataFiltering/components/FilterSearchInput.tsx
@@ -6,19 +6,21 @@ export const FilterSearchInput = ({ block }: { block?: boolean }) => {
 	const { filters, setFilter } = useSortAndFilterContext();
 
 	return (
-		<SearchInput
-			label="Search Business name"
-			aria-controls={tableId}
-			maxWidth="lg"
-			hideOptionalLabel
-			block={block}
-			value={filters.businessName || ''}
-			onChange={(searchString) => {
-				// TODO debounce
-				setFilter({
-					businessName: searchString,
-				});
-			}}
-		/>
+		<div aria-label="Audits" role="search">
+			<SearchInput
+				label="Search Business name"
+				aria-controls={tableId}
+				maxWidth="lg"
+				hideOptionalLabel
+				block={block}
+				value={filters.businessName || ''}
+				onChange={(searchString) => {
+					// TODO debounce
+					setFilter({
+						businessName: searchString,
+					});
+				}}
+			/>
+		</div>
 	);
 };

--- a/docs/content/patterns/search-filters/index.mdx
+++ b/docs/content/patterns/search-filters/index.mdx
@@ -26,7 +26,9 @@ The dataset should be displayed in a [Table](/components/table) or a list of [Ca
 				gap={1}
 				alignItems={['flex-start', 'flex-end']}
 			>
-				<SearchInput label="Search" hideOptionalLabel />
+				<div aria-label="Site" role="search">
+					<SearchInput label="Search" hideOptionalLabel />
+				</div>
 				<Button variant="secondary" iconAfter={FilterIcon}>
 					Show filters
 				</Button>
@@ -61,7 +63,9 @@ The dataset should be displayed in a [Table](/components/table) or a list of [Ca
 		<Divider />
 	</Stack>
 	<Stack gap={1}>
-		<H2 role="status">25 results</H2>
+		<H2>
+			<span role="status">25 results</span>
+		</H2>
 		{Array.from(Array(5).keys()).map((idx) => (
 			<Card key={idx} shadow clickable>
 				<CardInner>

--- a/packages/react/src/search-input/docs/overview.mdx
+++ b/packages/react/src/search-input/docs/overview.mdx
@@ -23,7 +23,7 @@ By default, the `SearchInput` component does not expand to fill the available sp
 
 - use to filter results on a page
 - provide a meaningful label – for example, Search components
-- wrap it in appropriately labelled `role="search"` landmark
+- wrap in an appropriately labelled `role="search"` landmark
 - hide the ‘optional’ label.
 
 <DontHeading />

--- a/packages/react/src/search-input/docs/overview.mdx
+++ b/packages/react/src/search-input/docs/overview.mdx
@@ -8,7 +8,9 @@ relatedComponents: ['search-box']
 ---
 
 ```jsx live
-<SearchInput label="Search" />
+<div aria-label="Site" role="search">
+	<SearchInput label="Search" />
+</div>
 ```
 
 The `SearchInput` component can be used as a filter to aid the user in finding content that has already been loaded on the page.
@@ -21,6 +23,7 @@ By default, the `SearchInput` component does not expand to fill the available sp
 
 - use to filter results on a page
 - provide a meaningful label – for example, Search components
+- wrap it in appropriately labelled `role="search"` landmark
 - hide the ‘optional’ label.
 
 <DontHeading />


### PR DESCRIPTION
The a11y audit recommended that we wrap search inputs in a landmark

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1812)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
