### PR TITLE
yourgov: Update all error messages to X is Y

### DIFF
--- a/.changeset/hungry-maps-crash.md
+++ b/.changeset/hungry-maps-crash.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/yourgov': minor
+---
+
+yourgov: Update all error messages to X is Y.

--- a/yourgov/components/FormMobileFoodVendorPermit/steps/FormState.ts
+++ b/yourgov/components/FormMobileFoodVendorPermit/steps/FormState.ts
@@ -12,10 +12,10 @@ import { type Status } from '../FormState';
 import { StaffMember } from '../../Staff/lib/types';
 
 export const stepOwnerDetailsFormSchema = z.object({
-	firstName: zodString('Enter your first name'),
-	lastName: zodString('Enter your last name'),
-	email: zodString('Enter your email address').email(
-		'Enter a valid email address'
+	firstName: zodString('First name is required'),
+	lastName: zodString('Last name is required'),
+	email: zodString('Email address is required').email(
+		'Email address is invalid'
 	),
 	mobileNumber: zodPhoneField(),
 	contactMethod: zodStringOptional(),
@@ -69,11 +69,11 @@ export type StepBusinessDetailsFormSchema = z.infer<
 export const stepBusinessAddressFormSchema = z
 	.object({
 		// business address
-		streetAddress: zodString('Enter your street address'),
-		suburbTownCity: zodString('Enter your suburb, town or city'),
-		state: zodString('Enter your state'),
-		postcode: zodString('Enter your postcode').length(4, {
-			message: 'An Australian postcode is 4 digits long',
+		streetAddress: zodString('Street address is required'),
+		suburbTownCity: zodString('Suburb, town or city is required'),
+		state: zodString('State or territory is required'),
+		postcode: zodString('Postcode is required').length(4, {
+			message: 'Postcode must be 4 digits',
 		}),
 		// postal address
 		isPostalAddressSameAsBusinessAddress: z.boolean(),
@@ -90,7 +90,7 @@ export const stepBusinessAddressFormSchema = z
 		) {
 			context.addIssue({
 				code: ZodIssueCode.invalid_string,
-				message: message || `Enter your ${label}`,
+				message: message || `${label} is required`,
 				validation: { includes: '' },
 				path: [key],
 			});
@@ -98,22 +98,18 @@ export const stepBusinessAddressFormSchema = z
 
 		if (!value.isPostalAddressSameAsBusinessAddress) {
 			if (!value.postalAddress) {
-				addIssue('postalAddress', 'postal address');
+				addIssue('postalAddress', 'Postal address');
 			}
 			if (!value.postalSuburbTownCity) {
-				addIssue('postalSuburbTownCity', 'suburb, town or city');
+				addIssue('postalSuburbTownCity', 'Suburb, town or city');
 			}
 			if (!value.postalState) {
-				addIssue('postalState', 'state');
+				addIssue('postalState', 'State or territory');
 			}
 			if (!value.postalPostcode) {
-				addIssue('postalPostcode', 'postcode');
+				addIssue('postalPostcode', 'Postcode');
 			} else if (value.postalPostcode.length !== 4) {
-				addIssue(
-					'postalPostcode',
-					'postcode',
-					'An Australian postcode is 4 digits long'
-				);
+				addIssue('postalPostcode', 'Postcode', 'Postcode must be 4 digits');
 			}
 		}
 	});
@@ -164,10 +160,10 @@ export type StepFoodServedFormSchema = z.infer<typeof stepFoodServedFormSchema>;
 export const stepEmployeesFormSchema = z.object({
 	employee: z.object({
 		id: zodString(),
-		firstName: zodString('Enter employee’s first name'),
-		lastName: zodString('Enter employee’s last name'),
-		email: zodString('Enter employee’s email address').email(
-			'Enter a valid email address'
+		firstName: zodString('First name is required'),
+		lastName: zodString('Last name is required'),
+		email: zodString('Email address is required').email(
+			'Email address is invalid'
 		),
 	}),
 });
@@ -265,14 +261,14 @@ export const defaultFormState: DeepPartial<FormState> = {
 
 export const inviteStaffFormSchema = z.object({
 	id: zodString(),
-	firstName: zodString('Enter employee’s first name'),
-	lastName: zodString('Enter employee’s last name'),
-	email: zodString('Enter employee’s email address').email(
-		'Enter a valid email address'
+	firstName: zodString('First name is required'),
+	lastName: zodString('Last name is required'),
+	email: zodString('Email address is required').email(
+		'Email address is invalid'
 	),
-	mobile: zodPhoneField('Enter employee’s mobile number'),
+	mobile: zodPhoneField('Mobile number'),
 	role: z.enum(['Manager', 'Employee', 'Trainee', 'Work experience'], {
-		errorMap: () => ({ message: 'Please choose a role' }),
+		errorMap: () => ({ message: 'Role is required' }),
 	}),
 	trainingCompleted: z.array(
 		z.enum(['Deliveries', 'Distribution', 'Ice cream making', 'Packaging'])
@@ -283,7 +279,7 @@ export type InviteStaffFormSchema = z.infer<typeof inviteStaffFormSchema>;
 
 export const editStaffFormSchema = z.object({
 	role: z.enum(['Manager', 'Employee', 'Trainee', 'Work experience'], {
-		errorMap: () => ({ message: 'Please choose a role' }),
+		errorMap: () => ({ message: 'Role is required' }),
 	}),
 	trainingCompleted: z.array(
 		z.enum(['Deliveries', 'Distribution', 'Ice cream making', 'Packaging'])

--- a/yourgov/components/FormMobileFoodVendorPermit/steps/StepTradingTimeForm.tsx
+++ b/yourgov/components/FormMobileFoodVendorPermit/steps/StepTradingTimeForm.tsx
@@ -157,7 +157,7 @@ export function StepTradingTimeForm() {
 
 	// FIXME: This should ideally be handled in zod
 	const tradingPeriodError = hasErrors.tradingPeriod.both
-		? 'Start date and End date are required'
+		? 'Start date and End date is required'
 		: hasErrors.tradingPeriod.from
 		? 'Start date is required'
 		: hasErrors.tradingPeriod.to

--- a/yourgov/components/FormMobileFoodVendorPermit/steps/StepUploadDocumentsForm.tsx
+++ b/yourgov/components/FormMobileFoodVendorPermit/steps/StepUploadDocumentsForm.tsx
@@ -321,7 +321,7 @@ export function StepUploadDocumentsForm() {
 							invalid={fileUploadInvalid}
 							label={`Upload ${currentDocument?.documentType}`}
 							maxSize={2000}
-							message="File is required."
+							message={`${currentDocument?.documentType} is required`}
 							onChange={(file) => {
 								setUploadedFile(file);
 								if (file.length) {

--- a/yourgov/components/Staff/DashboardFilterDrawer.tsx
+++ b/yourgov/components/Staff/DashboardFilterDrawer.tsx
@@ -227,11 +227,11 @@ export const DashboardFilterDrawer = ({
 							legend="Last active"
 							message={
 								fromInvalid && toInvalid
-									? 'Enter valid From and To dates'
+									? 'From date and To date is invalid'
 									: fromInvalid
-									? 'Enter a valid From date'
+									? 'From date is invalid'
 									: toInvalid
-									? 'Enter a valid To date'
+									? 'To date is invalid'
 									: undefined
 							}
 							onChange={(dateRange) => {

--- a/yourgov/lib/zodUtils.ts
+++ b/yourgov/lib/zodUtils.ts
@@ -14,40 +14,42 @@ export function zodString(message?: string) {
 export const zodStringOptional = () => z.string().trim().optional();
 
 const phoneError = {
-	lettersOrSymbols: 'Phone number must not include letters or symbols',
+	digitCount: 'must be 10 digits long',
+	lettersOrSymbols: 'must not include letters or symbols',
 	start0402:
 		'Mobile numbers must begin with ‘04’, landline numbers must begin with ‘02’',
-	digitCount: 'The Phone number must be 10 digits long',
 };
 
-export function zodPhoneField(message = 'Enter a phone number') {
+export function zodPhoneField(label = 'Mobile number') {
 	return (
-		zodString(message)
-			.regex(/^[\d\s]+$/, { message: phoneError.lettersOrSymbols })
+		zodString(`${label} is required`)
+			.regex(/^[\d\s]+$/, {
+				message: `${label} ${phoneError.lettersOrSymbols}`,
+			})
 			.regex(/^0[42][\d\s]+$/, { message: phoneError.start0402 })
 			// Refine returns with the wrong type information https://github.com/colinhacks/zod/issues/2474
 			.refine((val) => val.replace(/\s/g, '').length === 10, {
-				message: phoneError.digitCount,
+				message: `${label} ${phoneError.digitCount}`,
 			})
 	);
 }
-export function zodPhoneFieldOptional() {
+export function zodPhoneFieldOptional(label = 'Mobile number') {
 	return (
 		zodStringOptional()
 			.refine((value) => !value || /^[\d\s]+$/.test(value), {
-				message: phoneError.lettersOrSymbols,
+				message: `${label} ${phoneError.lettersOrSymbols}`,
 			})
 			.refine((value) => !value || /^0[42][\d\s]+$/.test(value), {
 				message: phoneError.start0402,
 			})
 			// Refine returns with the wrong type information https://github.com/colinhacks/zod/issues/2474
 			.refine((value) => !value || value?.replace(/\s/g, '').length === 10, {
-				message: phoneError.digitCount,
+				message: `${label} ${phoneError.digitCount}`,
 			})
 	);
 }
 
-export function zodDateField(message = 'Enter a valid date') {
+export function zodDateField(message = 'Date is invalid') {
 	return z
 		.union([
 			z.string({


### PR DESCRIPTION
Updates all error messaging to be "Label" is Verb (Required/Invalid etc)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1948)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
