### PR TITLE
yourgov: Reorder ABNs to appear after headings & before digits

### DIFF
--- a/.changeset/twelve-gifts-destroy.md
+++ b/.changeset/twelve-gifts-destroy.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/yourgov': minor
+---
+
+yourgov: Reorder ABNs to appear after headings & prefix before digits.

--- a/yourgov/pages/app/dashboard/index.tsx
+++ b/yourgov/pages/app/dashboard/index.tsx
@@ -27,11 +27,11 @@ const Page: NextPageWithLayout = () => {
 			<PageContent>
 				<Stack gap={3}>
 					<Stack alignItems="flex-start" gap={1}>
-						<Flex gap={0.5}>
-							<Tag>{selectedBusiness.abn}</Tag>
-							<Text>ABN</Text>
-						</Flex>
 						<H1>{selectedBusiness.name}</H1>
+						<Flex gap={0.5}>
+							<Text>ABN</Text>
+							<Tag>{selectedBusiness.abn}</Tag>
+						</Flex>
 						<TextLink href="/not-found">View business details</TextLink>
 					</Stack>
 

--- a/yourgov/pages/app/index.tsx
+++ b/yourgov/pages/app/index.tsx
@@ -103,10 +103,6 @@ const Page: NextPageWithLayout = () => {
 								<Card as="li" clickable key={idx} shadow>
 									<CardInner>
 										<Stack gap={1}>
-											<Flex gap={0.5}>
-												<Tag>{linkedBusinesses.abn}</Tag>
-												<Text>ABN</Text>
-											</Flex>
 											<H3>
 												<CardLink
 													href={businessHref}
@@ -117,6 +113,10 @@ const Page: NextPageWithLayout = () => {
 													{linkedBusinesses.name}
 												</CardLink>
 											</H3>
+											<Flex gap={0.5}>
+												<Text>ABN</Text>
+												<Tag>{linkedBusinesses.abn}</Tag>
+											</Flex>
 											<Text>Role: {linkedBusinesses.role}</Text>
 										</Stack>
 									</CardInner>


### PR DESCRIPTION
Re-orders the ABN so it's not after the important info that defines it.

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/27537d67-dd99-4aad-ae69-159ebad3e5e5" />
<img width="585" alt="image" src="https://github.com/user-attachments/assets/b295a832-27d1-4f7e-9746-91a4325f02b1" />


[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1937)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
