### PR TITLE
yourgov: Fix focus issues with Staff table

### DIFF
--- a/.changeset/selfish-ravens-rest.md
+++ b/.changeset/selfish-ravens-rest.md
@@ -1,0 +1,10 @@
+---
+'@ag.ds-next/react': minor
+'@ag.ds-next/yourgov': minor
+---
+
+modal: Add `elementToFocusOnClose` prop to allow for manual focus management.
+page-alert: Update `focusOnUpdate` to not focus on any falsey value.
+section-alert: Update `focusOnUpdate` to not focus on any falsey value.
+
+yourgov: Fix focus issues with Staff table.

--- a/packages/react/src/core/utils/useFocus.ts
+++ b/packages/react/src/core/utils/useFocus.ts
@@ -30,7 +30,7 @@ export function useFocus<T extends HTMLElement>({
 	useEffect(
 		() => {
 			if (
-				(focusOnUpdate === undefined && !focusOnMount) ||
+				(!focusOnUpdate && !focusOnMount) ||
 				!('current' in ref) ||
 				(Array.isArray(focusOnUpdate) &&
 					focusOnUpdate.filter(Boolean).length === 0)

--- a/packages/react/src/modal/Modal.tsx
+++ b/packages/react/src/modal/Modal.tsx
@@ -14,6 +14,7 @@ export type ModalProps = ModalDialogProps & {
 export const Modal: FunctionComponent<ModalProps> = ({
 	actions,
 	children,
+	elementToFocusOnClose,
 	isOpen = false,
 	onClose,
 	onDismiss,
@@ -47,7 +48,12 @@ export const Modal: FunctionComponent<ModalProps> = ({
 		<Fragment>
 			<LockScroll />
 			<ModalCover ref={modalContainerRef}>
-				<ModalDialog onClose={closeHandler} title={title} actions={actions}>
+				<ModalDialog
+					actions={actions}
+					elementToFocusOnClose={elementToFocusOnClose}
+					onClose={closeHandler}
+					title={title}
+				>
 					{children}
 				</ModalDialog>
 			</ModalCover>

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -13,10 +13,12 @@ import { useModalId } from './utils';
 export type ModalDialogProps = PropsWithChildren<{
 	/** The actions to display at the bottom of the modal panel. Typically a `ButtonGroup`. */
 	actions?: ReactNode;
-	/** @deprecated use `onClose` instead */
-	onDismiss?: () => void;
+	/** On close of the modal, this element will be focused, rather than the trigger element. */
+	elementToFocusOnClose?: HTMLElement | null;
 	/** Function to be called when the 'Close' button is pressed. */
 	onClose?: () => void;
+	/** @deprecated use `onClose` instead */
+	onDismiss?: () => void;
 	/** The title of the modal dialog. It can span lines but should not be too long. */
 	title: string;
 }>;
@@ -26,14 +28,26 @@ const MAX_WIDTH = '45rem'; // 720 px
 export const ModalDialog = ({
 	actions,
 	children,
-	title,
+	elementToFocusOnClose,
 	onClose,
 	onDismiss,
+	title,
 }: ModalDialogProps) => {
 	const closeHandler = getRequiredCloseHandler(onClose, onDismiss);
 	const { titleId } = useModalId();
 	return (
-		<FocusLock returnFocus>
+		<FocusLock
+			returnFocus={
+				elementToFocusOnClose
+					? () => {
+							// Running focus after focus-lock-react does its cleanup, more info here: https://github.com/theKashey/react-focus-lock#unmounting-and-focus-management
+							window.setTimeout(() => elementToFocusOnClose.focus(), 0);
+
+							return false;
+					  }
+					: true // Return focus to trigger on close
+			}
+		>
 			<Stack
 				aria-labelledby={titleId}
 				aria-modal="true"

--- a/yourgov/components/Staff/DataTable.tsx
+++ b/yourgov/components/Staff/DataTable.tsx
@@ -33,12 +33,14 @@ const descriptionId = 'data-table-description';
 type DataTableProps = {
 	/** The id of the heading that describes the table */
 	headingId?: string;
+	/** On close of the action modals, this element will be focused, rather than the trigger element. */
+	pageAlertRef?: HTMLElement | null;
 	/** Whether the table should be selectable */
 	selectable?: boolean;
 };
 
 export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
-	function DataTable({ headingId, selectable }, ref) {
+	function DataTable({ headingId, pageAlertRef, selectable }, ref) {
 		const { sort, setSort, pagination, resetFilters } =
 			useSortAndFilterContext();
 		const { displayData, loading, totalItems, error } = useDataContext();
@@ -213,12 +215,13 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 
 										return (
 											<DataTableRow
-												key={name}
-												selectable={selectable}
 												item={item}
 												itemId={item.id}
+												key={name}
 												name={name}
+												pageAlertRef={pageAlertRef}
 												rowIndex={rowIndex}
+												selectable={selectable}
 											>
 												<TableCell as="th" scope="row">
 													<TextLink
@@ -255,7 +258,7 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 						</TableBody>
 					</Table>
 				</TableWrapper>
-				<DataTableBatchActionsBar />
+				<DataTableBatchActionsBar pageAlertRef={pageAlertRef} />
 			</Stack>
 		);
 	}

--- a/yourgov/components/Staff/DataTable.tsx
+++ b/yourgov/components/Staff/DataTable.tsx
@@ -34,13 +34,13 @@ type DataTableProps = {
 	/** The id of the heading that describes the table */
 	headingId?: string;
 	/** On close of the action modals, this element will be focused, rather than the trigger element. */
-	pageAlertRef?: HTMLElement | null;
+	pageAlertElement?: HTMLElement | null;
 	/** Whether the table should be selectable */
 	selectable?: boolean;
 };
 
 export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
-	function DataTable({ headingId, pageAlertRef, selectable }, ref) {
+	function DataTable({ headingId, pageAlertElement, selectable }, ref) {
 		const { sort, setSort, pagination, resetFilters } =
 			useSortAndFilterContext();
 		const { displayData, loading, totalItems, error } = useDataContext();
@@ -219,7 +219,7 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 												itemId={item.id}
 												key={name}
 												name={name}
-												pageAlertRef={pageAlertRef}
+												pageAlertElement={pageAlertElement}
 												rowIndex={rowIndex}
 												selectable={selectable}
 											>
@@ -258,7 +258,7 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 						</TableBody>
 					</Table>
 				</TableWrapper>
-				<DataTableBatchActionsBar pageAlertRef={pageAlertRef} />
+				<DataTableBatchActionsBar pageAlertElement={pageAlertElement} />
 			</Stack>
 		);
 	}

--- a/yourgov/components/Staff/DataTableBatchActionsBar.tsx
+++ b/yourgov/components/Staff/DataTableBatchActionsBar.tsx
@@ -12,7 +12,12 @@ import { StaffMemberWithIndex } from './lib/types';
 import { useStaffGlobalState } from './StaffProvider';
 import { ModalConfirmChangeRole } from './ModalConfirmChangeRole';
 
-export const DataTableBatchActionsBar = () => {
+export const DataTableBatchActionsBar = ({
+	pageAlertRef,
+}: {
+	/** On close of the action modals, this element will be focused, rather than the trigger element. */
+	pageAlertRef?: HTMLElement | null;
+}) => {
 	const { setSuccessMessageType, setUpdatedStaffMemberName } = useDataContext();
 	const { staffMembersDelete, staffMembersUpdate } = useStaffGlobalState();
 	const { selection, clearRowSelections } = useSortAndFilterContext();
@@ -115,20 +120,23 @@ export const DataTableBatchActionsBar = () => {
 					isOpen={modalChangeRoleOpen}
 					onClose={() => setModalChangeRoleOpen(false)}
 					onConfirm={onConfirmChangeRole}
+					pageAlertRef={pageAlertRef}
 				/>
 
 				<ModalConfirmPauseAccess
-					itemsToPause={items}
 					isOpen={pauseModalOpen}
+					itemsToPause={items}
 					onClose={() => setPauseModalOpen(false)}
 					onConfirm={onConfirmPause}
+					pageAlertRef={pageAlertRef}
 				/>
 
 				<ModalConfirmRemoveAccess
-					itemsToDelete={items}
 					isOpen={removeModalOpen}
+					itemsToDelete={items}
 					onClose={() => setRemoveModalOpen(false)}
 					onConfirm={onConfirmRemove}
+					pageAlertRef={pageAlertRef}
 				/>
 			</TableBatchActionsBar>
 		);

--- a/yourgov/components/Staff/DataTableBatchActionsBar.tsx
+++ b/yourgov/components/Staff/DataTableBatchActionsBar.tsx
@@ -13,10 +13,10 @@ import { useStaffGlobalState } from './StaffProvider';
 import { ModalConfirmChangeRole } from './ModalConfirmChangeRole';
 
 export const DataTableBatchActionsBar = ({
-	pageAlertRef,
+	pageAlertElement,
 }: {
 	/** On close of the action modals, this element will be focused, rather than the trigger element. */
-	pageAlertRef?: HTMLElement | null;
+	pageAlertElement?: HTMLElement | null;
 }) => {
 	const { setSuccessMessageType, setUpdatedStaffMemberName } = useDataContext();
 	const { staffMembersDelete, staffMembersUpdate } = useStaffGlobalState();
@@ -120,7 +120,7 @@ export const DataTableBatchActionsBar = ({
 					isOpen={modalChangeRoleOpen}
 					onClose={() => setModalChangeRoleOpen(false)}
 					onConfirm={onConfirmChangeRole}
-					pageAlertRef={pageAlertRef}
+					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmPauseAccess
@@ -128,7 +128,7 @@ export const DataTableBatchActionsBar = ({
 					itemsToPause={items}
 					onClose={() => setPauseModalOpen(false)}
 					onConfirm={onConfirmPause}
-					pageAlertRef={pageAlertRef}
+					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmRemoveAccess
@@ -136,7 +136,7 @@ export const DataTableBatchActionsBar = ({
 					itemsToDelete={items}
 					onClose={() => setRemoveModalOpen(false)}
 					onConfirm={onConfirmRemove}
-					pageAlertRef={pageAlertRef}
+					pageAlertElement={pageAlertElement}
 				/>
 			</TableBatchActionsBar>
 		);

--- a/yourgov/components/Staff/DataTableRow.tsx
+++ b/yourgov/components/Staff/DataTableRow.tsx
@@ -48,7 +48,7 @@ export const DataTableRow = ({
 	item,
 	itemId,
 	name,
-	pageAlertRef,
+	pageAlertElement,
 	rowIndex,
 	selectable,
 }: {
@@ -57,7 +57,7 @@ export const DataTableRow = ({
 	itemId: string;
 	name: string;
 	/** On close of the action modals, this element will be focused, rather than the trigger element. */
-	pageAlertRef?: HTMLElement | null;
+	pageAlertElement?: HTMLElement | null;
 	rowIndex: number;
 	selectable?: boolean;
 }) => {
@@ -143,7 +143,7 @@ export const DataTableRow = ({
 					isOpen={modalChangeRoleOpen}
 					onClose={() => setModalChangeRoleOpen(false)}
 					onConfirm={onConfirmChangeRole}
-					pageAlertRef={pageAlertRef}
+					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmPauseAccess
@@ -151,7 +151,7 @@ export const DataTableRow = ({
 					itemsToPause={item}
 					onClose={() => setPauseModalOpen(false)}
 					onConfirm={onConfirmPause}
-					pageAlertRef={pageAlertRef}
+					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmRemoveAccess
@@ -159,7 +159,7 @@ export const DataTableRow = ({
 					itemsToDelete={item}
 					onClose={() => setRemoveModalOpen(false)}
 					onConfirm={onConfirmRemove}
-					pageAlertRef={pageAlertRef}
+					pageAlertElement={pageAlertElement}
 				/>
 			</TableRow>
 		);

--- a/yourgov/components/Staff/DataTableRow.tsx
+++ b/yourgov/components/Staff/DataTableRow.tsx
@@ -44,17 +44,20 @@ export const DataTableRowStatus = ({
 };
 
 export const DataTableRow = ({
-	name,
 	children,
 	item,
 	itemId,
+	name,
+	pageAlertRef,
 	rowIndex,
 	selectable,
 }: {
-	name: string;
 	children: ReactNode;
 	item: StaffMemberWithIndex;
 	itemId: string;
+	name: string;
+	/** On close of the action modals, this element will be focused, rather than the trigger element. */
+	pageAlertRef?: HTMLElement | null;
 	rowIndex: number;
 	selectable?: boolean;
 }) => {
@@ -140,20 +143,23 @@ export const DataTableRow = ({
 					isOpen={modalChangeRoleOpen}
 					onClose={() => setModalChangeRoleOpen(false)}
 					onConfirm={onConfirmChangeRole}
+					pageAlertRef={pageAlertRef}
 				/>
 
 				<ModalConfirmPauseAccess
-					itemsToPause={item}
 					isOpen={pauseModalOpen}
+					itemsToPause={item}
 					onClose={() => setPauseModalOpen(false)}
 					onConfirm={onConfirmPause}
+					pageAlertRef={pageAlertRef}
 				/>
 
 				<ModalConfirmRemoveAccess
-					itemsToDelete={item}
 					isOpen={removeModalOpen}
+					itemsToDelete={item}
 					onClose={() => setRemoveModalOpen(false)}
 					onConfirm={onConfirmRemove}
+					pageAlertRef={pageAlertRef}
 				/>
 			</TableRow>
 		);

--- a/yourgov/components/Staff/ModalConfirmChangeRole.tsx
+++ b/yourgov/components/Staff/ModalConfirmChangeRole.tsx
@@ -6,17 +6,20 @@ import { Radio } from '@ag.ds-next/react/radio';
 import { StaffMemberRole } from './lib/types';
 
 export type ModalConfirmChangeRoleProps = {
-	isOpen: boolean;
-	onConfirm: () => void;
-	onClose: () => void;
 	currentRole?: StaffMemberRole;
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	/** On close of the modal, this element will be focused, rather than the trigger element. */
+	pageAlertRef?: HTMLElement | null;
 };
 
 export const ModalConfirmChangeRole = ({
 	currentRole,
 	isOpen,
-	onConfirm,
 	onClose,
+	onConfirm,
+	pageAlertRef,
 }: ModalConfirmChangeRoleProps) => {
 	const [submitting, setSubmitting] = useState(false);
 	const [role, setRole] = useState<StaffMemberRole | undefined>(currentRole);
@@ -37,6 +40,7 @@ export const ModalConfirmChangeRole = ({
 
 	return (
 		<Drawer
+			elementToFocusOnClose={pageAlertRef}
 			isOpen={isOpen}
 			onClose={onClose}
 			title="Change role"

--- a/yourgov/components/Staff/ModalConfirmChangeRole.tsx
+++ b/yourgov/components/Staff/ModalConfirmChangeRole.tsx
@@ -11,7 +11,7 @@ export type ModalConfirmChangeRoleProps = {
 	onClose: () => void;
 	onConfirm: () => void;
 	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertRef?: HTMLElement | null;
+	pageAlertElement?: HTMLElement | null;
 };
 
 export const ModalConfirmChangeRole = ({
@@ -19,7 +19,7 @@ export const ModalConfirmChangeRole = ({
 	isOpen,
 	onClose,
 	onConfirm,
-	pageAlertRef,
+	pageAlertElement,
 }: ModalConfirmChangeRoleProps) => {
 	const [submitting, setSubmitting] = useState(false);
 	const [role, setRole] = useState<StaffMemberRole | undefined>(currentRole);
@@ -40,7 +40,7 @@ export const ModalConfirmChangeRole = ({
 
 	return (
 		<Drawer
-			elementToFocusOnClose={pageAlertRef}
+			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title="Change role"

--- a/yourgov/components/Staff/ModalConfirmPauseAccess.tsx
+++ b/yourgov/components/Staff/ModalConfirmPauseAccess.tsx
@@ -9,16 +9,19 @@ type RowData = StaffMemberWithIndex;
 
 export type ModalConfirmPauseAccessProps = {
 	isOpen: boolean;
-	onConfirm: () => void;
-	onClose: () => void;
 	itemsToPause: RowData | RowData[];
+	onClose: () => void;
+	onConfirm: () => void;
+	/** On close of the modal, this element will be focused, rather than the trigger element. */
+	pageAlertRef?: HTMLElement | null;
 };
 
 export function ModalConfirmPauseAccess({
 	isOpen,
-	onConfirm,
-	onClose,
 	itemsToPause,
+	onClose,
+	onConfirm,
+	pageAlertRef,
 }: ModalConfirmPauseAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -49,6 +52,7 @@ export function ModalConfirmPauseAccess({
 
 	return (
 		<Modal
+			elementToFocusOnClose={pageAlertRef}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/ModalConfirmPauseAccess.tsx
+++ b/yourgov/components/Staff/ModalConfirmPauseAccess.tsx
@@ -13,7 +13,7 @@ export type ModalConfirmPauseAccessProps = {
 	onClose: () => void;
 	onConfirm: () => void;
 	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertRef?: HTMLElement | null;
+	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmPauseAccess({
@@ -21,7 +21,7 @@ export function ModalConfirmPauseAccess({
 	itemsToPause,
 	onClose,
 	onConfirm,
-	pageAlertRef,
+	pageAlertElement,
 }: ModalConfirmPauseAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -52,7 +52,7 @@ export function ModalConfirmPauseAccess({
 
 	return (
 		<Modal
-			elementToFocusOnClose={pageAlertRef}
+			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/ModalConfirmRemoveAccess.tsx
+++ b/yourgov/components/Staff/ModalConfirmRemoveAccess.tsx
@@ -13,7 +13,7 @@ export type ModalConfirmRemoveAccessProps = {
 	onClose: () => void;
 	onConfirm: () => void;
 	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertRef?: HTMLElement | null;
+	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmRemoveAccess({
@@ -21,7 +21,7 @@ export function ModalConfirmRemoveAccess({
 	itemsToDelete,
 	onClose,
 	onConfirm,
-	pageAlertRef,
+	pageAlertElement,
 }: ModalConfirmRemoveAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -52,7 +52,7 @@ export function ModalConfirmRemoveAccess({
 
 	return (
 		<Modal
-			elementToFocusOnClose={pageAlertRef}
+			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/ModalConfirmRemoveAccess.tsx
+++ b/yourgov/components/Staff/ModalConfirmRemoveAccess.tsx
@@ -9,16 +9,19 @@ type RowData = StaffMemberWithIndex | StaffMember;
 
 export type ModalConfirmRemoveAccessProps = {
 	isOpen: boolean;
-	onConfirm: () => void;
-	onClose: () => void;
 	itemsToDelete: RowData | RowData[];
+	onClose: () => void;
+	onConfirm: () => void;
+	/** On close of the modal, this element will be focused, rather than the trigger element. */
+	pageAlertRef?: HTMLElement | null;
 };
 
 export function ModalConfirmRemoveAccess({
 	isOpen,
-	onConfirm,
-	onClose,
 	itemsToDelete,
+	onClose,
+	onConfirm,
+	pageAlertRef,
 }: ModalConfirmRemoveAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -49,6 +52,7 @@ export function ModalConfirmRemoveAccess({
 
 	return (
 		<Modal
+			elementToFocusOnClose={pageAlertRef}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/StaffMembersTable.tsx
+++ b/yourgov/components/Staff/StaffMembersTable.tsx
@@ -68,7 +68,7 @@ export const StaffMembersTable = ({
 	tableRef,
 }: StaffMembersTableProps) => {
 	const router = useRouter();
-	const pageAlertRef = useRef<HTMLDivElement>(null);
+	const pageAlertElement = useRef<HTMLDivElement>(null);
 
 	const { staffMembersGetState, staffMembersDelete } = useStaffGlobalState();
 
@@ -113,7 +113,7 @@ export const StaffMembersTable = ({
 							setSuccessMessageType(null);
 							router.replace(router.pathname, undefined, { shallow: true });
 						}}
-						ref={pageAlertRef}
+						ref={pageAlertElement}
 						title={`${successTypeToMessageText[successMessageType].titlePrefix} ${updatedStaffMemberName} ${successTypeToMessageText[successMessageType].titleSuffix}`}
 						tone="success"
 					>
@@ -162,9 +162,9 @@ export const StaffMembersTable = ({
 
 					<DataTable
 						headingId={headingId}
-						pageAlertRef={
+						pageAlertElement={
 							successMessageType && updatedStaffMemberName
-								? pageAlertRef?.current
+								? pageAlertElement?.current
 								: undefined
 						}
 						ref={tableRef}

--- a/yourgov/components/Staff/StaffMembersTable.tsx
+++ b/yourgov/components/Staff/StaffMembersTable.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useState } from 'react';
+import { RefObject, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Stack } from '@ag.ds-next/react/src/stack';
 import { Button } from '@ag.ds-next/react/src/button';
@@ -68,6 +68,7 @@ export const StaffMembersTable = ({
 	tableRef,
 }: StaffMembersTableProps) => {
 	const router = useRouter();
+	const pageAlertRef = useRef<HTMLDivElement>(null);
 
 	const { staffMembersGetState, staffMembersDelete } = useStaffGlobalState();
 
@@ -107,13 +108,12 @@ export const StaffMembersTable = ({
 			>
 				{successMessageType && updatedStaffMemberName && (
 					<SectionAlert
-						focusOnUpdate={[successMessageType, updatedStaffMemberName].join(
-							''
-						)}
+						focusOnMount
 						onClose={() => {
 							setSuccessMessageType(null);
 							router.replace(router.pathname, undefined, { shallow: true });
 						}}
+						ref={pageAlertRef}
 						title={`${successTypeToMessageText[successMessageType].titlePrefix} ${updatedStaffMemberName} ${successTypeToMessageText[successMessageType].titleSuffix}`}
 						tone="success"
 					>
@@ -162,6 +162,11 @@ export const StaffMembersTable = ({
 
 					<DataTable
 						headingId={headingId}
+						pageAlertRef={
+							successMessageType && updatedStaffMemberName
+								? pageAlertRef?.current
+								: undefined
+						}
 						ref={tableRef}
 						selectable={selectable}
 					/>

--- a/yourgov/pages/app/licences-and-permits/manage-existing/index.tsx
+++ b/yourgov/pages/app/licences-and-permits/manage-existing/index.tsx
@@ -2,6 +2,7 @@ import { Fragment, ReactElement } from 'react';
 import { PageContent } from '@ag.ds-next/react/content';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Breadcrumbs } from '@ag.ds-next/react/breadcrumbs';
+import { CallToActionLink } from '@ag.ds-next/react/call-to-action';
 import { Column, Columns } from '@ag.ds-next/react/columns';
 import { DocumentTitle } from '../../../../components/DocumentTitle';
 import { AppLayout } from '../../../../components/Layout/AppLayout';
@@ -28,6 +29,9 @@ const Page: NextPageWithLayout = () => {
 						title="Manage existing permits"
 						introduction="Stay compliant by registering for business permits."
 					/>
+					<CallToActionLink href="/app/licences-and-permits/apply-for-new-permit">
+						Apply for a permit
+					</CallToActionLink>
 					<ApplicationHistory />
 
 					<Columns cols={{ xs: 1, sm: 4 }}>


### PR DESCRIPTION
modal: Add `elementToFocusOnClose` prop to allow for manual focus management.
page-alert: Update `focusOnUpdate` to not focus on any falsey value.
section-alert: Update `focusOnUpdate` to not focus on any falsey value.

yourgov: Fix focus issues with Staff table.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1858)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.