### PR TITLE
yourgov: Fix mobile by adding correct viewport meta tag

### DIFF
--- a/.changeset/happy-rabbits-wonder.md
+++ b/.changeset/happy-rabbits-wonder.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/yourgov': patch
+---
+
+yourgov: Fix mobile rendering by adding correct viewport meta tag.

--- a/yourgov/pages/_app.tsx
+++ b/yourgov/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import { useEffect, useState, type ReactElement, type ReactNode } from 'react';
 import { theme } from '@ag.ds-next/react/ag-branding';
 import { Core } from '@ag.ds-next/react/core';
@@ -33,27 +34,32 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
 	// Use the layout defined at the page level, if available
 	const getLayout = Component.getLayout ?? ((page) => page);
 	return (
-		<Core theme={theme} linkComponent={LinkComponent}>
-			<AuthProvider>
-				<LinkedBusinessesProvider>
-					{isAlertVisible && (
-						<GlobalAlert
-							tone="info"
-							title="We are planning a maintenance outage to upgrade the service on 22 November 2024 from 12pm to 5pm AEDT"
-							onClose={() => {
-								safeSessionStorage?.setItem('isGlobalAlertVisible', 'false');
-								setIsAlertVisible(false);
-							}}
-						>
-							<Text as="p">
-								You won’t be able to access yourGov during that time. We
-								apologise for any inconvenience.
-							</Text>
-						</GlobalAlert>
-					)}
-					{getLayout(<Component {...pageProps} />)}
-				</LinkedBusinessesProvider>
-			</AuthProvider>
-		</Core>
+		<>
+			<Head>
+				<meta name="viewport" content="width=device-width, initial-scale=1" />
+			</Head>
+			<Core theme={theme} linkComponent={LinkComponent}>
+				<AuthProvider>
+					<LinkedBusinessesProvider>
+						{isAlertVisible && (
+							<GlobalAlert
+								tone="info"
+								title="We are planning a maintenance outage to upgrade the service on 22 November 2024 from 12pm to 5pm AEDT"
+								onClose={() => {
+									safeSessionStorage?.setItem('isGlobalAlertVisible', 'false');
+									setIsAlertVisible(false);
+								}}
+							>
+								<Text as="p">
+									You won’t be able to access yourGov during that time. We
+									apologise for any inconvenience.
+								</Text>
+							</GlobalAlert>
+						)}
+						{getLayout(<Component {...pageProps} />)}
+					</LinkedBusinessesProvider>
+				</AuthProvider>
+			</Core>
+		</>
 	);
 }


### PR DESCRIPTION
When the staff table loaded on mobile, everything was tiny. This fixes that

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1875)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
