### PR TITLE
yourgov: Fix focus when using staff/access modals

### DIFF
--- a/.changeset/real-pets-argue.md
+++ b/.changeset/real-pets-argue.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/yourgov': minor
+---
+
+yourgov: Support focus management when cancelling staff & access modals.

--- a/yourgov/components/Staff/AccessRequestsTable/AccessRequestsTable.tsx
+++ b/yourgov/components/Staff/AccessRequestsTable/AccessRequestsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
 	Table,
 	TableBatchActionsBar,
@@ -115,6 +115,14 @@ export const AccessRequestsTable = () => {
 			setRowSelections(accessRequests.map(({ id }) => id));
 		}
 	};
+
+	useEffect(() => {
+		if (successMessageContent && successMessageType) {
+			setTimeout(() => {
+				pageAlertRef.current?.focus();
+			}, 500);
+		}
+	}, [successMessageContent, successMessageType]);
 
 	return (
 		<>
@@ -320,7 +328,6 @@ export const AccessRequestsTable = () => {
 						setItemWithActiveAction(undefined);
 					}}
 					onConfirm={onConfirmApprove}
-					pageAlertElement={pageAlertRef?.current}
 				/>
 
 				<ModalConfirmRejectAccess
@@ -331,7 +338,6 @@ export const AccessRequestsTable = () => {
 						setItemWithActiveAction(undefined);
 					}}
 					onConfirm={onConfirmReject}
-					pageAlertElement={pageAlertRef?.current}
 				/>
 
 				<ModalUnavailableFeature

--- a/yourgov/components/Staff/AccessRequestsTable/ModalConfirmApproveAccess.tsx
+++ b/yourgov/components/Staff/AccessRequestsTable/ModalConfirmApproveAccess.tsx
@@ -10,8 +10,6 @@ export type ModalConfirmApproveAccessProps = {
 	onConfirm: () => void;
 	onClose: () => void;
 	itemsToApprove: StaffMemberAccessRequest | StaffMemberAccessRequest[];
-	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmApproveAccess({
@@ -19,7 +17,6 @@ export function ModalConfirmApproveAccess({
 	onConfirm,
 	onClose,
 	itemsToApprove,
-	pageAlertElement,
 }: ModalConfirmApproveAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -48,7 +45,6 @@ export function ModalConfirmApproveAccess({
 
 	return (
 		<Modal
-			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/AccessRequestsTable/ModalConfirmRejectAccess.tsx
+++ b/yourgov/components/Staff/AccessRequestsTable/ModalConfirmRejectAccess.tsx
@@ -10,8 +10,6 @@ export type ModalConfirmRejectAccessProps = {
 	onConfirm: () => void;
 	onClose: () => void;
 	itemsToReject: StaffMemberAccessRequest | StaffMemberAccessRequest[];
-	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmRejectAccess({
@@ -19,7 +17,6 @@ export function ModalConfirmRejectAccess({
 	onConfirm,
 	onClose,
 	itemsToReject,
-	pageAlertElement,
 }: ModalConfirmRejectAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -50,7 +47,6 @@ export function ModalConfirmRejectAccess({
 
 	return (
 		<Modal
-			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/DataTable.tsx
+++ b/yourgov/components/Staff/DataTable.tsx
@@ -33,14 +33,12 @@ const descriptionId = 'data-table-description';
 type DataTableProps = {
 	/** The id of the heading that describes the table */
 	headingId?: string;
-	/** On close of the action modals, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
 	/** Whether the table should be selectable */
 	selectable?: boolean;
 };
 
 export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
-	function DataTable({ headingId, pageAlertElement, selectable }, ref) {
+	function DataTable({ headingId, selectable }, ref) {
 		const { sort, setSort, pagination, resetFilters } =
 			useSortAndFilterContext();
 		const { displayData, loading, totalItems, error } = useDataContext();
@@ -225,7 +223,6 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 												itemId={item.id}
 												key={name}
 												name={name}
-												pageAlertElement={pageAlertElement}
 												rowIndex={rowIndex}
 												selectable={selectable}
 											>
@@ -264,7 +261,7 @@ export const DataTable = forwardRef<HTMLTableElement, DataTableProps>(
 						</TableBody>
 					</Table>
 				</TableWrapper>
-				<DataTableBatchActionsBar pageAlertElement={pageAlertElement} />
+				<DataTableBatchActionsBar />
 			</Stack>
 		);
 	}

--- a/yourgov/components/Staff/DataTableBatchActionsBar.tsx
+++ b/yourgov/components/Staff/DataTableBatchActionsBar.tsx
@@ -12,12 +12,7 @@ import { StaffMemberWithIndex } from './lib/types';
 import { useStaffGlobalState } from './StaffProvider';
 import { ModalConfirmChangeRole } from './ModalConfirmChangeRole';
 
-export const DataTableBatchActionsBar = ({
-	pageAlertElement,
-}: {
-	/** On close of the action modals, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
-}) => {
+export const DataTableBatchActionsBar = () => {
 	const { setSuccessMessageType, setUpdatedStaffMemberName } = useDataContext();
 	const { staffMembersDelete, staffMembersUpdate } = useStaffGlobalState();
 	const { selection, clearRowSelections } = useSortAndFilterContext();
@@ -120,7 +115,6 @@ export const DataTableBatchActionsBar = ({
 					isOpen={modalChangeRoleOpen}
 					onClose={() => setModalChangeRoleOpen(false)}
 					onConfirm={onConfirmChangeRole}
-					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmPauseAccess
@@ -128,7 +122,6 @@ export const DataTableBatchActionsBar = ({
 					itemsToPause={items}
 					onClose={() => setPauseModalOpen(false)}
 					onConfirm={onConfirmPause}
-					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmRemoveAccess
@@ -136,7 +129,6 @@ export const DataTableBatchActionsBar = ({
 					itemsToDelete={items}
 					onClose={() => setRemoveModalOpen(false)}
 					onConfirm={onConfirmRemove}
-					pageAlertElement={pageAlertElement}
 				/>
 			</TableBatchActionsBar>
 		);

--- a/yourgov/components/Staff/DataTableRow.tsx
+++ b/yourgov/components/Staff/DataTableRow.tsx
@@ -48,7 +48,6 @@ export const DataTableRow = ({
 	item,
 	itemId,
 	name,
-	pageAlertElement,
 	rowIndex,
 	selectable,
 }: {
@@ -56,8 +55,6 @@ export const DataTableRow = ({
 	item: StaffMemberWithIndex;
 	itemId: string;
 	name: string;
-	/** On close of the action modals, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
 	rowIndex: number;
 	selectable?: boolean;
 }) => {
@@ -143,7 +140,6 @@ export const DataTableRow = ({
 					isOpen={modalChangeRoleOpen}
 					onClose={() => setModalChangeRoleOpen(false)}
 					onConfirm={onConfirmChangeRole}
-					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmPauseAccess
@@ -151,7 +147,6 @@ export const DataTableRow = ({
 					itemsToPause={item}
 					onClose={() => setPauseModalOpen(false)}
 					onConfirm={onConfirmPause}
-					pageAlertElement={pageAlertElement}
 				/>
 
 				<ModalConfirmRemoveAccess
@@ -159,7 +154,6 @@ export const DataTableRow = ({
 					itemsToDelete={item}
 					onClose={() => setRemoveModalOpen(false)}
 					onConfirm={onConfirmRemove}
-					pageAlertElement={pageAlertElement}
 				/>
 			</TableRow>
 		);

--- a/yourgov/components/Staff/ModalConfirmChangeRole.tsx
+++ b/yourgov/components/Staff/ModalConfirmChangeRole.tsx
@@ -10,8 +10,6 @@ export type ModalConfirmChangeRoleProps = {
 	isOpen: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
-	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
 };
 
 export const ModalConfirmChangeRole = ({
@@ -19,7 +17,6 @@ export const ModalConfirmChangeRole = ({
 	isOpen,
 	onClose,
 	onConfirm,
-	pageAlertElement,
 }: ModalConfirmChangeRoleProps) => {
 	const [submitting, setSubmitting] = useState(false);
 	const [role, setRole] = useState<StaffMemberRole | undefined>(currentRole);
@@ -40,7 +37,6 @@ export const ModalConfirmChangeRole = ({
 
 	return (
 		<Drawer
-			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title="Change role"

--- a/yourgov/components/Staff/ModalConfirmPauseAccess.tsx
+++ b/yourgov/components/Staff/ModalConfirmPauseAccess.tsx
@@ -12,8 +12,6 @@ export type ModalConfirmPauseAccessProps = {
 	itemsToPause: RowData | RowData[];
 	onClose: () => void;
 	onConfirm: () => void;
-	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmPauseAccess({
@@ -21,7 +19,6 @@ export function ModalConfirmPauseAccess({
 	itemsToPause,
 	onClose,
 	onConfirm,
-	pageAlertElement,
 }: ModalConfirmPauseAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -52,7 +49,6 @@ export function ModalConfirmPauseAccess({
 
 	return (
 		<Modal
-			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/ModalConfirmRemoveAccess.tsx
+++ b/yourgov/components/Staff/ModalConfirmRemoveAccess.tsx
@@ -12,8 +12,6 @@ export type ModalConfirmRemoveAccessProps = {
 	itemsToDelete: RowData | RowData[];
 	onClose: () => void;
 	onConfirm: () => void;
-	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	pageAlertElement?: HTMLElement | null;
 };
 
 export function ModalConfirmRemoveAccess({
@@ -21,7 +19,6 @@ export function ModalConfirmRemoveAccess({
 	itemsToDelete,
 	onClose,
 	onConfirm,
-	pageAlertElement,
 }: ModalConfirmRemoveAccessProps) {
 	const [submitting, setSubmitting] = useState(false);
 
@@ -52,7 +49,6 @@ export function ModalConfirmRemoveAccess({
 
 	return (
 		<Modal
-			elementToFocusOnClose={pageAlertElement}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}

--- a/yourgov/components/Staff/StaffMembersTable.tsx
+++ b/yourgov/components/Staff/StaffMembersTable.tsx
@@ -180,7 +180,6 @@ export const StaffMembersTable = ({
 
 					<DataTable
 						headingId={headingId}
-						pageAlertElement={pageAlertRef?.current}
 						ref={tableRef}
 						selectable={selectable}
 					/>


### PR DESCRIPTION
yourgov: Support focus management when cancelling staff & access modals

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1870/yourgov)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
