### PR TITLE
loading: Announce fullscreen LoadingBlanket assertively

### DIFF
--- a/.changeset/itchy-coats-argue.md
+++ b/.changeset/itchy-coats-argue.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+loading: Announce `'fullscreen'` `LoadingBlanket` assertively.

--- a/packages/react/src/loading/LoadingBlanket.tsx
+++ b/packages/react/src/loading/LoadingBlanket.tsx
@@ -18,7 +18,9 @@ export const LoadingBlanket = ({
 	<LoadingBlanketContainer fullScreen={fullScreen}>
 		<LoadingBlanketContent>
 			<LoadingDots size={fullScreen ? 'lg' : 'md'} />
-			<LoadingBlanketLabel>{label}</LoadingBlanketLabel>
+			<LoadingBlanketLabel role={fullScreen ? 'alert' : 'status'}>
+				{label}
+			</LoadingBlanketLabel>
 		</LoadingBlanketContent>
 	</LoadingBlanketContainer>
 );

--- a/packages/react/src/loading/LoadingBlanketLabel.tsx
+++ b/packages/react/src/loading/LoadingBlanketLabel.tsx
@@ -3,10 +3,14 @@ import { Text } from '../text';
 
 export type LoadingBlanketLabelProps = {
 	children: ReactNode;
+	role: 'alert' | 'status';
 };
 
-export const LoadingBlanketLabel = ({ children }: LoadingBlanketLabelProps) => (
-	<Text fontSize="lg" fontWeight="bold" lineHeight="heading" role="status">
+export const LoadingBlanketLabel = ({
+	children,
+	role,
+}: LoadingBlanketLabelProps) => (
+	<Text fontSize="lg" fontWeight="bold" lineHeight="heading" role={role}>
 		{children}
 	</Text>
 );


### PR DESCRIPTION
We discovered that the fullscreen LoadingBlanket wasn't being announced in JAWS and NVDA in yourgov and other implementations. Making it `role="alert"` fixes it in these and makes no difference to the others.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1916)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
