### PR TITLE
app-layout, main-nav: Set aria-expanded to mobile menu's state

### DIFF
--- a/.changeset/two-colts-kick.md
+++ b/.changeset/two-colts-kick.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+app-layout: `AppLayoutHeader` - set `aria-expanded` to match mobile menu open state.
+
+main-nav: Set `aria-expanded` to match mobile menu open state.

--- a/packages/react/src/app-layout/AppLayoutHeaderNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderNav.tsx
@@ -39,10 +39,11 @@ function AppLayoutHeaderNavMenuButton({
 }: {
 	onClick: MouseEventHandler<HTMLButtonElement>;
 }) {
+	const { isMobileMenuOpen } = useAppLayoutContext();
 	return (
 		<Flex
 			alignItems="center"
-			aria-expanded="false"
+			aria-expanded={isMobileMenuOpen}
 			aria-haspopup="dialog"
 			as={BaseButton}
 			color="action"

--- a/packages/react/src/main-nav/MainNav.tsx
+++ b/packages/react/src/main-nav/MainNav.tsx
@@ -48,6 +48,7 @@ export function MainNav({
 				borderColor={borderColor}
 				focusMode={focusMode}
 				id={id}
+				isMobileMenuOpen={isMobileMenuOpen}
 				items={items}
 				openMobileMenu={openMobileMenu}
 				secondaryItems={secondaryItems}

--- a/packages/react/src/main-nav/MainNavContainer.tsx
+++ b/packages/react/src/main-nav/MainNavContainer.tsx
@@ -13,6 +13,7 @@ export type MainNavContainerProps = {
 	borderColor: ResponsiveProp<BorderColor>;
 	focusMode?: boolean;
 	id?: string;
+	isMobileMenuOpen: boolean;
 	items?: MainNavListItemType[];
 	openMobileMenu: () => void;
 	secondaryItems?: (MainNavListItemType | MainNavListDropdown)[];
@@ -24,6 +25,7 @@ export function MainNavContainer({
 	borderColor,
 	focusMode = false,
 	id,
+	isMobileMenuOpen,
 	items,
 	openMobileMenu,
 	secondaryItems,
@@ -53,7 +55,10 @@ export function MainNavContainer({
 					width="100%"
 				>
 					{items?.length ? (
-						<MainNavOpenButton onClick={openMobileMenu} />
+						<MainNavOpenButton
+							isMobileMenuOpen={isMobileMenuOpen}
+							onClick={openMobileMenu}
+						/>
 					) : null}
 					<MainNavList activePath={activePath} items={items} type="primary" />
 					{secondaryItems?.length ? (

--- a/packages/react/src/main-nav/MainNavMenuButtons.tsx
+++ b/packages/react/src/main-nav/MainNavMenuButtons.tsx
@@ -6,13 +6,17 @@ import { CloseIcon, MenuIcon } from '../icon';
 import { localPalette } from './localPalette';
 
 export type MainNavOpenButtonProps = PropsWithChildren<{
+	isMobileMenuOpen: boolean;
 	onClick: MouseEventHandler<HTMLButtonElement>;
 }>;
 
-export function MainNavOpenButton({ onClick }: MainNavOpenButtonProps) {
+export function MainNavOpenButton({
+	isMobileMenuOpen,
+	onClick,
+}: MainNavOpenButtonProps) {
 	return (
 		<Flex
-			aria-expanded="false"
+			aria-expanded={isMobileMenuOpen}
 			aria-haspopup="dialog"
 			as={BaseButton}
 			display={{ xs: 'flex', lg: 'none' }}


### PR DESCRIPTION
The a11y audit (incorrectly) told us to set the mobile menu button to `aria-expanded="true"` even though a user can never get to or hear it.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1836)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.