### PR TITLE
date-pickers: Fix all act/state warnings in tests

### DIFF
--- a/.changeset/tall-forks-flash.md
+++ b/.changeset/tall-forks-flash.md
@@ -1,0 +1,11 @@
+---
+'@ag.ds-next/react': patch
+---
+
+date-picker: Fix all `act`/state warnings in tests.
+
+date-picker-next: Fix all `act`/state warnings in tests.
+
+date-range-picker: Fix all `act`/state warnings in tests.
+
+date-range-picker-next: Fix all `act`/state warnings in tests.

--- a/packages/react/src/date-picker-next/DatePickerNext.test.tsx
+++ b/packages/react/src/date-picker-next/DatePickerNext.test.tsx
@@ -318,9 +318,11 @@ describe('DatePickerNext', () => {
 				label: 'Example',
 			});
 
+			const user = userEvent.setup();
+
 			// Type a valid date in the input field that isn't in the allowed format
-			await act(async () => userEvent.type(await getInput(), '05-23-2023'));
-			await act(() => userEvent.keyboard('{Tab}'));
+			await act(async () => user.type(await getInput(), '05-23-2023'));
+			await act(() => user.keyboard('{Tab}'));
 
 			// The input should not be formatted to the dateFormat prop
 			expect(await getInput()).toHaveValue('05-23-2023');

--- a/packages/react/src/date-picker-next/DatePickerNext.test.tsx
+++ b/packages/react/src/date-picker-next/DatePickerNext.test.tsx
@@ -201,10 +201,12 @@ describe('DatePickerNext', () => {
 		const date = parseDate(dateString) as Date;
 		const formattedDate = formatHumanReadableDate(date);
 
+		const user = userEvent.setup();
+
 		// Type in the input field
-		await userEvent.type(await getInput(), dateString);
+		await act(async () => user.type(await getInput(), dateString));
 		expect(await getInput()).toHaveValue(dateString);
-		await userEvent.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 
 		expect(onChange).toHaveBeenLastCalledWith(date);
 
@@ -224,10 +226,12 @@ describe('DatePickerNext', () => {
 
 		const dateString = '99/99/2000';
 
+		const user = userEvent.setup();
+
 		// Type in the input field
-		await userEvent.type(await getInput(), dateString);
+		await act(async () => user.type(await getInput(), dateString));
 		expect(await getInput()).toHaveValue(dateString);
-		await userEvent.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 
 		expect(onChange).toHaveBeenLastCalledWith(dateString);
 
@@ -241,7 +245,7 @@ describe('DatePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Type a valid date in the input field that isn't in the display format
-		await user.type(await getInput(), 'June 5th 2023');
+		await act(async () => user.type(await getInput(), 'June 5th 2023'));
 		await act(() => user.keyboard('{Tab}'));
 
 		// The input should be formatted to dd/MM/yyyy
@@ -257,11 +261,13 @@ describe('DatePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Type a valid date in the input field that isn't in the display format
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Example (e.g. 5 Aug 2015) (optional)',
-			}),
-			'05 06 2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Example (e.g. 5 Aug 2015) (optional)',
+				}),
+				'05 06 2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
 
@@ -279,9 +285,11 @@ describe('DatePickerNext', () => {
 			label: 'Example',
 		});
 
+		const user = userEvent.setup();
+
 		// Type a valid date in the input field that isn't in the allowed format
-		await userEvent.type(await getInput(), '05.23.2023');
-		await userEvent.keyboard('{Tab}');
+		await act(async () => user.type(await getInput(), '05.23.2023'));
+		await act(() => user.keyboard('{Tab}'));
 
 		// The input should not be formatted to the dateFormat prop
 		expect(await getInput()).toHaveValue('05.23.2023');
@@ -297,7 +305,7 @@ describe('DatePickerNext', () => {
 			const user = userEvent.setup();
 
 			// Type a valid date in the input field that is in the allowed format
-			await user.type(await getInput(), '23-05-2023');
+			await act(async () => user.type(await getInput(), '23-05-2023'));
 			await act(() => user.keyboard('{Tab}'));
 
 			// The input should be formatted to the dateFormat prop
@@ -311,8 +319,8 @@ describe('DatePickerNext', () => {
 			});
 
 			// Type a valid date in the input field that isn't in the allowed format
-			await userEvent.type(await getInput(), '05-23-2023');
-			await userEvent.keyboard('{Tab}');
+			await act(async () => userEvent.type(await getInput(), '05-23-2023'));
+			await act(() => userEvent.keyboard('{Tab}'));
 
 			// The input should not be formatted to the dateFormat prop
 			expect(await getInput()).toHaveValue('05-23-2023');
@@ -328,11 +336,13 @@ describe('DatePickerNext', () => {
 			const user = userEvent.setup();
 
 			// Type a valid date in the input field that isn't in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Example (e.g. 05 August 2015) (optional)',
-				}),
-				'08 Feb 2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Example (e.g. 05 August 2015) (optional)',
+					}),
+					'08 Feb 2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -387,10 +397,10 @@ describe('DatePickerNext', () => {
 		);
 
 		// Type in an invalid value
-		await userEvent.type(await getInput(), dateString);
+		await act(async () => userEvent.type(await getInput(), dateString));
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => userEvent.click(await getSubmitButton()));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			date,
@@ -410,7 +420,7 @@ describe('DatePickerNext', () => {
 		);
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => userEvent.click(await getSubmitButton()));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			date: undefined,

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -207,10 +207,12 @@ describe('DatePicker', () => {
 		const date = parseDate(dateString) as Date;
 		const formattedDate = formatHumanReadableDate(date);
 
+		const user = userEvent.setup();
+
 		// Type in the input field
-		await userEvent.type(await getInput(), dateString);
+		await act(async () => user.type(await getInput(), dateString));
 		expect(await getInput()).toHaveValue(dateString);
-		await userEvent.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 
 		expect(onChange).toHaveBeenLastCalledWith(date);
 
@@ -233,7 +235,7 @@ describe('DatePicker', () => {
 		const dateString = '01.01.2000';
 
 		// Type in the input field
-		await user.type(await getInput(), dateString);
+		await act(async () => user.type(await getInput(), dateString));
 		expect(await getInput()).toHaveValue(dateString);
 		await act(() => user.keyboard('{Tab}'));
 
@@ -249,7 +251,7 @@ describe('DatePicker', () => {
 		const user = userEvent.setup();
 
 		// Type a valid date in the input field that isn't in the display format
-		await user.type(await getInput(), 'June 5th 2023');
+		await act(async () => user.type(await getInput(), 'June 5th 2023'));
 		await act(() => user.keyboard('{Tab}'));
 
 		// The input should be formatted to dd/MM/yyyy
@@ -265,11 +267,13 @@ describe('DatePicker', () => {
 		const user = userEvent.setup();
 
 		// Type a valid date in the input field that isn't in the display format
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Example (e.g. 5 Aug 2015) (optional)',
-			}),
-			'05 06 2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Example (e.g. 5 Aug 2015) (optional)',
+				}),
+				'05 06 2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
 
@@ -287,9 +291,11 @@ describe('DatePicker', () => {
 			label: 'Example',
 		});
 
+		const user = userEvent.setup();
+
 		// Type a valid date in the input field that isn't in the allowed format
-		await userEvent.type(await getInput(), '05.23.2023');
-		await userEvent.keyboard('{Tab}');
+		await act(async () => user.type(await getInput(), '05.23.2023'));
+		await act(() => user.keyboard('{Tab}'));
 
 		// The input should not be formatted to the dateFormat prop
 		expect(await getInput()).toHaveValue('05.23.2023');
@@ -305,7 +311,7 @@ describe('DatePicker', () => {
 			const user = userEvent.setup();
 
 			// Type a valid date in the input field that is in the allowed format
-			await user.type(await getInput(), '23-05-2023');
+			await act(async () => user.type(await getInput(), '23-05-2023'));
 			await act(() => user.keyboard('{Tab}'));
 
 			// The input should be formatted to the dateFormat prop
@@ -318,9 +324,11 @@ describe('DatePicker', () => {
 				label: 'Example',
 			});
 
+			const user = userEvent.setup();
+
 			// Type a valid date in the input field that isn't in the allowed format
-			await userEvent.type(await getInput(), '05-23-2023');
-			await userEvent.keyboard('{Tab}');
+			await act(async () => user.type(await getInput(), '05-23-2023'));
+			await act(() => user.keyboard('{Tab}'));
 
 			// The input should not be formatted to the dateFormat prop
 			expect(await getInput()).toHaveValue('05-23-2023');
@@ -336,11 +344,13 @@ describe('DatePicker', () => {
 			const user = userEvent.setup();
 
 			// Type a valid date in the input field that isn't in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Example (e.g. 05 August 2015) (optional)',
-				}),
-				'08 Feb 2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Example (e.g. 05 August 2015) (optional)',
+					}),
+					'08 Feb 2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -395,10 +405,10 @@ describe('DatePicker', () => {
 		);
 
 		// Type in an invalid value
-		await userEvent.type(await getInput(), dateString);
+		await act(async () => userEvent.type(await getInput(), dateString));
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => userEvent.click(await getSubmitButton()));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			date,
@@ -418,7 +428,7 @@ describe('DatePicker', () => {
 		);
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => userEvent.click(await getSubmitButton()));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			date: undefined,
@@ -437,11 +447,13 @@ describe('DatePicker', () => {
 			/>
 		);
 
+		const user = userEvent.setup();
+
 		// Type in an invalid value
-		await userEvent.type(await getInput(), 'hello');
+		await act(async () => user.type(await getInput(), 'hello'));
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => user.click(await getSubmitButton()));
 		expect(onError).toHaveBeenCalledTimes(1);
 
 		// Expect an error
@@ -452,11 +464,11 @@ describe('DatePicker', () => {
 		expect(await getInput()).toHaveAttribute('aria-invalid', 'true');
 
 		// Type in a valid value
-		await userEvent.clear(await getInput());
-		await expect(await getInput()).toHaveValue('');
+		await act(async () => user.clear(await getInput()));
+		expect(await getInput()).toHaveValue('');
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => user.click(await getSubmitButton()));
 		expect(onSubmit).toHaveBeenCalledWith({
 			date: undefined,
 		});
@@ -474,11 +486,13 @@ describe('DatePicker', () => {
 			/>
 		);
 
+		const user = userEvent.setup();
+
 		// Type in an invalid value
-		await userEvent.type(await getInput(), 'hello');
+		await act(async () => user.type(await getInput(), 'hello'));
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => user.click(await getSubmitButton()));
 		expect(onError).toHaveBeenCalledTimes(1);
 
 		// Expect an error
@@ -489,11 +503,11 @@ describe('DatePicker', () => {
 		expect(await getInput()).toHaveAttribute('aria-invalid', 'true');
 
 		// Type in a valid value
-		await userEvent.clear(await getInput());
-		await expect(await getInput()).toHaveValue('');
+		await act(async () => user.clear(await getInput()));
+		expect(await getInput()).toHaveValue('');
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => user.click(await getSubmitButton()));
 		expect(onSubmit).toHaveBeenCalledWith({
 			date: undefined,
 		});
@@ -507,11 +521,13 @@ describe('DatePicker', () => {
 			<DatePickerInsideForm onError={onError} onSubmit={onSubmit} required />
 		);
 
+		const user = userEvent.setup();
+
 		// Type in an invalid value
-		await userEvent.type(await getInput(), 'hello');
+		await act(async () => user.type(await getInput(), 'hello'));
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => user.click(await getSubmitButton()));
 		expect(onError).toHaveBeenCalledTimes(1);
 
 		// Expect an error
@@ -524,13 +540,13 @@ describe('DatePicker', () => {
 		const validDateAsString = '02/03/2024';
 
 		// Type in a valid value
-		await userEvent.clear(await getInput());
-		await expect(await getInput()).toHaveValue('');
-		await userEvent.type(await getInput(), validDateAsString);
-		await expect(await getInput()).toHaveValue(validDateAsString);
+		await act(async () => user.clear(await getInput()));
+		expect(await getInput()).toHaveValue('');
+		await act(async () => user.type(await getInput(), validDateAsString));
+		expect(await getInput()).toHaveValue(validDateAsString);
 
 		// Submit the form
-		await userEvent.click(await getSubmitButton());
+		await act(async () => user.click(await getSubmitButton()));
 		expect(onSubmit).toHaveBeenCalledWith({
 			date: parseDate(validDateAsString),
 		});

--- a/packages/react/src/date-range-picker-next/DateRangePickerNext.test.tsx
+++ b/packages/react/src/date-range-picker-next/DateRangePickerNext.test.tsx
@@ -222,25 +222,29 @@ describe('DateRangePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Type in the input fields
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 05/08/2015) (optional)',
-			}),
-			fromDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 05/08/2015) (optional)',
+				}),
+				fromDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'Start date (e.g. 05/08/2015) (optional)',
 			})
 		).toHaveValue(fromDateString);
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 06/08/2015) (optional)',
-			}),
-			toDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 06/08/2015) (optional)',
+				}),
+				toDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'End date (e.g. 06/08/2015) (optional)',
@@ -276,25 +280,29 @@ describe('DateRangePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Type in the input fields
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 05/08/2015) (optional)',
-			}),
-			fromDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 05/08/2015) (optional)',
+				}),
+				fromDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'Start date (e.g. 05/08/2015) (optional)',
 			})
 		).toHaveValue(fromDateString);
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 06/08/2015) (optional)',
-			}),
-			toDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 06/08/2015) (optional)',
+				}),
+				toDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'End date (e.g. 06/08/2015) (optional)',
@@ -326,18 +334,22 @@ describe('DateRangePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Type valid dates in the input fields that are not in the display format
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 05/08/2015) (optional)',
-			}),
-			'5 June 2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 05/08/2015) (optional)',
+				}),
+				'5 June 2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 06/08/2015) (optional)',
-			}),
-			'10 June 2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 06/08/2015) (optional)',
+				}),
+				'10 June 2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
 
@@ -360,18 +372,22 @@ describe('DateRangePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Type valid dates in the input fields that are not in the display format
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 5 Aug 2015) (optional)',
-			}),
-			'05/06/2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 5 Aug 2015) (optional)',
+				}),
+				'05/06/2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 6 Aug 2015) (optional)',
-			}),
-			'10/06/2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 6 Aug 2015) (optional)',
+				}),
+				'10/06/2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
 
@@ -397,18 +413,22 @@ describe('DateRangePickerNext', () => {
 			const user = userEvent.setup();
 
 			// Type valid dates in the input fields that are not in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Start date (e.g. 05/08/2015) (optional)',
-				}),
-				'23-05-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Start date (e.g. 05/08/2015) (optional)',
+					}),
+					'23-05-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'End date (e.g. 06/08/2015) (optional)',
-				}),
-				'24-06-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'End date (e.g. 06/08/2015) (optional)',
+					}),
+					'24-06-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -433,19 +453,23 @@ describe('DateRangePickerNext', () => {
 			const user = userEvent.setup();
 
 			// Type valid dates in the input fields that are not in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Start date (e.g. 05/08/2015) (optional)',
-				}),
-				'05-23-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Start date (e.g. 05/08/2015) (optional)',
+					}),
+					'05-23-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'End date (e.g. 06/08/2015) (optional)',
-				}),
-				'06-24-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'End date (e.g. 06/08/2015) (optional)',
+					}),
+					'06-24-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -471,19 +495,23 @@ describe('DateRangePickerNext', () => {
 			const user = userEvent.setup();
 
 			// Type valid dates in the input field that isn't in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Start date (e.g. 05 August 2015) (optional)',
-				}),
-				'08 Feb 2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Start date (e.g. 05 August 2015) (optional)',
+					}),
+					'08 Feb 2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'End date (e.g. 06 August 2015) (optional)',
-				}),
-				'09 Mar 2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'End date (e.g. 06 August 2015) (optional)',
+					}),
+					'09 Mar 2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -752,24 +780,28 @@ describe('DateRangePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Type in a valid value
-		await user.type(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
-			fromValidDateAsString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
+				fromValidDateAsString
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
 		).toHaveValue(fromValidDateAsString);
 
-		await user.type(
-			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
-			toValidDateAsString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
+				toValidDateAsString
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
 		).toHaveValue(toValidDateAsString);
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			dateRange: {
@@ -794,7 +826,7 @@ describe('DateRangePickerNext', () => {
 		const user = userEvent.setup();
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			dateRange: { from: undefined, to: undefined },

--- a/packages/react/src/date-range-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.test.tsx
@@ -233,25 +233,29 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type in the input fields
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 05/08/2015) (optional)',
-			}),
-			fromDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 05/08/2015) (optional)',
+				}),
+				fromDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'Start date (e.g. 05/08/2015) (optional)',
 			})
 		).toHaveValue(fromDateString);
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 06/08/2015) (optional)',
-			}),
-			toDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 06/08/2015) (optional)',
+				}),
+				toDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'End date (e.g. 06/08/2015) (optional)',
@@ -285,13 +289,15 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type in the input fields
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 05/08/2015) (optional)',
-			}),
-			fromDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 05/08/2015) (optional)',
+				}),
+				fromDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'Start date (e.g. 05/08/2015) (optional)',
@@ -318,13 +324,15 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type in the input fields
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 06/08/2015) (optional)',
-			}),
-			toDateString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 06/08/2015) (optional)',
+				}),
+				toDateString
+			)
 		);
-		await user.keyboard('{Tab}');
+		await act(() => user.keyboard('{Tab}'));
 		expect(
 			screen.getByRole('textbox', {
 				name: 'End date (e.g. 06/08/2015) (optional)',
@@ -347,18 +355,22 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type valid dates in the input fields that are not in the display format
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 05/08/2015) (optional)',
-			}),
-			'5 June 2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 05/08/2015) (optional)',
+				}),
+				'5 June 2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 06/08/2015) (optional)',
-			}),
-			'10 June 2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 06/08/2015) (optional)',
+				}),
+				'10 June 2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
 
@@ -381,18 +393,22 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type valid dates in the input fields that are not in the display format
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'Start date (e.g. 5 Aug 2015) (optional)',
-			}),
-			'05/06/2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'Start date (e.g. 5 Aug 2015) (optional)',
+				}),
+				'05/06/2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
-		await user.type(
-			screen.getByRole('textbox', {
-				name: 'End date (e.g. 6 Aug 2015) (optional)',
-			}),
-			'10/06/2023'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', {
+					name: 'End date (e.g. 6 Aug 2015) (optional)',
+				}),
+				'10/06/2023'
+			)
 		);
 		await act(() => user.keyboard('{Tab}'));
 
@@ -418,18 +434,22 @@ describe('DateRangePicker', () => {
 			const user = userEvent.setup();
 
 			// Type valid dates in the input fields that are not in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Start date (e.g. 05/08/2015) (optional)',
-				}),
-				'23-05-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Start date (e.g. 05/08/2015) (optional)',
+					}),
+					'23-05-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'End date (e.g. 06/08/2015) (optional)',
-				}),
-				'24-06-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'End date (e.g. 06/08/2015) (optional)',
+					}),
+					'24-06-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -454,19 +474,23 @@ describe('DateRangePicker', () => {
 			const user = userEvent.setup();
 
 			// Type valid dates in the input fields that are not in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Start date (e.g. 05/08/2015) (optional)',
-				}),
-				'05-23-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Start date (e.g. 05/08/2015) (optional)',
+					}),
+					'05-23-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'End date (e.g. 06/08/2015) (optional)',
-				}),
-				'06-24-2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'End date (e.g. 06/08/2015) (optional)',
+					}),
+					'06-24-2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -492,19 +516,23 @@ describe('DateRangePicker', () => {
 			const user = userEvent.setup();
 
 			// Type valid dates in the input field that isn't in the display format
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'Start date (e.g. 05 August 2015) (optional)',
-				}),
-				'08 Feb 2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'Start date (e.g. 05 August 2015) (optional)',
+					}),
+					'08 Feb 2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
-			await user.type(
-				screen.getByRole('textbox', {
-					name: 'End date (e.g. 06 August 2015) (optional)',
-				}),
-				'09 Mar 2023'
+			await act(() =>
+				user.type(
+					screen.getByRole('textbox', {
+						name: 'End date (e.g. 06 August 2015) (optional)',
+					}),
+					'09 Mar 2023'
+				)
 			);
 			await act(() => user.keyboard('{Tab}'));
 
@@ -773,24 +801,28 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type in a valid value
-		await user.type(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
-			fromValidDateAsString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
+				fromValidDateAsString
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
 		).toHaveValue(fromValidDateAsString);
 
-		await user.type(
-			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
-			toValidDateAsString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
+				toValidDateAsString
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
 		).toHaveValue(toValidDateAsString);
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			dateRange: {
@@ -815,7 +847,7 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onError).not.toHaveBeenCalled();
 		expect(onSubmit).toHaveBeenCalledWith({
 			dateRange: { from: undefined, to: undefined },
@@ -837,17 +869,21 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type in an invalid value
-		await user.type(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
-			'hi'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
+				'hi'
+			)
 		);
-		await user.type(
-			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
-			'hello'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
+				'hello'
+			)
 		);
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onError).toHaveBeenCalledTimes(1);
 
 		// Expect an error
@@ -870,21 +906,25 @@ describe('DateRangePicker', () => {
 		).toHaveAttribute('aria-invalid', 'true');
 
 		// Type in a valid value
-		await user.clear(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
+		await act(() =>
+			user.clear(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
 		).toHaveValue('');
-		await user.clear(
-			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
+		await act(() =>
+			user.clear(
+				screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
 		).toHaveValue('');
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onSubmit).toHaveBeenCalledWith({
 			dateRange: { from: undefined, to: undefined },
 		});
@@ -905,13 +945,15 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type in an invalid value
-		await user.type(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
-			'hello'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
+				'hello'
+			)
 		);
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onError).toHaveBeenCalledTimes(1);
 
 		// Expect an error
@@ -928,15 +970,17 @@ describe('DateRangePicker', () => {
 		).toHaveAttribute('aria-invalid', 'true');
 
 		// Type in a valid value
-		await user.clear(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
+		await act(() =>
+			user.clear(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
 		).toHaveValue('');
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onSubmit).toHaveBeenCalledWith({
 			dateRange: { from: undefined, to: undefined },
 		});
@@ -957,17 +1001,21 @@ describe('DateRangePicker', () => {
 		const user = userEvent.setup();
 
 		// Type in an invalid value
-		await user.type(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
-			'hi'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
+				'hi'
+			)
 		);
-		await user.type(
-			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
-			'hello'
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
+				'hello'
+			)
 		);
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onError).toHaveBeenCalledTimes(1);
 
 		// Expect an error
@@ -993,36 +1041,44 @@ describe('DateRangePicker', () => {
 		const toValidDateAsString = '03/03/2024';
 
 		// Type in a valid value
-		await user.clear(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
+		await act(() =>
+			user.clear(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
 		).toHaveValue('');
-		await user.type(
-			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
-			fromValidDateAsString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' }),
+				fromValidDateAsString
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'Start date (e.g. 05/08/2015)' })
 		).toHaveValue(fromValidDateAsString);
 
-		await user.clear(
-			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
+		await act(() =>
+			user.clear(
+				screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
 		).toHaveValue('');
-		await user.type(
-			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
-			toValidDateAsString
+		await act(() =>
+			user.type(
+				screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' }),
+				toValidDateAsString
+			)
 		);
 		expect(
 			screen.getByRole('textbox', { name: 'End date (e.g. 06/08/2015)' })
 		).toHaveValue(toValidDateAsString);
 
 		// Submit the form
-		await user.click(screen.getByRole('button', { name: 'Submit' }));
+		await act(() => user.click(screen.getByRole('button', { name: 'Submit' })));
 		expect(onSubmit).toHaveBeenCalledWith({
 			dateRange: {
 				from: parseDate(fromValidDateAsString),


### PR DESCRIPTION
The existing tests for date-picker and date-range-picker were full of state warnings, and these carried across into the next versions of these components, too.

There were so many and it was annoying, so I fixed them.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1940)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
