### PR TITLE
table: Improve usage guidance in docs

### DIFF
--- a/.changeset/fluffy-beers-roll.md
+++ b/.changeset/fluffy-beers-roll.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+table: Improve usage guidance.

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -106,16 +106,16 @@ For data tables with a small amount of rows, use the default table. Align text c
 <DontHeading />
 
 - repeat information across cells. If each cell has the same content, add it as the column header – for example, Width (cm)
-- nest tables inside tables
 - use if a list, paragraph of text or diagram will work
 - use to summarise form collection data - use a [Summary list](/components/summary-list)
 - add lists, diagrams or images
 - use a combination of actions in table cells and actions in dropdown menus together in the same table row
 - put form inputs in table cells - use an action in a cell to open a drawer or navigate to another page instead
 - have too many rows. Use pagination or start another table where logical – for example, an alphabetical list, Table 1: A to D, Table 2: E to H and so on
-- use bespoke styling - follow consistent layouts and styles
+- use bespoke styling – follow consistent layouts and styles
 - nest tables inside tables
-- use inside an accorion
+- use inside an accordion
+- use empty table headers unless spanning multiple columns and a header isn’t appropriate
 - set a row as invalid without adding a section alert.
 
 ## Striped


### PR DESCRIPTION
The a11y audit wanted changes and fixes to our docs.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1828)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).


**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets

