### PR TITLE
modal: Remove `elementToFocusOnClose` prop.

### DIFF
--- a/.changeset/polite-flowers-exist.md
+++ b/.changeset/polite-flowers-exist.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+modal: Remove `elementToFocusOnClose` prop.

--- a/packages/react/src/modal/Modal.tsx
+++ b/packages/react/src/modal/Modal.tsx
@@ -14,7 +14,6 @@ export type ModalProps = ModalDialogProps & {
 export const Modal: FunctionComponent<ModalProps> = ({
 	actions,
 	children,
-	elementToFocusOnClose,
 	isOpen = false,
 	onClose,
 	onDismiss,
@@ -48,12 +47,7 @@ export const Modal: FunctionComponent<ModalProps> = ({
 		<Fragment>
 			<LockScroll />
 			<ModalCover ref={modalContainerRef}>
-				<ModalDialog
-					actions={actions}
-					elementToFocusOnClose={elementToFocusOnClose}
-					onClose={closeHandler}
-					title={title}
-				>
+				<ModalDialog actions={actions} onClose={closeHandler} title={title}>
 					{children}
 				</ModalDialog>
 			</ModalCover>

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -13,8 +13,6 @@ import { useModalId } from './utils';
 export type ModalDialogProps = PropsWithChildren<{
 	/** The actions to display at the bottom of the modal panel. Typically a `ButtonGroup`. */
 	actions?: ReactNode;
-	/** On close of the modal, this element will be focused, rather than the trigger element. */
-	elementToFocusOnClose?: HTMLElement | null;
 	/** Function to be called when the 'Close' button is pressed. */
 	onClose?: () => void;
 	/** @deprecated use `onClose` instead */
@@ -28,7 +26,6 @@ const MAX_WIDTH = '45rem'; // 720 px
 export const ModalDialog = ({
 	actions,
 	children,
-	elementToFocusOnClose,
 	onClose,
 	onDismiss,
 	title,
@@ -36,18 +33,7 @@ export const ModalDialog = ({
 	const closeHandler = getRequiredCloseHandler(onClose, onDismiss);
 	const { titleId } = useModalId();
 	return (
-		<FocusLock
-			returnFocus={
-				elementToFocusOnClose
-					? () => {
-							// Running focus after focus-lock-react does its cleanup, more info here: https://github.com/theKashey/react-focus-lock#unmounting-and-focus-management
-							window.setTimeout(() => elementToFocusOnClose.focus(), 0);
-
-							return false;
-					  }
-					: true // Return focus to trigger on close
-			}
-		>
+		<FocusLock returnFocus>
 			<Stack
 				aria-labelledby={titleId}
 				aria-modal="true"


### PR DESCRIPTION
During yourgov development, we added an `elementToFocusOnClose` prop which did not prove useful. Removing it so we consumers don't get and we later have to deprecate it.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1894)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
