### PR TITLE
yourgov: Fix alert focus management in staff and access requests

### DIFF
--- a/.changeset/thick-pans-give.md
+++ b/.changeset/thick-pans-give.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/yourgov': patch
+---
+
+yourgov: Fix alert focus management in staff and access requests.

--- a/yourgov/components/Staff/AccessRequestsTable/AccessRequestsTable.tsx
+++ b/yourgov/components/Staff/AccessRequestsTable/AccessRequestsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
 	Table,
 	TableBatchActionsBar,
@@ -32,7 +32,8 @@ import { ModalConfirmRejectAccess } from './ModalConfirmRejectAccess';
 import { ModalUnavailableFeature } from './ModalUnavailableFeature';
 
 export const AccessRequestsTable = () => {
-	const [focusUpdateTime, setFocusUpdateTime] = useState(0);
+	const pageAlertRef = useRef<HTMLDivElement>(null);
+
 	const { accessRequestsDelete, accessRequestsGetState, accessRequestsUpdate } =
 		useStaffGlobalState();
 	const [rowSelections, setRowSelections] = useState<
@@ -92,7 +93,6 @@ export const AccessRequestsTable = () => {
 		});
 		setItemWithActiveAction(undefined);
 		closeApproveModal();
-		setFocusUpdateTime(Date.now());
 	};
 
 	const onConfirmReject = () => {
@@ -102,7 +102,6 @@ export const AccessRequestsTable = () => {
 		accessRequestsDelete(itemWithActiveAction || items);
 		setItemWithActiveAction(undefined);
 		closeRejectModal();
-		setFocusUpdateTime(Date.now());
 	};
 
 	const isSelectAllCheckboxChecked =
@@ -119,16 +118,23 @@ export const AccessRequestsTable = () => {
 
 	return (
 		<>
-			{successMessageContent && successMessageType && (
+			<Box
+				css={{
+					display:
+						successMessageContent && successMessageType ? 'block' : 'none',
+				}}
+				focusRingFor="all"
+				ref={pageAlertRef}
+				tabIndex={-1}
+			>
 				<SectionAlert
-					focusOnUpdate={focusUpdateTime}
 					onClose={() => {
 						setSuccessMessageContent(undefined);
 					}}
 					title={`Access request for ${
 						Array.isArray(successMessageContent)
 							? successMessageContent.length
-							: `${successMessageContent.firstName} ${successMessageContent.lastName}`
+							: `${successMessageContent?.firstName} ${successMessageContent?.lastName}`
 					} ${plural(
 						Array.isArray(successMessageContent)
 							? successMessageContent.length
@@ -143,7 +149,7 @@ export const AccessRequestsTable = () => {
 						request has been {successMessageType}.
 					</Text>
 				</SectionAlert>
-			)}
+			</Box>
 			<Stack gap={0.5}>
 				{accessRequests.length === 0 ? (
 					<Stack gap={2} alignItems="flex-start" paddingY={1} role="status">
@@ -314,6 +320,7 @@ export const AccessRequestsTable = () => {
 						setItemWithActiveAction(undefined);
 					}}
 					onConfirm={onConfirmApprove}
+					pageAlertElement={pageAlertRef?.current}
 				/>
 
 				<ModalConfirmRejectAccess
@@ -324,6 +331,7 @@ export const AccessRequestsTable = () => {
 						setItemWithActiveAction(undefined);
 					}}
 					onConfirm={onConfirmReject}
+					pageAlertElement={pageAlertRef?.current}
 				/>
 
 				<ModalUnavailableFeature

--- a/yourgov/components/Staff/AccessRequestsTable/ModalConfirmApproveAccess.tsx
+++ b/yourgov/components/Staff/AccessRequestsTable/ModalConfirmApproveAccess.tsx
@@ -10,6 +10,8 @@ export type ModalConfirmApproveAccessProps = {
 	onConfirm: () => void;
 	onClose: () => void;
 	itemsToApprove: StaffMemberAccessRequest | StaffMemberAccessRequest[];
+	/** On close of the modal, this element will be focused, rather than the trigger element. */
+	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmApproveAccess({
@@ -17,6 +19,7 @@ export function ModalConfirmApproveAccess({
 	onConfirm,
 	onClose,
 	itemsToApprove,
+	pageAlertElement,
 }: ModalConfirmApproveAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -45,6 +48,7 @@ export function ModalConfirmApproveAccess({
 
 	return (
 		<Modal
+			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/AccessRequestsTable/ModalConfirmRejectAccess.tsx
+++ b/yourgov/components/Staff/AccessRequestsTable/ModalConfirmRejectAccess.tsx
@@ -10,6 +10,8 @@ export type ModalConfirmRejectAccessProps = {
 	onConfirm: () => void;
 	onClose: () => void;
 	itemsToReject: StaffMemberAccessRequest | StaffMemberAccessRequest[];
+	/** On close of the modal, this element will be focused, rather than the trigger element. */
+	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmRejectAccess({
@@ -17,6 +19,7 @@ export function ModalConfirmRejectAccess({
 	onConfirm,
 	onClose,
 	itemsToReject,
+	pageAlertElement,
 }: ModalConfirmRejectAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -47,6 +50,7 @@ export function ModalConfirmRejectAccess({
 
 	return (
 		<Modal
+			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/StaffMembersTable.tsx
+++ b/yourgov/components/Staff/StaffMembersTable.tsx
@@ -103,7 +103,7 @@ export const StaffMembersTable = ({
 				pageAlertRef.current?.focus();
 			}, 500);
 		}
-	}, [pageAlertRef.current, successMessageType, updatedStaffMemberName]);
+	}, [successMessageType, updatedStaffMemberName]);
 
 	return (
 		<SortAndFilterProvider value={sortAndFilter}>

--- a/yourgov/components/Staff/StaffMembersTable.tsx
+++ b/yourgov/components/Staff/StaffMembersTable.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useRef, useState } from 'react';
+import { RefObject, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Stack } from '@ag.ds-next/react/src/stack';
 import { Button } from '@ag.ds-next/react/src/button';
@@ -68,7 +68,7 @@ export const StaffMembersTable = ({
 	tableRef,
 }: StaffMembersTableProps) => {
 	const router = useRouter();
-	const pageAlertElement = useRef<HTMLDivElement>(null);
+	const pageAlertRef = useRef<HTMLDivElement>(null);
 
 	const { staffMembersGetState, staffMembersDelete } = useStaffGlobalState();
 
@@ -97,6 +97,14 @@ export const StaffMembersTable = ({
 		return updatedStaffMember?.name || '';
 	});
 
+	useEffect(() => {
+		if (successMessageType && updatedStaffMemberName) {
+			setTimeout(() => {
+				pageAlertRef.current?.focus();
+			}, 500);
+		}
+	}, [pageAlertRef.current, successMessageType, updatedStaffMemberName]);
+
 	return (
 		<SortAndFilterProvider value={sortAndFilter}>
 			<DataProvider
@@ -106,19 +114,20 @@ export const StaffMembersTable = ({
 					setUpdatedStaffMemberName,
 				}}
 			>
-				<div
+				<Box
 					css={{
 						display:
 							successMessageType && updatedStaffMemberName ? 'block' : 'none',
 					}}
+					focusRingFor="all"
+					ref={pageAlertRef}
+					tabIndex={-1}
 				>
 					<SectionAlert
-						focusOnMount
 						onClose={() => {
 							setSuccessMessageType(null);
 							router.replace(router.pathname, undefined, { shallow: true });
 						}}
-						ref={pageAlertElement}
 						title={
 							successMessageType
 								? `${successTypeToMessageText[successMessageType].titlePrefix} ${updatedStaffMemberName} ${successTypeToMessageText[successMessageType].titleSuffix}`
@@ -134,7 +143,7 @@ export const StaffMembersTable = ({
 								</Text>
 							)}
 					</SectionAlert>
-				</div>
+				</Box>
 				<Stack gap={0}>
 					<FilterRegion>
 						<FilterBar>
@@ -171,7 +180,7 @@ export const StaffMembersTable = ({
 
 					<DataTable
 						headingId={headingId}
-						pageAlertElement={pageAlertElement?.current}
+						pageAlertElement={pageAlertRef?.current}
 						ref={tableRef}
 						selectable={selectable}
 					/>


### PR DESCRIPTION
Works around the focus management issues in staff members and access requests tables.

Tested all scenarios in VO with Safari & Chrome, VO on iOS, NVDA in Edge and TalkBack on Android.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1865/yourgov)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
