### PR TITLE
progress-indicator: Only set active step when path matches exactly or has a sub-step

### DIFF
--- a/.changeset/great-snails-dress.md
+++ b/.changeset/great-snails-dress.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+progress-indicator: Only set active step when path matches exactly or has a sub-step.

--- a/packages/react/src/progress-indicator/ProgressIndicator.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicator.tsx
@@ -87,11 +87,7 @@ export const ProgressIndicator = ({
 					!!activePathMatcher &&
 					(activePath === activePathMatcher || hasActiveSubStep);
 
-				const isActive =
-					isActiveFromLegacyDoingStatus ||
-					hasActiveSubStep ||
-					isActivePath ||
-					false;
+				const isActive = isActiveFromLegacyDoingStatus || isActivePath || false;
 
 				const levelTwoItemsWithIsActive =
 					'items' in item

--- a/packages/react/src/progress-indicator/ProgressIndicator.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicator.tsx
@@ -76,10 +76,22 @@ export const ProgressIndicator = ({
 				const isActiveFromLegacyDoingStatus = item.status === 'doing';
 
 				const activePathMatcher = 'href' in item ? item.href : item.label;
-				const isActivePath =
-					!!activePathMatcher && activePath?.startsWith(activePathMatcher);
+				const activePathMatcherWithTrailingSlash = `${activePathMatcher}${
+					activePathMatcher?.endsWith('/') ? '' : '/'
+				}`;
+				const hasActiveSubStep = !!activePath?.split(
+					activePathMatcherWithTrailingSlash
+				)[1]?.length;
 
-				const isActive = isActiveFromLegacyDoingStatus || isActivePath || false;
+				const isActivePath =
+					!!activePathMatcher &&
+					(activePath === activePathMatcher || hasActiveSubStep);
+
+				const isActive =
+					isActiveFromLegacyDoingStatus ||
+					hasActiveSubStep ||
+					isActivePath ||
+					false;
 
 				const levelTwoItemsWithIsActive =
 					'items' in item


### PR DESCRIPTION
If a pathname matched the start of two separate steps, both would be the active step as indicated in the "Before" image below. This PR forces the check to be either an exact match or a sub-step, i.e. denoted with `'/'`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1876)

**Before:**

![image](https://github.com/user-attachments/assets/05b216c1-73c5-4c1b-ba78-99b3a6503500)

**After:**

![image](https://github.com/user-attachments/assets/6f0845fd-f341-46d8-adbc-74df38c13176)


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets

**Creating new component**

- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Preconstruct entrypoint has been created (run `yarn` in the root of the repo to do this)
- [ ] Changeset file includes a minor
- [ ] Export components for docs site and Playroom (`docs/components/designSystemComponents.tsx`)
- [ ] Add component to Kitchen Sink (`.storybook/stories/KitchenSink.tsx`)
- [ ] Add snippets to Playroom (`docs/playroom/snippets.ts`)
- [ ] Add pictogram to Docs (`docs/components/pictograms/index.tsx`)
