### PR TITLE
file-input, file-upload: Announce optional in button label

### DIFF
--- a/.changeset/five-toys-change.md
+++ b/.changeset/five-toys-change.md
@@ -2,4 +2,6 @@
 '@ag.ds-next/react': patch
 ---
 
-file-input: Focus button after change event to workaround IOS VoiceOver bug.
+file-input: Include secondary label in button announcement, e.g. (optional).
+
+file-upload: Include secondary label in button announcement, e.g. (optional).

--- a/.changeset/five-toys-change.md
+++ b/.changeset/five-toys-change.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+file-input: Focus button after change event to workaround IOS VoiceOver bug.

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -1,6 +1,7 @@
-import { ElementType, PropsWithChildren, useMemo } from 'react';
+import { ElementType, PropsWithChildren } from 'react';
 import { Box } from '../box';
 import { Text } from '../text';
+import { useSecondaryLabel } from './useSecondaryLabel';
 
 export type FieldLabelProps = PropsWithChildren<{
 	as?: ElementType;
@@ -25,26 +26,24 @@ export const FieldLabel = ({
 	id,
 	htmlFor,
 	required,
-	secondaryLabel: secondaryLabelProp,
+	secondaryLabel,
 	hideOptionalLabel,
 }: FieldLabelProps) => {
-	const secondaryLabel = useMemo(() => {
-		return [
-			secondaryLabelProp,
-			hideOptionalLabel || required ? null : '(optional)',
-		]
-			.filter(Boolean)
-			.join(' ');
-	}, [required, secondaryLabelProp, hideOptionalLabel]);
+	const secondaryLabelWithOptional = useSecondaryLabel({
+		hideOptionalLabel,
+		required,
+		secondaryLabel,
+	});
+
 	return (
 		<Box as={as} id={id} htmlFor={htmlFor} className={className}>
 			<Text as="span" fontWeight="bold">
 				{children}
 			</Text>
-			{secondaryLabel ? (
+			{secondaryLabelWithOptional ? (
 				<Text as="span" color="muted">
 					{' '}
-					{secondaryLabel}
+					{secondaryLabelWithOptional}
 				</Text>
 			) : null}
 		</Box>

--- a/packages/react/src/field/useSecondaryLabel.tsx
+++ b/packages/react/src/field/useSecondaryLabel.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { FieldLabelProps } from './FieldLabel';
+
+export const useSecondaryLabel = ({
+	hideOptionalLabel,
+	required,
+	secondaryLabel,
+}: Partial<
+	Pick<FieldLabelProps, 'hideOptionalLabel' | 'required' | 'secondaryLabel'>
+>) => {
+	return useMemo(() => {
+		return [secondaryLabel, hideOptionalLabel || required ? null : '(optional)']
+			.filter(Boolean)
+			.join(' ');
+	}, [required, secondaryLabel, hideOptionalLabel]);
+};

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -16,6 +16,7 @@ import { AcceptedFileMimeTypes } from '../file-upload';
 import { fileTypeMapping } from '../file-upload/utils';
 import { Stack } from '../stack';
 import { Text } from '../text';
+import { useSecondaryLabel } from '../field/useSecondaryLabel';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
 
@@ -79,9 +80,6 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		// Called on the hidden input to manage the selected file(s)
 		const onChange = useCallback(
 			(event: ChangeEvent<HTMLInputElement>) => {
-				setTimeout(() => {
-					visibleButtonRef.current?.focus();
-				}, 0);
 				onChangeProp?.(event);
 				if (!event.target.files) return;
 				setFileNames(Array.from(event.target.files).map((file) => file.name));
@@ -141,11 +139,17 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		const fallbackHint =
 			hint || (accept && `Files accepted: ${acceptedFileExtensions}`);
 
+		const secondaryLabelWithOptional = useSecondaryLabel({
+			hideOptionalLabel,
+			required,
+		});
+
 		const fileOrFiles = multiple ? 'files' : 'file';
 		const buttonLabel = `Select ${fileOrFiles}`;
 		const ariaLabel = [
 			buttonLabel,
 			label,
+			secondaryLabelWithOptional,
 			required && 'required',
 			invalid && 'invalid',
 			getSelectedFilesMessage({ fileNames, fileOrFiles }),

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -79,7 +79,9 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		// Called on the hidden input to manage the selected file(s)
 		const onChange = useCallback(
 			(event: ChangeEvent<HTMLInputElement>) => {
-				visibleButtonRef.current?.focus();
+				setTimeout(() => {
+					visibleButtonRef.current?.focus();
+				}, 0);
 				onChangeProp?.(event);
 				if (!event.target.files) return;
 				setFileNames(Array.from(event.target.files).map((file) => file.name));

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -79,6 +79,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		// Called on the hidden input to manage the selected file(s)
 		const onChange = useCallback(
 			(event: ChangeEvent<HTMLInputElement>) => {
+				visibleButtonRef.current?.focus();
 				onChangeProp?.(event);
 				if (!event.target.files) return;
 				setFileNames(Array.from(event.target.files).map((file) => file.name));

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
     >
       <button
         aria-describedby="field-:r2:-message"
-        aria-label="Select file, Example, invalid, No file selected"
+        aria-label="Select file, Example, (optional), invalid, No file selected"
         class="css-18q2kyp-BaseButton-Button"
         id="field-:r2:"
         type="button"
@@ -116,7 +116,7 @@ exports[`FileInput renders correctly 1`] = `
       class="css-5mk7dj-boxStyles"
     >
       <button
-        aria-label="Select file, Example, No file selected"
+        aria-label="Select file, Example, (optional), No file selected"
         class="css-18q2kyp-BaseButton-Button"
         id="field-:r0:"
         type="button"

--- a/packages/react/src/file-input/docs/overview.mdx
+++ b/packages/react/src/file-input/docs/overview.mdx
@@ -69,7 +69,7 @@ The usage of `hideOptionalLabel` should be reserved for inputs that filter data 
 Use the `invalid` prop to indicate if the user input is invalid.
 
 ```jsx live
-<FileInput label="Passport" invalid message="Passport is invalid" />
+<FileInput label="Passport" invalid message="Passport must be added" required />
 ```
 
 ## Accept

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -17,6 +17,7 @@ import { SectionAlert } from '../section-alert';
 import { Stack } from '../stack';
 import { Text } from '../text';
 import { Box } from '../box';
+import { useSecondaryLabel } from '../field/useSecondaryLabel';
 import { FileUploadExistingFileList } from './FileUploadExistingFileList';
 import { FileUploadFileList } from './FileUploadFileList';
 import {
@@ -267,10 +268,16 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			? `${fallbackId}-accepted-files-desc`
 			: '';
 
+		const secondaryLabelWithOptional = useSecondaryLabel({
+			hideOptionalLabel,
+			required,
+		});
+
 		const buttonLabel = `Select ${fileOrFiles}`;
 		const ariaLabel = [
 			buttonLabel,
 			label,
+			secondaryLabelWithOptional,
 			required && 'required',
 			invalid && 'invalid',
 			fileSummaryText,

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`FileUpload 1 selected file renders correctly 1`] = `
           </div>
           <button
             aria-describedby="field-:r9:-hint"
-            aria-label="Select file, Upload file, 1 file selected"
+            aria-label="Select file, Upload file, (optional), 1 file selected"
             class="css-1qjel8e-BaseButton-Button"
             id="field-:r9:"
             type="button"
@@ -316,7 +316,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
           </div>
           <button
             aria-describedby="field-:r1:-hint"
-            aria-label="Select file, Upload file"
+            aria-label="Select file, Upload file, (optional)"
             class="css-1qjel8e-BaseButton-Button"
             id="field-:r1:"
             type="button"
@@ -432,7 +432,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
           </div>
           <button
             aria-describedby="field-:rd:-hint"
-            aria-label="Select file, Upload file, 2 files selected"
+            aria-label="Select file, Upload file, (optional), 2 files selected"
             class="css-1qjel8e-BaseButton-Button"
             id="field-:rd:"
             type="button"
@@ -794,7 +794,7 @@ exports[`FileUpload Multiple, maxSize and accepted file extensions renders corre
           </div>
           <button
             aria-describedby="field-:r5:-hint :r4:-file-size-desc :r4:-accepted-files-desc"
-            aria-label="Select files, Upload file"
+            aria-label="Select files, Upload file, (optional)"
             class="css-1qjel8e-BaseButton-Button"
             id="field-:r5:"
             type="button"


### PR DESCRIPTION
Optional file inputs and file uploads were not being announced

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1891)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
