### PR TITLE
many: Improve appearance & experience for high contrast users

### DIFF
--- a/.changeset/brown-ways-speak.md
+++ b/.changeset/brown-ways-speak.md
@@ -12,6 +12,8 @@ global-alert: Improve appearance and experience for high contrast users.
 
 modal: Improve appearance and experience for high contrast users.
 
+notification-badge: Improve appearance and experience for high contrast users.
+
 progress-indicator: Improve appearance and experience for high contrast users.
 
 radio: Improve appearance and experience for high contrast users.

--- a/.changeset/brown-ways-speak.md
+++ b/.changeset/brown-ways-speak.md
@@ -1,0 +1,21 @@
+---
+'@ag.ds-next/react': minor
+---
+
+button: Improve appearance and experience for high contrast users.
+
+checkbox: Improve appearance and experience for high contrast users.
+
+drawer: Improve appearance and experience for high contrast users.
+
+global-alert: Improve appearance and experience for high contrast users.
+
+modal: Improve appearance and experience for high contrast users.
+
+progress-indicator: Improve appearance and experience for high contrast users.
+
+radio: Improve appearance and experience for high contrast users.
+
+sub-nav: Improve appearance and experience for high contrast users.
+
+tabs: Improve appearance and experience for high contrast users.

--- a/packages/react/src/button/styles.ts
+++ b/packages/react/src/button/styles.ts
@@ -28,6 +28,11 @@ const variants = {
 		color: boxPalette.foregroundAction,
 		textDecoration: 'none',
 
+		// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+		'@media (forced-colors: active)': {
+			borderColor: 'Highlight',
+		},
+
 		'&:not(:disabled):hover': {
 			background: boxPalette.backgroundBody,
 			borderColor: boxPalette.foregroundText,
@@ -40,6 +45,11 @@ const variants = {
 		borderColor: 'transparent',
 		color: boxPalette.foregroundAction,
 		...packs.underline,
+
+		// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+		'@media (forced-colors: active)': {
+			borderColor: 'ButtonFace',
+		},
 
 		'&:not(:disabled):hover': {
 			background: 'transparent',

--- a/packages/react/src/checkbox/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/CheckboxIndicator.tsx
@@ -36,6 +36,11 @@ export const CheckboxIndicator = ({
 					color: boxPalette.borderMuted,
 					borderColor: boxPalette.borderMuted,
 					backgroundColor: boxPalette.backgroundShade,
+					// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+					'@media (forced-colors: active)': {
+						borderColor: 'GrayText',
+						color: 'GrayText',
+					},
 				}),
 
 				...(invalid && {

--- a/packages/react/src/columns/docs/overview.mdx
+++ b/packages/react/src/columns/docs/overview.mdx
@@ -12,12 +12,13 @@ This package includes the components `<Columns />` and `<Column />`.
 The `Columns` component creates a 12 column grid by default. You can use the `cols` prop to specify how many columns are needed. As a general rule, we prefer layouts to have 1 column for mobile and 2 columns for tablet viewports.
 
 ```jsx live
+/* highContrastOutline outline added for demo purposes only */
 <Columns gap={1.5} cols={{ xs: 1, sm: 2, md: 3 }}>
-	<Box background="shadeAlt" padding={1} />
-	<Box background="shadeAlt" padding={1} />
-	<Box background="shadeAlt" padding={1} />
-	<Box background="shadeAlt" padding={1} />
-	<Box background="shadeAlt" padding={1} />
+	<Box background="shadeAlt" highContrastOutline padding={1} />
+	<Box background="shadeAlt" highContrastOutline padding={1} />
+	<Box background="shadeAlt" highContrastOutline padding={1} />
+	<Box background="shadeAlt" highContrastOutline padding={1} />
+	<Box background="shadeAlt" highContrastOutline padding={1} />
 </Columns>
 ```
 
@@ -28,10 +29,11 @@ The `gap` prop effects both the row and column gap. To set a different gap for r
 You can use `Column` to make an item span multiple columns.
 
 ```jsx live
+/* highContrastOutline outline added for demo purposes only */
 <Columns gap={1.5} cols={{ xs: 1, md: 3 }}>
-	<Box background="shadeAlt" padding={1} />
+	<Box background="shadeAlt" highContrastOutline padding={1} />
 	<Column columnSpan={{ xs: 1, md: 2 }}>
-		<Box background="shadeAlt" padding={1} />
+		<Box background="shadeAlt" highContrastOutline padding={1} />
 	</Column>
 </Columns>
 ```
@@ -41,9 +43,10 @@ You can use `Column` to make an item span multiple columns.
 The `columnStart` and `columnEnd` props can be used to determine the Column’s start and end location within the row.
 
 ```jsx live
+/* highContrastOutline outline added for demo purposes only */
 <Columns>
 	<Column columnStart={3} columnEnd={9}>
-		<Box background="shadeAlt" padding={1} />
+		<Box background="shadeAlt" highContrastOutline padding={1} />
 	</Column>
 </Columns>
 ```

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -662,7 +662,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -687,7 +687,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -712,7 +712,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -737,7 +737,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -841,7 +841,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -868,7 +868,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -895,7 +895,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -922,7 +922,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -985,7 +985,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -1010,7 +1010,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -1035,7 +1035,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -1060,7 +1060,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1sqol0e-boxStyles-RadioIndicator"
+                class="css-erbirp-boxStyles-RadioIndicator"
               />
             </span>
             <span

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`DatePicker renders correctly 1`] = `
         />
         <button
           aria-label="Change date, 1st January 2000 Saturday"
-          class="css-1martsc-BaseButton-DateInput"
+          class="css-1bg0u8-BaseButton-DateInput"
           type="button"
         >
           <span>

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change start date, 1st January 2000 Saturday"
-                class="css-1martsc-BaseButton-DateInput"
+                class="css-1bg0u8-BaseButton-DateInput"
                 type="button"
               >
                 <span>
@@ -143,7 +143,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change end date, 2nd January 2000 Sunday"
-                class="css-1martsc-BaseButton-DateInput"
+                class="css-1bg0u8-BaseButton-DateInput"
                 type="button"
               >
                 <span>

--- a/packages/react/src/drawer/DrawerDialog.tsx
+++ b/packages/react/src/drawer/DrawerDialog.tsx
@@ -63,12 +63,9 @@ export function DrawerDialog({
 			}
 		>
 			<AnimatedFlex
-				flexDirection="column"
-				role="dialog"
+				aria-labelledby={titleId}
 				aria-modal="true"
 				background="body"
-				aria-labelledby={titleId}
-				maxWidth={WIDTH_MAP[width]}
 				css={{
 					boxShadow: tokens.shadow.lg,
 					position: 'fixed',
@@ -79,6 +76,10 @@ export function DrawerDialog({
 						overflowY: 'auto',
 					},
 				}}
+				flexDirection="column"
+				highContrastOutline
+				maxWidth={WIDTH_MAP[width]}
+				role="dialog"
 				style={style}
 			>
 				<DrawerHeader>

--- a/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Drawer renders correctly 1`] = `
       <div
         aria-labelledby="drawer-:r0:-title"
         aria-modal="true"
-        class="css-bugcec-boxStyles-DrawerDialog"
+        class="css-1sh13sj-boxStyles-DrawerDialog"
         role="dialog"
         style="transform: translateX(100%);"
       >

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       >
         <span
           aria-hidden="true"
-          class="css-16ju22e-boxStyles-NotificationBadge"
+          class="css-1w074qx-boxStyles-NotificationBadge"
         >
           99+
         </span>

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-1599sfo"
+      class="css-3lh49h"
       id="field-:r2:"
       type="file"
     />
@@ -90,7 +90,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-1599sfo"
+      class="css-3lh49h"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`FileUpload 1 selected file renders correctly 1`] = `
             </span>
           </div>
           <button
-            class="css-g9kgvi-BaseButton-Button"
+            class="css-82tp6n-BaseButton-Button"
             type="button"
           >
             <span>
@@ -311,7 +311,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
             </span>
           </div>
           <button
-            class="css-g9kgvi-BaseButton-Button"
+            class="css-82tp6n-BaseButton-Button"
             type="button"
           >
             <span>
@@ -424,7 +424,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
             </span>
           </div>
           <button
-            class="css-g9kgvi-BaseButton-Button"
+            class="css-82tp6n-BaseButton-Button"
             type="button"
           >
             <span>
@@ -784,7 +784,7 @@ exports[`FileUpload Multiple, maxSize and accepted file extensions renders corre
           </div>
           <button
             aria-describedby=":r4:-file-size-desc, :r4:-accepted-files-desc"
-            class="css-g9kgvi-BaseButton-Button"
+            class="css-82tp6n-BaseButton-Button"
             type="button"
           >
             <span>

--- a/packages/react/src/global-alert/GlobalAlert.tsx
+++ b/packages/react/src/global-alert/GlobalAlert.tsx
@@ -38,6 +38,7 @@ export function GlobalAlert({
 			as="section"
 			aria-label={title || ariaLabel}
 			css={{ backgroundColor: bg }}
+			highContrastOutline
 		>
 			<Flex
 				alignItems="center"

--- a/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
+++ b/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`GlobalAlert Dismissable renders correctly 1`] = `
 <div>
   <section
     aria-label="Alert title"
-    class="css-1nshtlu-boxStyles-GlobalAlert"
+    class="css-1v0vzf6-boxStyles-GlobalAlert"
   >
     <div
       class="css-10khfcq-boxStyles-GlobalAlert"
@@ -100,7 +100,7 @@ exports[`GlobalAlert with tone info renders correctly 1`] = `
 <div>
   <section
     aria-label="Alert title"
-    class="css-1wlrpz7-boxStyles-GlobalAlert"
+    class="css-h8illz-boxStyles-GlobalAlert"
   >
     <div
       class="css-vh758l-boxStyles-GlobalAlert"
@@ -155,7 +155,7 @@ exports[`GlobalAlert with tone warning renders correctly 1`] = `
 <div>
   <section
     aria-label="Alert title"
-    class="css-1nshtlu-boxStyles-GlobalAlert"
+    class="css-1v0vzf6-boxStyles-GlobalAlert"
   >
     <div
       class="css-10khfcq-boxStyles-GlobalAlert"

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -35,15 +35,9 @@ export const ModalDialog = ({
 	return (
 		<FocusLock returnFocus>
 			<Stack
-				role="dialog"
+				aria-labelledby={titleId}
 				aria-modal="true"
 				background="body"
-				aria-labelledby={titleId}
-				rounded
-				paddingX={{ xs: 0.75, md: 1.5 }}
-				paddingY={{ xs: 1, md: 1.5 }}
-				gap={1}
-				maxWidth={MAX_WIDTH}
 				css={{
 					boxShadow: tokens.shadow.lg,
 					position: 'relative',
@@ -55,6 +49,13 @@ export const ModalDialog = ({
 						minHeight: 'auto',
 					},
 				}}
+				gap={1}
+				highContrastOutline
+				maxWidth={MAX_WIDTH}
+				paddingX={{ xs: 0.75, md: 1.5 }}
+				paddingY={{ xs: 1, md: 1.5 }}
+				role="dialog"
+				rounded
 			>
 				<Button
 					variant="text"

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Modal renders correctly 1`] = `
       <div
         aria-labelledby="modal-:r0:-title"
         aria-modal="true"
-        class="css-1zh0al-boxStyles-ModalDialog"
+        class="css-1s6nlwb-boxStyles-ModalDialog"
         role="dialog"
       >
         <button

--- a/packages/react/src/notification-badge/NotificationBadge.tsx
+++ b/packages/react/src/notification-badge/NotificationBadge.tsx
@@ -23,14 +23,7 @@ export const NotificationBadge = ({
 	const backgroundColor = badgeToneMap[tone];
 	return (
 		<Text
-			display="inline-flex"
 			alignItems="center"
-			justifyContent="center"
-			height={mapSpacing(1.5)}
-			paddingX={0.5}
-			rounded
-			fontSize="sm"
-			lineHeight="nospace"
 			aria-hidden={ariaHidden}
 			css={{
 				color: boxPalette.backgroundBody,
@@ -38,6 +31,14 @@ export const NotificationBadge = ({
 				minWidth: mapSpacing(1.5),
 				borderRadius: mapSpacing(0.75),
 			}}
+			display="inline-flex"
+			fontSize="sm"
+			height={mapSpacing(1.5)}
+			highContrastOutline
+			justifyContent="center"
+			lineHeight="nospace"
+			paddingX={0.5}
+			rounded
 		>
 			{max === undefined || value <= max ? value : `${max}+`}
 		</Text>

--- a/packages/react/src/notification-badge/__snapshots__/NotificationBadge.test.tsx.snap
+++ b/packages/react/src/notification-badge/__snapshots__/NotificationBadge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NotificationBadge tone: action renders correctly 1`] = `
 <div>
   <span
-    class="css-16ju22e-boxStyles-NotificationBadge"
+    class="css-1w074qx-boxStyles-NotificationBadge"
   >
     5
   </span>
@@ -13,7 +13,7 @@ exports[`NotificationBadge tone: action renders correctly 1`] = `
 exports[`NotificationBadge tone: neutral renders correctly 1`] = `
 <div>
   <span
-    class="css-1eg0j6v-boxStyles-NotificationBadge"
+    class="css-so24xo-boxStyles-NotificationBadge"
   >
     5
   </span>

--- a/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
@@ -186,6 +186,10 @@ const ProgressIndicatorItemTimeline = () => (
 			flex: 1,
 			justifySelf: 'center',
 			width: tokens.borderWidth.md,
+			// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+			'@media (forced-colors: active)': {
+				backgroundColor: 'GrayText',
+			},
 		}}
 		{...{ [progressIndicatorItemTimelineDataAttr]: '' }}
 	/>

--- a/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -115,7 +115,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -148,7 +148,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -173,7 +173,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -206,7 +206,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -246,7 +246,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -280,7 +280,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -311,7 +311,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -344,7 +344,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -372,7 +372,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -405,7 +405,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -445,7 +445,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -478,7 +478,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -504,7 +504,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -622,7 +622,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -649,7 +649,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -682,7 +682,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -707,7 +707,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -740,7 +740,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -780,7 +780,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -814,7 +814,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -845,7 +845,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -878,7 +878,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -906,7 +906,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -939,7 +939,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -979,7 +979,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1012,7 +1012,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1038,7 +1038,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1156,7 +1156,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1183,7 +1183,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1216,7 +1216,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1241,7 +1241,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1275,7 +1275,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1315,7 +1315,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1348,7 +1348,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1379,7 +1379,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1412,7 +1412,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1440,7 +1440,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1473,7 +1473,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1513,7 +1513,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1546,7 +1546,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1572,7 +1572,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1690,7 +1690,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1717,7 +1717,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1750,7 +1750,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1775,7 +1775,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1809,7 +1809,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1849,7 +1849,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1882,7 +1882,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1913,7 +1913,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -1946,7 +1946,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -1974,7 +1974,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2007,7 +2007,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2047,7 +2047,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2080,7 +2080,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2106,7 +2106,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2224,7 +2224,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2251,7 +2251,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2284,7 +2284,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2309,7 +2309,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2342,7 +2342,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2382,7 +2382,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2416,7 +2416,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2447,7 +2447,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2480,7 +2480,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2508,7 +2508,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2541,7 +2541,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2581,7 +2581,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2614,7 +2614,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2640,7 +2640,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2758,7 +2758,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2785,7 +2785,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2818,7 +2818,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2843,7 +2843,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2876,7 +2876,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2916,7 +2916,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -2950,7 +2950,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -2981,7 +2981,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3014,7 +3014,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3042,7 +3042,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3075,7 +3075,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3115,7 +3115,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3148,7 +3148,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3174,7 +3174,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3292,7 +3292,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3319,7 +3319,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3352,7 +3352,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3377,7 +3377,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3410,7 +3410,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3450,7 +3450,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3483,7 +3483,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3514,7 +3514,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3547,7 +3547,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3575,7 +3575,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3608,7 +3608,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3648,7 +3648,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3682,7 +3682,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3708,7 +3708,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3826,7 +3826,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3853,7 +3853,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3886,7 +3886,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3911,7 +3911,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -3944,7 +3944,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -3984,7 +3984,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -4017,7 +4017,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -4048,7 +4048,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -4081,7 +4081,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -4109,7 +4109,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -4142,7 +4142,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -4182,7 +4182,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>
@@ -4216,7 +4216,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 class="css-11emnjx-boxStyles"
               >
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
                 <span
@@ -4242,7 +4242,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                   </svg>
                 </span>
                 <span
-                  class="css-1umyplw-ProgressIndicatorItemTimeline"
+                  class="css-1rmsy9y-ProgressIndicatorItemTimeline"
                   data-agds-progress-indicator-item-timeline-action=""
                 />
               </span>

--- a/packages/react/src/radio/RadioIndicator.tsx
+++ b/packages/react/src/radio/RadioIndicator.tsx
@@ -34,6 +34,11 @@ export function RadioIndicator({
 					color: boxPalette.borderMuted,
 					borderColor: boxPalette.borderMuted,
 					backgroundColor: boxPalette.backgroundShade,
+					// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+					'@media (forced-colors: active)': {
+						borderColor: 'GrayText',
+						color: 'GrayText',
+					},
 				}),
 
 				...(invalid && {
@@ -51,9 +56,15 @@ export function RadioIndicator({
 				css={{
 					borderRadius: '100%',
 					backgroundColor: boxPalette.foregroundText,
+					'@media (forced-colors: active)': {
+						backgroundColor: 'MenuText',
+					},
 
 					...(disabled && {
 						backgroundColor: boxPalette.borderMuted,
+						'@media (forced-colors: active)': {
+							backgroundColor: 'GrayText',
+						},
 					}),
 				}}
 			/>

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Radio renders correctly 1`] = `
       class="css-osss6w-boxStyles-RadioIndicator"
     >
       <span
-        class="css-1sqol0e-boxStyles-RadioIndicator"
+        class="css-erbirp-boxStyles-RadioIndicator"
       />
     </span>
     <span

--- a/packages/react/src/stack/docs/overview.mdx
+++ b/packages/react/src/stack/docs/overview.mdx
@@ -7,10 +7,11 @@ relatedComponents: ['box', 'flex', 'form-stack']
 ---
 
 ```jsx live showCode
+/* highContrastOutline outline added for demo purposes only */
 <Stack gap={1}>
-	<Box background="shade" padding={1} />
-	<Box background="shade" padding={1} />
-	<Box background="shade" padding={1} />
+	<Box background="shade" highContrastOutline padding={1} />
+	<Box background="shade" highContrastOutline padding={1} />
+	<Box background="shade" highContrastOutline padding={1} />
 </Stack>
 ```
 
@@ -19,10 +20,11 @@ relatedComponents: ['box', 'flex', 'form-stack']
 By default, the Stack component renders an HTML `<div>` element. You can render it with a different HTML element tag by using the `as` prop.
 
 ```jsx live showCode
+/* highContrastOutline outline added for demo purposes only */
 <Stack as="section" gap={1}>
-	<Box background="shade" padding={1} />
-	<Box background="shade" padding={1} />
-	<Box background="shade" padding={1} />
+	<Box background="shade" highContrastOutline padding={1} />
+	<Box background="shade" highContrastOutline padding={1} />
+	<Box background="shade" highContrastOutline padding={1} />
 </Stack>
 ```
 

--- a/packages/react/src/sub-nav/SubNavListItem.tsx
+++ b/packages/react/src/sub-nav/SubNavListItem.tsx
@@ -30,10 +30,19 @@ export function SubNavListItem({ children, active }: SubNavListItemProps) {
 					mapSpacing(0.5),
 				]),
 
+				// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+				'@media (forced-colors: active)': {
+					borderBottomColor: active ? 'Background' : 'MenuText',
+				},
+
 				'&:first-of-type': {
 					borderTopWidth: mapResponsiveProp([tokens.borderWidth.sm, 0]),
 					borderTopStyle: 'solid',
 					borderTopColor: boxPalette.borderMuted,
+
+					'@media (forced-colors: active)': {
+						borderBottomColor: 'GrayText',
+					},
 				},
 
 				'& a': {
@@ -51,6 +60,11 @@ export function SubNavListItem({ children, active }: SubNavListItemProps) {
 					borderLeftStyle: 'solid',
 					borderLeftWidth: mapResponsiveProp([tokens.borderWidth.xl, 0]),
 					borderLeftColor: active ? boxPalette.selected : 'transparent',
+
+					// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+					'@media (forced-colors: active)': {
+						borderLeftColor: active ? 'MenuText' : 'Background',
+					},
 
 					...focusStyles,
 

--- a/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
+++ b/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SubNav renders correctly 1`] = `
       class="css-1ipxjn1-boxStyles-SubNavList"
     >
       <li
-        class="css-16llfk1-boxStyles-SubNavListItem"
+        class="css-gp1ecr-boxStyles-SubNavListItem"
       >
         <a
           href="/"
@@ -21,7 +21,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-yxjwge-boxStyles-SubNavListItem"
+        class="css-ynp456-boxStyles-SubNavListItem"
       >
         <a
           aria-current="page"
@@ -33,7 +33,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-16llfk1-boxStyles-SubNavListItem"
+        class="css-gp1ecr-boxStyles-SubNavListItem"
       >
         <a
           href="/content"
@@ -44,7 +44,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-16llfk1-boxStyles-SubNavListItem"
+        class="css-gp1ecr-boxStyles-SubNavListItem"
       >
         <a
           href="/accessibility"

--- a/packages/react/src/tabs/TabButton.tsx
+++ b/packages/react/src/tabs/TabButton.tsx
@@ -139,6 +139,10 @@ export function TabButton({ children, endElement }: TabButtonProps) {
 						background: isSelected
 							? boxPalette.selected
 							: boxPalette.borderMuted,
+						// See https://www.w3.org/TR/CSS21/ui.html#system-colors
+						'@media (forced-colors: active)': {
+							backgroundColor: isSelected ? 'MenuText' : 'GrayText',
+						},
 					},
 				},
 

--- a/packages/react/src/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react/src/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Tabs renders correctly 1`] = `
       <button
         aria-controls="tabs-:r0:-tab-panel-0"
         aria-selected="true"
-        class="css-cmofij-BaseButton-boxStyles-TabButton"
+        class="css-ynuge8-BaseButton-boxStyles-TabButton"
         id="tabs-:r0:-tab-button-0"
         role="tab"
         tabindex="0"
@@ -27,7 +27,7 @@ exports[`Tabs renders correctly 1`] = `
       <button
         aria-controls="tabs-:r0:-tab-panel-1"
         aria-selected="false"
-        class="css-16a6lnh-BaseButton-boxStyles-TabButton"
+        class="css-8vwak-BaseButton-boxStyles-TabButton"
         id="tabs-:r0:-tab-button-1"
         role="tab"
         tabindex="-1"
@@ -40,7 +40,7 @@ exports[`Tabs renders correctly 1`] = `
       <button
         aria-controls="tabs-:r0:-tab-panel-2"
         aria-selected="false"
-        class="css-16a6lnh-BaseButton-boxStyles-TabButton"
+        class="css-8vwak-BaseButton-boxStyles-TabButton"
         id="tabs-:r0:-tab-button-2"
         role="tab"
         tabindex="-1"


### PR DESCRIPTION
My testing in high contrast mode found multiple issues with various components


[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1829)

Before:

![image](https://github.com/user-attachments/assets/eba15052-421d-4702-a6d5-89ba24faebae)


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
