### PR TITLE
docs: Remove unused react-simple-code-editor

### DIFF
--- a/.changeset/neat-toes-hang.md
+++ b/.changeset/neat-toes-hang.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+docs: Remove unused react-simple-code-editor.

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,6 @@
 		"react": "18.1.0",
 		"react-dom": "18.1.0",
 		"react-live": "^4.1.5",
-		"react-simple-code-editor": "^0.13.1",
 		"remark-hint": "^1.0.10",
 		"remark-mdx-code-meta": "^2.0.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -15006,11 +15006,6 @@ react-side-effect@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
   integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
-react-simple-code-editor@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz#4514553fa132dcaffec33a6612c58f1613c52416"
-  integrity sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==
-
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
Discovered that react-simple-code-editor has been unused since Feb 2022 https://github.com/agriculturegovau/agds-next/pull/65/files

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1906)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
