### PR TITLE
section-alert: Improve announcements across screen readers

### DIFF
--- a/.changeset/gentle-socks-impress.md
+++ b/.changeset/gentle-socks-impress.md
@@ -2,4 +2,6 @@
 '@ag.ds-next/react': minor
 ---
 
+icon: Add `id` as allowed prop.
+
 section-alert: Assign `role` and `aria-label` to improve announcements across screen readers.

--- a/.changeset/gentle-socks-impress.md
+++ b/.changeset/gentle-socks-impress.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+section-alert: Assign `role` and `aria-label` to improve announcements across screen readers.

--- a/packages/react/src/icon/Icon.tsx
+++ b/packages/react/src/icon/Icon.tsx
@@ -44,6 +44,7 @@ export type IconProps = {
 	'aria-label'?: NativeSvgProps['aria-label'];
 	className?: string;
 	color?: IconColor;
+	id?: NativeSvgProps['id'];
 	size?: ResponsiveProp<IconSize>;
 	style?: NativeSvgProps['style'];
 	weight?: IconWeight;
@@ -55,6 +56,7 @@ export const createIcon = (children: ReactNode, name: string) => {
 		'aria-label': ariaLabel,
 		className,
 		color,
+		id,
 		size = 'md',
 		style,
 		weight = 'regular',
@@ -66,14 +68,10 @@ export const createIcon = (children: ReactNode, name: string) => {
 		);
 		return (
 			<svg
-				// Note the width and height attribute is a fallback for older browsers.
-				// This may not be required and could potentially be removed.
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
+				aria-hidden={ariaHidden}
+				aria-label={ariaLabel}
+				className={className}
 				clipRule="evenodd"
-				fillRule="evenodd"
-				xmlns="http://www.w3.org/2000/svg"
 				css={mq({
 					color: color ? iconColors[color] : 'currentcolor',
 					fill: 'none',
@@ -85,12 +83,17 @@ export const createIcon = (children: ReactNode, name: string) => {
 					strokeWidth: resolvedWeight,
 					width: resolvedSize,
 				})}
+				fillRule="evenodd"
+				focusable="false"
+				// Note the width and height attribute is a fallback for older browsers.
+				// This may not be required and could potentially be removed.
+				height="24"
+				id={id}
 				role="img"
 				style={style}
-				className={className}
-				focusable="false"
-				aria-hidden={ariaHidden}
-				aria-label={ariaLabel}
+				viewBox="0 0 24 24"
+				width="24"
+				xmlns="http://www.w3.org/2000/svg"
 			>
 				{children}
 			</svg>

--- a/packages/react/src/section-alert/SectionAlert.test.tsx
+++ b/packages/react/src/section-alert/SectionAlert.test.tsx
@@ -30,13 +30,18 @@ describe('SectionAlert', () => {
 					const { container } = renderSectionAlert({ tone });
 					expect(container).toHTMLValidate({
 						extends: ['html-validate:recommended'],
+						rules: {
+							'prefer-native-element': 'off',
+							// react 18s `useId` break this rule
+							'valid-id': 'off',
+						},
 					});
 				});
 			});
 		});
 	}
 
-	describe(`with a description`, () => {
+	describe('with a description', () => {
 		it('renders correctly', () => {
 			const { container } = renderSectionAlert({
 				children: <Text as="p">Section alert description text</Text>,
@@ -49,11 +54,16 @@ describe('SectionAlert', () => {
 			});
 			expect(container).toHTMLValidate({
 				extends: ['html-validate:recommended'],
+				rules: {
+					'prefer-native-element': 'off',
+					// react 18s `useId` break this rule
+					'valid-id': 'off',
+				},
 			});
 		});
 	});
 
-	describe(`which is closable`, () => {
+	describe('which is closable', () => {
 		const onClose = jest.fn();
 		const onDismiss = jest.fn();
 
@@ -69,6 +79,11 @@ describe('SectionAlert', () => {
 			});
 			expect(container).toHTMLValidate({
 				extends: ['html-validate:recommended'],
+				rules: {
+					'prefer-native-element': 'off',
+					// react 18s `useId` break this rule
+					'valid-id': 'off',
+				},
 			});
 		});
 		it('calls the onClose function when clicked', () => {

--- a/packages/react/src/section-alert/SectionAlert.tsx
+++ b/packages/react/src/section-alert/SectionAlert.tsx
@@ -4,6 +4,7 @@ import {
 	MouseEventHandler,
 	ReactNode,
 } from 'react';
+import { visuallyHiddenStyles } from '../a11y';
 import { useId } from '../core';
 import { useFocus } from '../core/utils/useFocus';
 import { Flex } from '../flex';
@@ -59,16 +60,16 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 			focusOnUpdate,
 			forwardedRef,
 		});
-		const { childrenId, iconId, titleId } = useSectionAlertIds(id);
+		const { childrenId, titleId, toneId } = useSectionAlertIds(id);
 
-		const Icon = sectionAlertIconMap[tone];
+		const icon = sectionAlertIconMap[tone];
 		const closeHandler = getOptionalCloseHandler(onClose, onDismiss);
 
 		return (
 			<Flex
 				{...props}
 				alignItems="center"
-				aria-labelledby={`${iconId} ${titleId} ${children ? childrenId : ''}`}
+				aria-labelledby={`${toneId} ${titleId} ${children ? childrenId : ''}`}
 				background={tone}
 				borderColor={tone}
 				borderLeft
@@ -80,12 +81,22 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 				justifyContent="space-between"
 				padding={1}
 				ref={ref}
+				// Not using default arg because is if someone accidentally passes a falsey value, we still need the role to be set.
 				role={role || 'region'}
 				rounded
 				tabIndex={tabIndex ?? (focusOnMount || focusOnUpdate ? -1 : undefined)}
 			>
 				<Flex gap={0.5}>
-					<Icon id={iconId} />
+					<span
+						css={{
+							display: 'inline-flex',
+						}}
+					>
+						{icon}
+						<span css={visuallyHiddenStyles} id={toneId}>
+							{tone}
+						</span>
+					</span>
 					<Flex flexDirection="column" gap={0.25}>
 						{title && (
 							<Text fontWeight="bold" id={titleId}>
@@ -106,7 +117,7 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 function useSectionAlertIds(idProp?: string) {
 	const autoId = useId(idProp);
 	const childrenId = `section-alert-children-${autoId}`;
-	const iconId = `section-alert-icon-${autoId}`;
 	const titleId = `section-alert-title-${autoId}`;
-	return { childrenId, iconId, titleId };
+	const toneId = `section-alert-icon-${autoId}`;
+	return { childrenId, titleId, toneId };
 }

--- a/packages/react/src/section-alert/SectionAlert.tsx
+++ b/packages/react/src/section-alert/SectionAlert.tsx
@@ -4,12 +4,13 @@ import {
 	MouseEventHandler,
 	ReactNode,
 } from 'react';
+import { useId } from '../core';
 import { useFocus } from '../core/utils/useFocus';
 import { Flex } from '../flex';
 import { getOptionalCloseHandler } from '../getCloseHandler';
 import { Text } from '../text';
 import { SectionAlertDismissButton } from './SectionAlertDismissButton';
-import { sectionAlertIconMap, SectionAlertTone } from './utils';
+import { sectionAlertIconMap, type SectionAlertTone } from './utils';
 
 type DivProps = HTMLAttributes<HTMLDivElement>;
 
@@ -40,9 +41,9 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 	function SectionAlert(
 		{
 			children,
-			id,
 			focusOnMount,
 			focusOnUpdate,
+			id,
 			onClose,
 			onDismiss,
 			role,
@@ -58,34 +59,40 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 			focusOnUpdate,
 			forwardedRef,
 		});
+		const { childrenId, iconId, titleId } = useSectionAlertIds(id);
 
 		const Icon = sectionAlertIconMap[tone];
 		const closeHandler = getOptionalCloseHandler(onClose, onDismiss);
 
 		return (
 			<Flex
+				{...props}
 				alignItems="center"
+				aria-labelledby={`${iconId} ${titleId} ${children ? childrenId : ''}`}
 				background={tone}
 				borderColor={tone}
 				borderLeft
 				borderLeftWidth="xl"
+				focusRingFor="all"
 				gap={0.5}
 				highContrastOutline
 				id={id}
-				focusRingFor="all"
 				justifyContent="space-between"
 				padding={1}
 				ref={ref}
-				role={role}
+				role={role || 'region'}
 				rounded
 				tabIndex={tabIndex ?? (focusOnMount || focusOnUpdate ? -1 : undefined)}
-				{...props}
 			>
 				<Flex gap={0.5}>
-					{Icon}
-					<Flex gap={0.25} flexDirection={'column'}>
-						{title && <Text fontWeight="bold">{title}</Text>}
-						{children}
+					<Icon id={iconId} />
+					<Flex flexDirection="column" gap={0.25}>
+						{title && (
+							<Text fontWeight="bold" id={titleId}>
+								{title}
+							</Text>
+						)}
+						{children && <div id={childrenId}>{children}</div>}
 					</Flex>
 				</Flex>
 				{closeHandler ? (
@@ -95,3 +102,11 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 		);
 	}
 );
+
+function useSectionAlertIds(idProp?: string) {
+	const autoId = useId(idProp);
+	const childrenId = `section-alert-children-${autoId}`;
+	const iconId = `section-alert-icon-${autoId}`;
+	const titleId = `section-alert-title-${autoId}`;
+	return { childrenId, iconId, titleId };
+}

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -10,26 +10,34 @@ exports[`SectionAlert which is closable renders correctly 1`] = `
     <div
       class="css-1urm0li-boxStyles"
     >
-      <svg
-        aria-hidden="false"
-        aria-label="Success, "
-        class="css-vvfklf-Icon"
-        clip-rule="evenodd"
-        fill-rule="evenodd"
-        focusable="false"
-        height="24"
-        id="section-alert-icon-:r8:"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="css-1lb5yh3-SectionAlert"
       >
-        <path
-          d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24ZM17.7071 9.70711C18.0976 9.31658 18.0976 8.68342 17.7071 8.29289C17.3166 7.90237 16.6834 7.90237 16.2929 8.29289L10 14.5858L7.70711 12.2929C7.31658 11.9024 6.68342 11.9024 6.29289 12.2929C5.90237 12.6834 5.90237 13.3166 6.29289 13.7071L9.29289 16.7071C9.68342 17.0976 10.3166 17.0976 10.7071 16.7071L17.7071 9.70711Z"
-          fill="currentColor"
-          stroke="none"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="css-vvfklf-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24ZM17.7071 9.70711C18.0976 9.31658 18.0976 8.68342 17.7071 8.29289C17.3166 7.90237 16.6834 7.90237 16.2929 8.29289L10 14.5858L7.70711 12.2929C7.31658 11.9024 6.68342 11.9024 6.29289 12.2929C5.90237 12.6834 5.90237 13.3166 6.29289 13.7071L9.29289 16.7071C9.68342 17.0976 10.3166 17.0976 10.7071 16.7071L17.7071 9.70711Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r8:"
+        >
+          success
+        </span>
+      </span>
       <div
         class="css-1i7cdx8-boxStyles"
       >
@@ -96,26 +104,34 @@ exports[`SectionAlert with a description renders correctly 1`] = `
     <div
       class="css-1urm0li-boxStyles"
     >
-      <svg
-        aria-hidden="false"
-        aria-label="Success, "
-        class="css-vvfklf-Icon"
-        clip-rule="evenodd"
-        fill-rule="evenodd"
-        focusable="false"
-        height="24"
-        id="section-alert-icon-:r6:"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="css-1lb5yh3-SectionAlert"
       >
-        <path
-          d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24ZM17.7071 9.70711C18.0976 9.31658 18.0976 8.68342 17.7071 8.29289C17.3166 7.90237 16.6834 7.90237 16.2929 8.29289L10 14.5858L7.70711 12.2929C7.31658 11.9024 6.68342 11.9024 6.29289 12.2929C5.90237 12.6834 5.90237 13.3166 6.29289 13.7071L9.29289 16.7071C9.68342 17.0976 10.3166 17.0976 10.7071 16.7071L17.7071 9.70711Z"
-          fill="currentColor"
-          stroke="none"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="css-vvfklf-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24ZM17.7071 9.70711C18.0976 9.31658 18.0976 8.68342 17.7071 8.29289C17.3166 7.90237 16.6834 7.90237 16.2929 8.29289L10 14.5858L7.70711 12.2929C7.31658 11.9024 6.68342 11.9024 6.29289 12.2929C5.90237 12.6834 5.90237 13.3166 6.29289 13.7071L9.29289 16.7071C9.68342 17.0976 10.3166 17.0976 10.7071 16.7071L17.7071 9.70711Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r6:"
+        >
+          success
+        </span>
+      </span>
       <div
         class="css-1i7cdx8-boxStyles"
       >
@@ -150,26 +166,34 @@ exports[`SectionAlert with error tone renders correctly 1`] = `
     <div
       class="css-1urm0li-boxStyles"
     >
-      <svg
-        aria-hidden="false"
-        aria-label="Error, "
-        class="css-1w78ld0-Icon"
-        clip-rule="evenodd"
-        fill-rule="evenodd"
-        focusable="false"
-        height="24"
-        id="section-alert-icon-:r0:"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="css-1lb5yh3-SectionAlert"
       >
-        <path
-          d="M16.4661 0.5C16.7332 0.5 16.9893 0.6069 17.1771 0.796862L23.2111 6.89871C23.3962 7.08591 23.5 7.33857 23.5 7.60185V16.3935C23.5 16.6595 23.394 16.9146 23.2055 17.1023L17.0712 23.2087C16.8838 23.3953 16.6301 23.5 16.3657 23.5H7.63889C7.37177 23.5 7.11576 23.3931 6.92792 23.2032L0.789033 16.9968C0.60386 16.8095 0.5 16.5569 0.5 16.2935V7.60646C0.5 7.34045 0.605983 7.08541 0.794505 6.89774L6.92885 0.791284C7.11625 0.604732 7.36991 0.5 7.63434 0.5H16.4661ZM16.7071 7.29289C17.0976 7.68342 17.0976 8.31658 16.7071 8.70711L13.4142 12L16.7071 15.2929C17.0976 15.6834 17.0976 16.3166 16.7071 16.7071C16.3166 17.0976 15.6834 17.0976 15.2929 16.7071L12 13.4142L8.70711 16.7071C8.31658 17.0976 7.68342 17.0976 7.29289 16.7071C6.90237 16.3166 6.90237 15.6834 7.29289 15.2929L10.5858 12L7.29289 8.70711C6.90237 8.31658 6.90237 7.68342 7.29289 7.29289C7.68342 6.90237 8.31658 6.90237 8.70711 7.29289L12 10.5858L15.2929 7.29289C15.6834 6.90237 16.3166 6.90237 16.7071 7.29289Z"
-          fill="currentColor"
-          stroke="none"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="css-1w78ld0-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.4661 0.5C16.7332 0.5 16.9893 0.6069 17.1771 0.796862L23.2111 6.89871C23.3962 7.08591 23.5 7.33857 23.5 7.60185V16.3935C23.5 16.6595 23.394 16.9146 23.2055 17.1023L17.0712 23.2087C16.8838 23.3953 16.6301 23.5 16.3657 23.5H7.63889C7.37177 23.5 7.11576 23.3931 6.92792 23.2032L0.789033 16.9968C0.60386 16.8095 0.5 16.5569 0.5 16.2935V7.60646C0.5 7.34045 0.605983 7.08541 0.794505 6.89774L6.92885 0.791284C7.11625 0.604732 7.36991 0.5 7.63434 0.5H16.4661ZM16.7071 7.29289C17.0976 7.68342 17.0976 8.31658 16.7071 8.70711L13.4142 12L16.7071 15.2929C17.0976 15.6834 17.0976 16.3166 16.7071 16.7071C16.3166 17.0976 15.6834 17.0976 15.2929 16.7071L12 13.4142L8.70711 16.7071C8.31658 17.0976 7.68342 17.0976 7.29289 16.7071C6.90237 16.3166 6.90237 15.6834 7.29289 15.2929L10.5858 12L7.29289 8.70711C6.90237 8.31658 6.90237 7.68342 7.29289 7.29289C7.68342 6.90237 8.31658 6.90237 8.70711 7.29289L12 10.5858L15.2929 7.29289C15.6834 6.90237 16.3166 6.90237 16.7071 7.29289Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r0:"
+        >
+          error
+        </span>
+      </span>
       <div
         class="css-1i7cdx8-boxStyles"
       >
@@ -195,26 +219,34 @@ exports[`SectionAlert with success tone renders correctly 1`] = `
     <div
       class="css-1urm0li-boxStyles"
     >
-      <svg
-        aria-hidden="false"
-        aria-label="Success, "
-        class="css-vvfklf-Icon"
-        clip-rule="evenodd"
-        fill-rule="evenodd"
-        focusable="false"
-        height="24"
-        id="section-alert-icon-:r2:"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="css-1lb5yh3-SectionAlert"
       >
-        <path
-          d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24ZM17.7071 9.70711C18.0976 9.31658 18.0976 8.68342 17.7071 8.29289C17.3166 7.90237 16.6834 7.90237 16.2929 8.29289L10 14.5858L7.70711 12.2929C7.31658 11.9024 6.68342 11.9024 6.29289 12.2929C5.90237 12.6834 5.90237 13.3166 6.29289 13.7071L9.29289 16.7071C9.68342 17.0976 10.3166 17.0976 10.7071 16.7071L17.7071 9.70711Z"
-          fill="currentColor"
-          stroke="none"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="css-vvfklf-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24ZM17.7071 9.70711C18.0976 9.31658 18.0976 8.68342 17.7071 8.29289C17.3166 7.90237 16.6834 7.90237 16.2929 8.29289L10 14.5858L7.70711 12.2929C7.31658 11.9024 6.68342 11.9024 6.29289 12.2929C5.90237 12.6834 5.90237 13.3166 6.29289 13.7071L9.29289 16.7071C9.68342 17.0976 10.3166 17.0976 10.7071 16.7071L17.7071 9.70711Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r2:"
+        >
+          success
+        </span>
+      </span>
       <div
         class="css-1i7cdx8-boxStyles"
       >
@@ -240,26 +272,34 @@ exports[`SectionAlert with warning tone renders correctly 1`] = `
     <div
       class="css-1urm0li-boxStyles"
     >
-      <svg
-        aria-hidden="false"
-        aria-label="Warning, "
-        class="css-15hefj6-Icon"
-        clip-rule="evenodd"
-        fill-rule="evenodd"
-        focusable="false"
-        height="24"
-        id="section-alert-icon-:r4:"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="css-1lb5yh3-SectionAlert"
       >
-        <path
-          d="m23.1 20.1-9.3-18C13.4 1.4 12.7 1 12 1s-1.4.4-1.8 1.1l-9.3 18c-.3.6-.3 1.4.1 2 .4.6 1 1 1.7 1h18.7c.7 0 1.31-.33 1.7-1 .36-.6.3-1.4 0-2ZM12 19c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1Zm1-5c0 .6-.4 1-1 1s-1-.4-1-1V9c0-.6.4-1 1-1s1 .4 1 1v5Z"
-          fill="currentColor"
-          stroke="none"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="css-15hefj6-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m23.1 20.1-9.3-18C13.4 1.4 12.7 1 12 1s-1.4.4-1.8 1.1l-9.3 18c-.3.6-.3 1.4.1 2 .4.6 1 1 1.7 1h18.7c.7 0 1.31-.33 1.7-1 .36-.6.3-1.4 0-2ZM12 19c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1Zm1-5c0 .6-.4 1-1 1s-1-.4-1-1V9c0-.6.4-1 1-1s1 .4 1 1v5Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r4:"
+        >
+          warning
+        </span>
+      </span>
       <div
         class="css-1i7cdx8-boxStyles"
       >

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -3,19 +3,22 @@
 exports[`SectionAlert which is closable renders correctly 1`] = `
 <div>
   <div
+    aria-labelledby="section-alert-icon-:r8: section-alert-title-:r8: "
     class="css-1td0tl7-boxStyles"
+    role="region"
   >
     <div
       class="css-1urm0li-boxStyles"
     >
       <svg
         aria-hidden="false"
-        aria-label="Success"
+        aria-label="Success, "
         class="css-vvfklf-Icon"
         clip-rule="evenodd"
         fill-rule="evenodd"
         focusable="false"
         height="24"
+        id="section-alert-icon-:r8:"
         role="img"
         viewBox="0 0 24 24"
         width="24"
@@ -32,6 +35,7 @@ exports[`SectionAlert which is closable renders correctly 1`] = `
       >
         <span
           class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r8:"
         >
           Title of Section alert
         </span>
@@ -85,19 +89,22 @@ exports[`SectionAlert which is closable renders correctly 1`] = `
 exports[`SectionAlert with a description renders correctly 1`] = `
 <div>
   <div
+    aria-labelledby="section-alert-icon-:r6: section-alert-title-:r6: section-alert-children-:r6:"
     class="css-1td0tl7-boxStyles"
+    role="region"
   >
     <div
       class="css-1urm0li-boxStyles"
     >
       <svg
         aria-hidden="false"
-        aria-label="Success"
+        aria-label="Success, "
         class="css-vvfklf-Icon"
         clip-rule="evenodd"
         fill-rule="evenodd"
         focusable="false"
         height="24"
+        id="section-alert-icon-:r6:"
         role="img"
         viewBox="0 0 24 24"
         width="24"
@@ -114,14 +121,19 @@ exports[`SectionAlert with a description renders correctly 1`] = `
       >
         <span
           class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r6:"
         >
           Title of Section alert
         </span>
-        <p
-          class="css-dbscsh-boxStyles"
+        <div
+          id="section-alert-children-:r6:"
         >
-          Section alert description text
-        </p>
+          <p
+            class="css-dbscsh-boxStyles"
+          >
+            Section alert description text
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -131,19 +143,22 @@ exports[`SectionAlert with a description renders correctly 1`] = `
 exports[`SectionAlert with error tone renders correctly 1`] = `
 <div>
   <div
+    aria-labelledby="section-alert-icon-:r0: section-alert-title-:r0: "
     class="css-3ieit4-boxStyles"
+    role="region"
   >
     <div
       class="css-1urm0li-boxStyles"
     >
       <svg
         aria-hidden="false"
-        aria-label="Error"
+        aria-label="Error, "
         class="css-1w78ld0-Icon"
         clip-rule="evenodd"
         fill-rule="evenodd"
         focusable="false"
         height="24"
+        id="section-alert-icon-:r0:"
         role="img"
         viewBox="0 0 24 24"
         width="24"
@@ -160,6 +175,7 @@ exports[`SectionAlert with error tone renders correctly 1`] = `
       >
         <span
           class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r0:"
         >
           Title of Section alert
         </span>
@@ -172,19 +188,22 @@ exports[`SectionAlert with error tone renders correctly 1`] = `
 exports[`SectionAlert with success tone renders correctly 1`] = `
 <div>
   <div
+    aria-labelledby="section-alert-icon-:r2: section-alert-title-:r2: "
     class="css-1td0tl7-boxStyles"
+    role="region"
   >
     <div
       class="css-1urm0li-boxStyles"
     >
       <svg
         aria-hidden="false"
-        aria-label="Success"
+        aria-label="Success, "
         class="css-vvfklf-Icon"
         clip-rule="evenodd"
         fill-rule="evenodd"
         focusable="false"
         height="24"
+        id="section-alert-icon-:r2:"
         role="img"
         viewBox="0 0 24 24"
         width="24"
@@ -201,6 +220,7 @@ exports[`SectionAlert with success tone renders correctly 1`] = `
       >
         <span
           class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r2:"
         >
           Title of Section alert
         </span>
@@ -213,19 +233,22 @@ exports[`SectionAlert with success tone renders correctly 1`] = `
 exports[`SectionAlert with warning tone renders correctly 1`] = `
 <div>
   <div
+    aria-labelledby="section-alert-icon-:r4: section-alert-title-:r4: "
     class="css-9xmjo1-boxStyles"
+    role="region"
   >
     <div
       class="css-1urm0li-boxStyles"
     >
       <svg
         aria-hidden="false"
-        aria-label="Warning"
+        aria-label="Warning, "
         class="css-15hefj6-Icon"
         clip-rule="evenodd"
         fill-rule="evenodd"
         focusable="false"
         height="24"
+        id="section-alert-icon-:r4:"
         role="img"
         viewBox="0 0 24 24"
         width="24"
@@ -242,6 +265,7 @@ exports[`SectionAlert with warning tone renders correctly 1`] = `
       >
         <span
           class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r4:"
         >
           Title of Section alert
         </span>

--- a/packages/react/src/section-alert/docs/overview.mdx
+++ b/packages/react/src/section-alert/docs/overview.mdx
@@ -224,7 +224,7 @@ Press the "Focus the alert" button below to set focus on the alert. To achieve t
 				title="Submission successful"
 				tone="success"
 			>
-				<Text as="p">Your application has been successfully submitted.</Text>
+				<Text as="p">Your application has been received.</Text>
 			</SectionAlert>
 		</Stack>
 	);

--- a/packages/react/src/section-alert/utils.tsx
+++ b/packages/react/src/section-alert/utils.tsx
@@ -4,33 +4,10 @@ import {
 	WarningFilledIcon,
 } from '@ag.ds-next/react/icon';
 
-type SectionAlertIconProps = { id: string };
-
 export const sectionAlertIconMap = {
-	error: ({ id }: SectionAlertIconProps) => (
-		<AlertFilledIcon
-			aria-hidden="false"
-			aria-label="Error, "
-			color="error"
-			id={id}
-		/>
-	),
-	success: ({ id }: SectionAlertIconProps) => (
-		<SuccessFilledIcon
-			aria-hidden="false"
-			aria-label="Success, "
-			color="success"
-			id={id}
-		/>
-	),
-	warning: ({ id }: SectionAlertIconProps) => (
-		<WarningFilledIcon
-			aria-hidden="false"
-			aria-label="Warning, "
-			color="warning"
-			id={id}
-		/>
-	),
+	error: <AlertFilledIcon color="error" />,
+	success: <SuccessFilledIcon color="success" />,
+	warning: <WarningFilledIcon color="warning" />,
 };
 
 export type SectionAlertTone = keyof typeof sectionAlertIconMap;

--- a/packages/react/src/section-alert/utils.tsx
+++ b/packages/react/src/section-alert/utils.tsx
@@ -4,22 +4,31 @@ import {
 	WarningFilledIcon,
 } from '@ag.ds-next/react/icon';
 
+type SectionAlertIconProps = { id: string };
+
 export const sectionAlertIconMap = {
-	success: (
-		<SuccessFilledIcon
-			color="success"
+	error: ({ id }: SectionAlertIconProps) => (
+		<AlertFilledIcon
 			aria-hidden="false"
-			aria-label="Success"
+			aria-label="Error, "
+			color="error"
+			id={id}
 		/>
 	),
-	error: (
-		<AlertFilledIcon color="error" aria-hidden="false" aria-label="Error" />
-	),
-	warning: (
-		<WarningFilledIcon
-			color="warning"
+	success: ({ id }: SectionAlertIconProps) => (
+		<SuccessFilledIcon
 			aria-hidden="false"
-			aria-label="Warning"
+			aria-label="Success, "
+			color="success"
+			id={id}
+		/>
+	),
+	warning: ({ id }: SectionAlertIconProps) => (
+		<WarningFilledIcon
+			aria-hidden="false"
+			aria-label="Warning, "
+			color="warning"
+			id={id}
 		/>
 	),
 };


### PR DESCRIPTION
The audt and my testing found that focusing the alert wasn't announcing it in JAWS and iOS 16.7.10 & 18 something, instead it just announced the graphic.

This change makes the alert a region, so not only does it appear in the landmarks menu (which is important since there is no heading to jump to), it improves the announcements across all screen readers. JAWS still doesn't announce it on the default setting, but changing to "high" does.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1893)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
