### PR TITLE
tags: focus management of removed tags. Improve docs

### DIFF
--- a/.changeset/loud-suns-notice.md
+++ b/.changeset/loud-suns-notice.md
@@ -1,0 +1,8 @@
+---
+'@ag.ds-next/react': minor
+'@ag.ds-next/docs': minor
+---
+
+tags: Automatically focus previous tag `onRemove`. Add `ref` support.
+
+docs: Export `visuallyHiddenStyles` for use within live code examples.

--- a/docs/components/designSystemComponents.tsx
+++ b/docs/components/designSystemComponents.tsx
@@ -48,7 +48,11 @@ export { FileUpload } from '@ag.ds-next/react/file-upload';
 export { Header } from '@ag.ds-next/react/header';
 export { Heading, H1, H2, H3, H4, H5, H6 } from '@ag.ds-next/react/heading';
 export { Select } from '@ag.ds-next/react/select';
-export { ExternalLinkCallout, VisuallyHidden } from '@ag.ds-next/react/a11y';
+export {
+	ExternalLinkCallout,
+	VisuallyHidden,
+	visuallyHiddenStyles,
+} from '@ag.ds-next/react/a11y';
 export { UnorderedList, OrderedList, ListItem } from '@ag.ds-next/react/list';
 export { Text } from '@ag.ds-next/react/text';
 export { TextLink, TextLinkExternal } from '@ag.ds-next/react/text-link';

--- a/packages/react/src/tags/Tag.tsx
+++ b/packages/react/src/tags/Tag.tsx
@@ -8,9 +8,9 @@ import { BaseButton } from '../button';
 
 export type TagProps = Omit<LinkProps, 'children'> & {
 	children: string;
-	/* A private function to handle the focsusing of in Tags. */
+	/* A private function to handle the focusing of Tags when removed. */
 	focusOnRemove?: (index: number) => void;
-	/* A private number which is passed as arg to focusOnRemove. */
+	/* A private number which is passed as an arg to focusOnRemove. */
 	index?: number;
 	onRemove?: MouseEventHandler<HTMLButtonElement>;
 };

--- a/packages/react/src/tags/Tag.tsx
+++ b/packages/react/src/tags/Tag.tsx
@@ -8,8 +8,10 @@ import { BaseButton } from '../button';
 
 export type TagProps = Omit<LinkProps, 'children'> & {
 	children: string;
-	focusOnRemove: (index: number) => void;
-	index: number;
+	/* A private function to handle the focsusing of in Tags. */
+	focusOnRemove?: (index: number) => void;
+	/* A private number which is passed as arg to focusOnRemove. */
+	index?: number;
 	onRemove?: MouseEventHandler<HTMLButtonElement>;
 };
 
@@ -45,7 +47,9 @@ export const Tag = ({
 					aria-label={`Remove ${children}`}
 					onClick={(event) => {
 						// We call this first so consumers can manage focus separately in their onRemove
-						focusOnRemove(index);
+						if (index && focusOnRemove) {
+							focusOnRemove(index);
+						}
 						onRemove(event);
 					}}
 				/>

--- a/packages/react/src/tags/Tag.tsx
+++ b/packages/react/src/tags/Tag.tsx
@@ -8,10 +8,18 @@ import { BaseButton } from '../button';
 
 export type TagProps = Omit<LinkProps, 'children'> & {
 	children: string;
+	focusOnRemove: (index: number) => void;
+	index: number;
 	onRemove?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export const Tag = ({ children, onRemove, ...props }: TagProps) => {
+export const Tag = ({
+	children,
+	focusOnRemove,
+	index,
+	onRemove,
+	...props
+}: TagProps) => {
 	const { href } = props;
 	return (
 		<Flex
@@ -33,7 +41,14 @@ export const Tag = ({ children, onRemove, ...props }: TagProps) => {
 				{children}
 			</Box>
 			{onRemove && (
-				<TagRemoveButton aria-label={`Remove ${children}`} onClick={onRemove} />
+				<TagRemoveButton
+					aria-label={`Remove ${children}`}
+					onClick={(event) => {
+						// We call this first so consumers can manage focus separately in their onRemove
+						focusOnRemove(index);
+						onRemove(event);
+					}}
+				/>
 			)}
 		</Flex>
 	);

--- a/packages/react/src/tags/Tags.tsx
+++ b/packages/react/src/tags/Tags.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useRef } from 'react';
+import { forwardRef, ReactNode, useRef } from 'react';
 import { Box } from '../box';
+import { mergeRefs } from '../core';
 import { Tag, TagProps } from './Tag';
 import { TagsContainer } from './TagsContainer';
 import { TagsList } from './TagsList';
@@ -9,8 +10,12 @@ export type TagsProps = {
 	items: Omit<TagProps, 'children'> & { label: string }[];
 };
 
-export const Tags = ({ heading, items }: TagsProps) => {
-	const listRef = useRef<HTMLDivElement>(null);
+export const Tags = forwardRef<HTMLDivElement, TagsProps>(function Tags(
+	{ heading, items },
+	forwardedRef
+) {
+	const ref = useRef<HTMLDivElement>(null);
+	const listRef = mergeRefs([ref, forwardedRef]);
 	const focusOnRemove = (index: number) => {
 		const nextButtonToFocus =
 			listRef?.current &&
@@ -31,4 +36,4 @@ export const Tags = ({ heading, items }: TagsProps) => {
 			</TagsList>
 		</TagsContainer>
 	);
-};
+});

--- a/packages/react/src/tags/Tags.tsx
+++ b/packages/react/src/tags/Tags.tsx
@@ -1,7 +1,7 @@
-import { ReactNode } from 'react';
+import { ReactNode, useRef } from 'react';
 import { Box } from '../box';
-import { TagsContainer } from './TagsContainer';
 import { Tag, TagProps } from './Tag';
+import { TagsContainer } from './TagsContainer';
 import { TagsList } from './TagsList';
 
 export type TagsProps = {
@@ -9,15 +9,26 @@ export type TagsProps = {
 	items: Omit<TagProps, 'children'> & { label: string }[];
 };
 
-export const Tags = ({ items, heading }: TagsProps) => (
-	<TagsContainer>
-		{heading}
-		<TagsList>
-			{items.map(({ label, ...props }, index) => (
-				<Box as="li" key={index}>
-					<Tag {...props}>{label}</Tag>
-				</Box>
-			))}
-		</TagsList>
-	</TagsContainer>
-);
+export const Tags = ({ heading, items }: TagsProps) => {
+	const listRef = useRef<HTMLDivElement>(null);
+	const focusOnRemove = (index: number) => {
+		const nextButtonToFocus =
+			listRef?.current &&
+			listRef.current.querySelectorAll('button')[Math.max(0, index - 1)];
+		nextButtonToFocus?.focus();
+	};
+	return (
+		<TagsContainer ref={listRef}>
+			{heading}
+			<TagsList>
+				{items.map(({ label, ...props }, index) => (
+					<Box as="li" key={index}>
+						<Tag {...props} focusOnRemove={focusOnRemove} index={index}>
+							{label}
+						</Tag>
+					</Box>
+				))}
+			</TagsList>
+		</TagsContainer>
+	);
+};

--- a/packages/react/src/tags/Tags.tsx
+++ b/packages/react/src/tags/Tags.tsx
@@ -7,7 +7,7 @@ import { TagsList } from './TagsList';
 
 export type TagsProps = {
 	heading?: ReactNode;
-	items: Omit<TagProps, 'children'> & { label: string }[];
+	items: Omit<TagProps, 'children' | 'focusOnRemove'> & { label: string }[];
 };
 
 export const Tags = forwardRef<HTMLDivElement, TagsProps>(function Tags(
@@ -15,15 +15,15 @@ export const Tags = forwardRef<HTMLDivElement, TagsProps>(function Tags(
 	forwardedRef
 ) {
 	const ref = useRef<HTMLDivElement>(null);
-	const listRef = mergeRefs([ref, forwardedRef]);
 	const focusOnRemove = (index: number) => {
 		const nextButtonToFocus =
-			listRef?.current &&
-			listRef.current.querySelectorAll('button')[Math.max(0, index - 1)];
+			ref?.current &&
+			ref.current.querySelectorAll('button')[Math.max(0, index - 1)];
 		nextButtonToFocus?.focus();
 	};
+
 	return (
-		<TagsContainer ref={listRef}>
+		<TagsContainer ref={mergeRefs([ref, forwardedRef])}>
 			{heading}
 			<TagsList>
 				{items.map(({ label, ...props }, index) => (

--- a/packages/react/src/tags/TagsContainer.tsx
+++ b/packages/react/src/tags/TagsContainer.tsx
@@ -1,8 +1,14 @@
-import type { ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 import { Stack } from '../stack';
 
 export type TagsContainerProps = { children: ReactNode };
 
-export const TagsContainer = ({ children }: TagsContainerProps) => (
-	<Stack gap={0.25}>{children}</Stack>
+export const TagsContainer = forwardRef<HTMLDivElement, TagsContainerProps>(
+	function TagsContainer({ children }, ref) {
+		return (
+			<Stack gap={0.25} ref={ref}>
+				{children}
+			</Stack>
+		);
+	}
 );

--- a/packages/react/src/tags/docs/overview.mdx
+++ b/packages/react/src/tags/docs/overview.mdx
@@ -65,7 +65,7 @@ When a user removes a tag, their focus is automatically moved to the previous ta
 
 Screen reader users need to be informed when a tag has been removed. Depending on the context, this may be done explicitly, like in the example below, or more commonly implicitly by announcing the resultant changes to the page (like in the [Search filter pattern](/patterns/search-filters)).
 
-Avoid using Tags with links and remove buttons together to not confuse users.
+Avoid using Tags with links and Remove buttons together, as this will confuse users.
 
 ```jsx live
 () => {

--- a/packages/react/src/tags/docs/overview.mdx
+++ b/packages/react/src/tags/docs/overview.mdx
@@ -59,11 +59,13 @@ A list of related tags without links.
 
 ## Removable tags
 
-Tags can be removed from a list, if you add an `onRemove` function.
+Tags can be removed from a list when you pass a function to the `onRemove` prop.
 
-Please avoid using Tags with links and remove buttons together, as it is confusing for users.
+When a user removes a tag, their focus is automatically moved to the previous tag in the list. When the last tag is removed, focus is not moved, and, depending on the context, may need to be manually moved in `onRemove` to help the user continue their task.
 
-When a user removes a tag, their focus is automatically moved to the next tag in the list (where appropriate). However it’s important to manage their focus appropriately to help them continue their task or journey. In some cases, there may not be an obvious (or any) element to send focus to, such as when the alert was triggered by an action on a previous page or from a drawer that is now closed. Always carefully consider the context and previous user actions before moving their focus to ensure a smooth and accessible experience.
+Screen reader users need to be informed when a tag has been removed. Depending on the context, this may be done explicitly, like in the example below, or more commonly implicitly by announcing the resultant changes to the page (like in the [Search filter pattern](/patterns/search-filters)).
+
+Avoid using Tags with links and remove buttons together to not confuse users.
 
 ```jsx live
 () => {
@@ -77,7 +79,6 @@ When a user removes a tag, their focus is automatically moved to the next tag in
 	const handleRemove = (label) => {
 		setItems((prevItems) => prevItems.filter((item) => item.label !== label));
 		setAnnouncement(`${label} removed`);
-		// document.getElementById(label).focus();
 	};
 
 	const itemsWithHandlers = items.map((item) => ({
@@ -87,10 +88,7 @@ When a user removes a tag, their focus is automatically moved to the next tag in
 
 	return (
 		<>
-			<button id="Apple">Apple</button>
-			<button id="Orange">Orange</button>
-			<button id="Peach">Peach</button>
-			<Box zcss={visuallyHiddenStyles} role="status">
+			<Box css={visuallyHiddenStyles} role="status">
 				{announcement}
 			</Box>
 			{items.length > 0 ? (

--- a/packages/react/src/tags/docs/overview.mdx
+++ b/packages/react/src/tags/docs/overview.mdx
@@ -59,11 +59,11 @@ A list of related tags without links.
 
 ## Removable tags
 
-Tags can be removed from a list when you pass a function to the `onRemove` prop.
+Tags can be removed from a list by passing a function to the `onRemove` prop.
 
-When a user removes a tag, their focus is automatically moved to the previous tag in the list. When the last tag is removed, focus is not moved, and, depending on the context, may need to be manually moved in `onRemove` to help the user continue their task.
+When a user removes a tag, their focus automatically shifts to the previous tag in the list. If the last tag is removed, focus is lost, and depending on the context, you may need to manually set focus within `onRemove` to help the user continue their task.
 
-Screen reader users need to be informed when a tag has been removed. Depending on the context, this may be done explicitly, like in the example below, or more commonly implicitly by announcing the resultant changes to the page (like in the [Search filter pattern](/patterns/search-filters)).
+For screen reader users, it’s important to provide feedback when a tag is removed; the method of which depends on the context. In the example below, an explicit announcement is made. More commonly, however, the page that the tags affect would announce the resulting changes (e.g., “25 results found”), similar to the approach used in the [Search filter pattern](/patterns/search-filters).
 
 Avoid using Tags with links and Remove buttons together, as this will confuse users.
 

--- a/packages/react/src/tags/docs/overview.mdx
+++ b/packages/react/src/tags/docs/overview.mdx
@@ -63,6 +63,8 @@ Tags can be removed from a list, if you add an `onRemove` function.
 
 Please avoid using Tags with links and remove buttons together, as it is confusing for users.
 
+When a user removes a tag, their focus is automatically moved to the next tag in the list (where appropriate). However it’s important to manage their focus appropriately to help them continue their task or journey. In some cases, there may not be an obvious (or any) element to send focus to, such as when the alert was triggered by an action on a previous page or from a drawer that is now closed. Always carefully consider the context and previous user actions before moving their focus to ensure a smooth and accessible experience.
+
 ```jsx live
 () => {
 	const [items, setItems] = React.useState([
@@ -70,9 +72,12 @@ Please avoid using Tags with links and remove buttons together, as it is confusi
 		{ label: 'Orange' },
 		{ label: 'Peach' },
 	]);
+	const [announcement, setAnnouncement] = React.useState('');
 
 	const handleRemove = (label) => {
 		setItems((prevItems) => prevItems.filter((item) => item.label !== label));
+		setAnnouncement(`${label} removed`);
+		// document.getElementById(label).focus();
 	};
 
 	const itemsWithHandlers = items.map((item) => ({
@@ -80,15 +85,25 @@ Please avoid using Tags with links and remove buttons together, as it is confusi
 		onRemove: () => handleRemove(item.label),
 	}));
 
-	return items.length > 0 ? (
-		<Tags
-			heading={
-				<Text as="h2" fontWeight="bold">
-					Tags:
-				</Text>
-			}
-			items={itemsWithHandlers}
-		/>
-	) : undefined;
+	return (
+		<>
+			<button id="Apple">Apple</button>
+			<button id="Orange">Orange</button>
+			<button id="Peach">Peach</button>
+			<Box zcss={visuallyHiddenStyles} role="status">
+				{announcement}
+			</Box>
+			{items.length > 0 ? (
+				<Tags
+					heading={
+						<Text as="h2" fontWeight="bold">
+							Tags:
+						</Text>
+					}
+					items={itemsWithHandlers}
+				/>
+			) : undefined}
+		</>
+	);
 };
 ```


### PR DESCRIPTION
The a11y audit found that we should manage focus when removing tags.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-[PR_NUMBER])

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
