### PR TITLE
time-input: Handle am/pm when separated from times with a space

### DIFF
--- a/.changeset/six-poems-glow.md
+++ b/.changeset/six-poems-glow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+time-input: Correctly handle "am" and "pm" when separated from times with a space.

--- a/packages/react/src/time-input/utils.test.ts
+++ b/packages/react/src/time-input/utils.test.ts
@@ -18,6 +18,7 @@ describe('isValidTime', () => {
 		expect(isValidTime('24')).toEqual(true);
 		expect(isValidTime('9')).toEqual(true);
 		expect(isValidTime('9:00')).toEqual(true);
+		expect(isValidTime('9.00')).toEqual(true);
 		expect(isValidTime('9am')).toEqual(true);
 		expect(isValidTime('9pm')).toEqual(true);
 		expect(isValidTime('9p')).toEqual(true);
@@ -60,14 +61,84 @@ describe('formatTime', () => {
 		expect(formatTime('0', 'HH:mm')).toEqual('00:00');
 	});
 
-	test('Single or double-digits greater than 12 return time in pm', () => {
+	test('Double-digits greater than 12 return time in pm', () => {
 		for (let i = 13; i < 24; i += 1) {
 			expect(formatTime(`${i}`, 'h:mm aaa')).toEqual(`${i - 12}:00 pm`);
 			expect(formatTime(`${i}`, 'hh:mm aaa')).toEqual(
 				`${i - 12}:00 pm`.padStart(8, '0')
 			);
-
 			expect(formatTime(`${i}`, 'HH:mm')).toEqual(`${i}:00`.padStart(5, '0'));
+		}
+	});
+
+	test('Single or double-digits less than 12 with am suffix return time in am', () => {
+		for (let i = 1; i < 12; i += 1) {
+			expect(formatTime(`${i} am`, 'h:mm aaa')).toEqual(`${i}:00 am`);
+			expect(formatTime(`${i}am`, 'h:mm aaa')).toEqual(`${i}:00 am`);
+			expect(formatTime(`${i} am`, 'hh:mm aaa')).toEqual(
+				`${i}:00 am`.padStart(8, '0')
+			);
+			expect(formatTime(`${i}am`, 'hh:mm aaa')).toEqual(
+				`${i}:00 am`.padStart(8, '0')
+			);
+			expect(formatTime(`${i} am`, 'HH:mm')).toEqual(
+				`${i}:00`.padStart(5, '0')
+			);
+			expect(formatTime(`${i}am`, 'HH:mm')).toEqual(`${i}:00`.padStart(5, '0'));
+		}
+	});
+
+	test('0 with am suffix returns 12:00 am', () => {
+		expect(formatTime('0 am', 'h:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('0am', 'h:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('0 am', 'hh:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('0am', 'hh:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('0 am', 'HH:mm')).toEqual('00:00');
+		expect(formatTime('0am', 'HH:mm')).toEqual('00:00');
+	});
+
+	test('12 with am suffix returns 12:00 am', () => {
+		expect(formatTime('12 am', 'h:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('12am', 'h:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('12 am', 'hh:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('12am', 'hh:mm aaa')).toEqual('12:00 am');
+		expect(formatTime('12 am', 'HH:mm')).toEqual('00:00');
+		expect(formatTime('12am', 'HH:mm')).toEqual('00:00');
+	});
+
+	test('Single or double-digits less than 12 with pm suffix return time in pm', () => {
+		for (let i = 1; i < 12; i += 1) {
+			expect(formatTime(`${i} pm`, 'h:mm aaa')).toEqual(`${i}:00 pm`);
+			expect(formatTime(`${i}pm`, 'h:mm aaa')).toEqual(`${i}:00 pm`);
+			expect(formatTime(`${i} pm`, 'hh:mm aaa')).toEqual(
+				`${i}:00 pm`.padStart(8, '0')
+			);
+			expect(formatTime(`${i}pm`, 'hh:mm aaa')).toEqual(
+				`${i}:00 pm`.padStart(8, '0')
+			);
+			expect(formatTime(`${i} pm`, 'HH:mm')).toEqual(
+				`${i + 12}:00`.padStart(5, '0')
+			);
+			expect(formatTime(`${i}pm`, 'HH:mm')).toEqual(
+				`${i + 12}:00`.padStart(5, '0')
+			);
+		}
+	});
+
+	test('Double-digits greater than 12 with pm suffix return time in pm', () => {
+		for (let i = 13; i < 24; i += 1) {
+			expect(formatTime(`${i} pm`, 'h:mm aaa')).toEqual(`${i - 12}:00 pm`);
+			expect(formatTime(`${i}pm`, 'h:mm aaa')).toEqual(`${i - 12}:00 pm`);
+			expect(formatTime(`${i} pm`, 'hh:mm aaa')).toEqual(
+				`${i - 12}:00 pm`.padStart(8, '0')
+			);
+			expect(formatTime(`${i}pm`, 'hh:mm aaa')).toEqual(
+				`${i - 12}:00 pm`.padStart(8, '0')
+			);
+			expect(formatTime(`${i} pm`, 'HH:mm')).toEqual(
+				`${i}:00`.padStart(5, '0')
+			);
+			expect(formatTime(`${i}pm`, 'HH:mm')).toEqual(`${i}:00`.padStart(5, '0'));
 		}
 	});
 
@@ -75,6 +146,15 @@ describe('formatTime', () => {
 		expect(formatTime('12', 'h:mm aaa')).toEqual('12:00 pm');
 		expect(formatTime('12', 'hh:mm aaa')).toEqual('12:00 pm');
 		expect(formatTime('12', 'HH:mm')).toEqual('12:00');
+	});
+
+	test('12 with pm suffix returns 12:00 pm', () => {
+		expect(formatTime('12 pm', 'h:mm aaa')).toEqual('12:00 pm');
+		expect(formatTime('12pm', 'h:mm aaa')).toEqual('12:00 pm');
+		expect(formatTime('12 pm', 'hh:mm aaa')).toEqual('12:00 pm');
+		expect(formatTime('12pm', 'hh:mm aaa')).toEqual('12:00 pm');
+		expect(formatTime('12 pm', 'HH:mm')).toEqual('12:00');
+		expect(formatTime('12pm', 'HH:mm')).toEqual('12:00');
 	});
 
 	test('24 returns 12:00 am', () => {
@@ -126,23 +206,6 @@ describe('formatTime', () => {
 		expect(formatTime('131500999', 'h:mm aaa')).toEqual('1:15 pm');
 		expect(formatTime('143015999', 'h:mm aaa')).toEqual('2:30 pm');
 		expect(formatTime('154530999', 'h:mm aaa')).toEqual('3:45 pm');
-	});
-
-	test('3am returns 3:00 am', () => {
-		expect(formatTime('3am', 'h:mm aaa')).toEqual('3:00 am');
-	});
-
-	test('3pm returns 3:00 pm', () => {
-		expect(formatTime('3pm', 'h:mm aaa')).toEqual('3:00 pm');
-		expect(formatTime('3p', 'h:mm aaa')).toEqual('3:00 pm');
-	});
-
-	test('12am returns 12:00 am', () => {
-		expect(formatTime('12am', 'h:mm aaa')).toEqual('12:00 am');
-	});
-
-	test('12pm returns 12:00 pm', () => {
-		expect(formatTime('12pm', 'h:mm aaa')).toEqual('12:00 pm');
 	});
 
 	test('Colon-separators work', () => {

--- a/packages/react/src/time-input/utils.ts
+++ b/packages/react/src/time-input/utils.ts
@@ -7,11 +7,12 @@ export const formatTime = (timeString = '', timeFormat: TimeFormat) => {
 	}
 
 	const date = new Date();
+	const trimmedTimeString = timeString.replace(/\s/g, '');
 	const time = (
-		timeString.match(/\d+/) !== null
-			? timeString.replace(/\s/g, '').length === 3
-				? timeString.match(/(\w)(\w{1,2})/)?.slice(1) ?? []
-				: timeString.match(/\d{1,2}/gi) ?? []
+		trimmedTimeString.match(/\d+/) !== null
+			? trimmedTimeString.length === 3
+				? trimmedTimeString.match(/(\w)(\w{1,2})/)?.slice(1) ?? []
+				: trimmedTimeString.match(/\d{1,2}/gi) ?? []
 			: []
 	).map((digit) => Number(digit) | 0);
 


### PR DESCRIPTION
We discovered that users tried to type "3 pm" which then incorrectly converted to "12:00 am". This fixes that.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1886)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
