### PR TITLE
prose: Apply bodyText maxWidth token to lists.

### DIFF
--- a/.changeset/large-bottles-explode.md
+++ b/.changeset/large-bottles-explode.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+prose: Apply `bodyText` `maxWidth` token to lists.

--- a/packages/react/src/prose/Prose.tsx
+++ b/packages/react/src/prose/Prose.tsx
@@ -95,6 +95,7 @@ export const proseClass = css({
 	[`ul${notSelector}, ol${notSelector}`]: {
 		'> li': {
 			marginTop: mapSpacing(0.5),
+			maxWidth: tokens.maxWidth.bodyText,
 
 			[`> ul${notSelector}, > ol${notSelector}`]: {
 				marginTop: mapSpacing(0.5),
@@ -107,6 +108,8 @@ export const proseClass = css({
 	},
 
 	[`dl${notSelector}`]: {
+		maxWidth: tokens.maxWidth.bodyText,
+
 		'> dd': {
 			marginTop: mapSpacing(0.5),
 			paddingLeft: mapSpacing(0.5),


### PR DESCRIPTION
I noticed that Prose restricted paragraphs, but didn't restrict lists. Since markdown doesn't produce paragraphs in list

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1824)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
