### PR TITLE
docs: Add role & unique aria-label to live code editors

### DIFF
--- a/.changeset/kind-mayflies-suffer.md
+++ b/.changeset/kind-mayflies-suffer.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': minor
+---
+
+docs: Add a unique `aria-label` to live code editors.

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -117,7 +117,7 @@ function LiveCode({
 			pre.ariaLabel = `Live code editor ${id}`;
 			pre.role = 'region';
 		}
-	}, []);
+	}, [id]);
 
 	// Using `Box` here instead of Code snippets with popovers (date picker, combobox, dropdown menu etc) need overflow
 	return (

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -6,6 +6,7 @@ import React, {
 	useRef,
 	KeyboardEvent,
 	useContext,
+	useEffect,
 } from 'react';
 import { LiveProvider, LiveEditor, LivePreview, LiveContext } from 'react-live';
 import { createUrl } from 'playroom/utils';
@@ -63,6 +64,7 @@ function LiveCode({
 	exampleContentHeading?: string;
 	exampleContentHeadingType?: 'h2' | 'h3' | 'h4';
 }) {
+	const liveEditorRef = useRef<HTMLDivElement>(null);
 	const liveCodeToggleButton = useRef<HTMLButtonElement>(null);
 	const live = useContext(LiveContext);
 
@@ -107,6 +109,14 @@ function LiveCode({
 		},
 		[toggleIsCodeVisible]
 	);
+
+	// LiveEditor doesn't support aria-label, so we have to do it the DOM way
+	useEffect(() => {
+		const pre = liveEditorRef.current?.querySelector('pre');
+		if (pre) {
+			pre.ariaLabel = `Live code editor ${id}`;
+		}
+	}, []);
 
 	// Using `Box` here instead of Code snippets with popovers (date picker, combobox, dropdown menu etc) need overflow
 	return (
@@ -169,10 +179,10 @@ function LiveCode({
 				css={packs.print.visible}
 				palette="dark"
 				onKeyDown={onLiveEditorContainerKeyDown}
+				ref={liveEditorRef}
 			>
 				<LiveEditor
 					tabMode="focus"
-					aria-label="Live code editor, press the escape key to leave the editor"
 					theme={prismTheme}
 					code={live.code}
 					language={live.language}

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -115,6 +115,7 @@ function LiveCode({
 		const pre = liveEditorRef.current?.querySelector('pre');
 		if (pre) {
 			pre.ariaLabel = `Live code editor ${id}`;
+			pre.role = 'region';
 		}
 	}, []);
 

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -115,6 +115,8 @@ function LiveCode({
 		const pre = liveEditorRef.current?.querySelector('pre');
 		if (pre) {
 			pre.ariaLabel = `Live code editor ${id}`;
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Property 'role' does not exist on type 'HTMLPreElement'
 			pre.role = 'region';
 		}
 	}, [id]);


### PR DESCRIPTION
The audit suggested that we add a unique label to live code editors

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1881)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets