### PR TITLE
tags: Set background to body

### DIFF
--- a/.changeset/tiny-emus-teach.md
+++ b/.changeset/tiny-emus-teach.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+tags: Set background to "body".

--- a/packages/react/src/tags/Tag.tsx
+++ b/packages/react/src/tags/Tag.tsx
@@ -27,6 +27,7 @@ export const Tag = ({
 		<Flex
 			alignItems="center"
 			as="span"
+			background="body"
 			border
 			color={href ? 'action' : 'text'}
 			css={{

--- a/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
+++ b/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Tags With links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-12vpy0u-boxStyles-Tag"
+          class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
             class="css-1qb2lpt-TextLink-boxStyles"
@@ -31,7 +31,7 @@ exports[`Tags With links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-12vpy0u-boxStyles-Tag"
+          class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
             class="css-1qb2lpt-TextLink-boxStyles"
@@ -45,7 +45,7 @@ exports[`Tags With links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-12vpy0u-boxStyles-Tag"
+          class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
             class="css-1qb2lpt-TextLink-boxStyles"
@@ -77,7 +77,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-12vpy0u-boxStyles-Tag"
+          class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
             class="css-1qb2lpt-TextLink-boxStyles"
@@ -122,7 +122,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-12vpy0u-boxStyles-Tag"
+          class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
             class="css-1qb2lpt-TextLink-boxStyles"
@@ -167,7 +167,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-12vpy0u-boxStyles-Tag"
+          class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
             class="css-1qb2lpt-TextLink-boxStyles"
@@ -230,7 +230,7 @@ exports[`Tags Without links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-a8btkt-boxStyles-Tag"
+          class="css-impmck-boxStyles-Tag"
         >
           <span
             class="css-79i25n-boxStyles"
@@ -243,7 +243,7 @@ exports[`Tags Without links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-a8btkt-boxStyles-Tag"
+          class="css-impmck-boxStyles-Tag"
         >
           <span
             class="css-79i25n-boxStyles"
@@ -256,7 +256,7 @@ exports[`Tags Without links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-a8btkt-boxStyles-Tag"
+          class="css-impmck-boxStyles-Tag"
         >
           <span
             class="css-79i25n-boxStyles"


### PR DESCRIPTION
It was flagged that tags should have the background set for when they're used in coloured components.

[Before](https://design-system.agriculture.gov.au/develop/playroom/#?code=N4Igxg9gJgpiBcIA8BlALgQzAawAQHMMAHAXmAEYBfAPgB0A7XXVGMNASwnoEEAbGAE5pcHNPxK0QAORgB3ERnwBnSSK4wJIWRgH129fJLqMmzACqKludmhgBbJWQDawXLwwAjGL3i5JAMQgIVUoAGlxXdy8fPxAAIR0Q8MjPb19JBIAvEIBdSlwAemMmJAKUVg4uPkE0YuY4iAAPXCgdbDqShuaPLGx8AQgAV3ooTQ9oAE9VIgwoKH18MioO0yQLZWtbB2cU6PSQQOCQXDCIt1SYjMTj09202Kzc-KKGU2YCrrrSz4ZX%2BqaWm0Vkgurgejh%2BkMRmNJtNZvMDEsaH83iw2JwePwhCIbOJJDJ5JhlKo0OpNNpdAsjCi3uZLDTaZt7I5gC5zntYockmcovcrgJuXdLvEMNkbnkGaYXiZUWUKhjqkJgR8ml8VY1jKV0L1jCBQlp2FA0AALJQIJwAVgA7AA2PJAA)

[After](https://design-system.agriculture.gov.au/pr-preview/pr-1879/playroom/#?code=N4Igxg9gJgpiBcIA8BlALgQzAawAQHMMAHAXmAEYBfAPgB0A7XXVGMNASwnoEEAbGAE5pcHNPxK0QAORgB3ERnwBnSSK4wJIWRgH129fJLqMmzACqKludmhgBbJWQDawXLwwAjGL3i5JAMQgIVUoAGlxXdy8fPxAAIR0Q8MjPb19JBIAvEIBdSlwAemMmJAKUVg4uPkE0YuY4iAAPXCgdbDqShuaPLGx8AQgAV3ooTQ9oAE9VIgwoKH18MioO0yQLZWtbB2cU6PSQQOCQXDCIt1SYjMTj09202Kzc-KKGU2YCrrrSz4ZX%2BqaWm0Vkgurgejh%2BkMRmNJtNZvMDEsaH83iw2JwePwhCIbOJJDJ5JhlKo0OpNNpdAsjCi3uZLDTaZt7I5gC5zntYockmcovcrgJuXdLvEMNkbnkGaYXiZUWUKhjqkJgR8ml8VY1jKV0L1jCBQlp2FA0AALJQIJwAVgA7AA2PJAA)


[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1879)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
