### PR TITLE
date-pickers: Fix Escape keydown to not close parent Drawer

### DIFF
--- a/.changeset/fifty-mirrors-collect.md
+++ b/.changeset/fifty-mirrors-collect.md
@@ -1,0 +1,15 @@
+---
+'@ag.ds-next/react': patch
+'@ag.ds-next/docs': patch
+---
+
+
+date-picker: Fix Escape keydown listener to not close parent `Drawer`.
+
+date-picker-next: Fix Escape keydown listener to not close parent `Drawer`.
+
+date-range-picker: Fix Escape keydown listener to not close parent `Drawer`.
+
+date-range-picker-next: Fix Escape keydown listener to not close parent `Drawer`.
+
+drawer: Add `DatePickerNext` to form example.

--- a/.changeset/fifty-mirrors-collect.md
+++ b/.changeset/fifty-mirrors-collect.md
@@ -1,5 +1,6 @@
 ---
 '@ag.ds-next/react': patch
+'@ag.ds-next/yourgov': patch
 '@ag.ds-next/docs': patch
 ---
 
@@ -13,3 +14,5 @@ date-range-picker: Fix Escape keydown listener to not close parent `Drawer`.
 date-range-picker-next: Fix Escape keydown listener to not close parent `Drawer`.
 
 drawer: Add `DatePickerNext` to form example.
+
+yourgov: Allow pdf files in Upload documents.

--- a/packages/react/src/date-picker-next/DatePickerNext.tsx
+++ b/packages/react/src/date-picker-next/DatePickerNext.tsx
@@ -181,8 +181,9 @@ export const DatePickerNext = ({
 				closeCalendar();
 			}
 		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
+		window.addEventListener('keydown', handleKeyDown, { capture: true });
+		return () =>
+			window.removeEventListener('keydown', handleKeyDown, { capture: true });
 	}, [isCalendarOpen, closeCalendar]);
 
 	const disabledCalendarDays = useMemo(() => {

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -190,8 +190,9 @@ export const DatePicker = ({
 				closeCalendar();
 			}
 		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
+		window.addEventListener('keydown', handleKeyDown, { capture: true });
+		return () =>
+			window.removeEventListener('keydown', handleKeyDown, { capture: true });
 	}, [isCalendarOpen, closeCalendar]);
 
 	const disabledCalendarDays = useMemo(() => {

--- a/packages/react/src/date-range-picker-next/DateRangePickerNext.tsx
+++ b/packages/react/src/date-range-picker-next/DateRangePickerNext.tsx
@@ -296,8 +296,9 @@ export const DateRangePickerNext = ({
 				closeCalendarAndFocusTrigger();
 			}
 		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
+		window.addEventListener('keydown', handleKeyDown, { capture: true });
+		return () =>
+			window.removeEventListener('keydown', handleKeyDown, { capture: true });
 	}, [closeCalendarAndFocusTrigger, isCalendarOpen]);
 
 	const disabledCalendarDays = useMemo(() => {

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -294,8 +294,9 @@ export const DateRangePicker = ({
 				setInputMode(undefined);
 			}
 		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
+		window.addEventListener('keydown', handleKeyDown, { capture: true });
+		return () =>
+			window.removeEventListener('keydown', handleKeyDown, { capture: true });
 	}, [isCalendarOpen, closeCalendar]);
 
 	const disabledCalendarDays = useMemo(() => {

--- a/packages/react/src/drawer/docs/overview.mdx
+++ b/packages/react/src/drawer/docs/overview.mdx
@@ -425,11 +425,17 @@ This will allow keyboard users to submit the form by pressing "enter" on the for
 () => {
 	const formRef = React.useRef(null);
 	const [isDrawerOpen, openDrawer, closeDrawer] = useTernaryState(false);
+	const [dateValue, setDateValue] = React.useState();
+	const [value, setValue] = React.useState({ from: undefined, to: undefined });
+
 	const onSubmitForm = (event) => {
 		event.preventDefault();
 
 		const formData = Object.fromEntries(new FormData(formRef.current));
-		console.log('Form submitted with values:', formData);
+		console.log('Form submitted with values:', {
+			...formData,
+			dateInput: dateValue,
+		});
 
 		closeDrawer();
 	};
@@ -459,9 +465,15 @@ This will allow keyboard users to submit the form by pressing "enter" on the for
 						<TextInput label="Example text input" name="textInput" />
 
 						<TextInput
-							label="Example text input"
+							label="Example number input"
 							name="numberInput"
 							type="number"
+						/>
+
+						<DatePickerNext
+							label="Select date"
+							value={dateValue}
+							onChange={setDateValue}
 						/>
 					</FormStack>
 				</form>

--- a/yourgov/components/FormMobileFoodVendorPermit/steps/StepUploadDocumentsForm.tsx
+++ b/yourgov/components/FormMobileFoodVendorPermit/steps/StepUploadDocumentsForm.tsx
@@ -315,7 +315,7 @@ export function StepUploadDocumentsForm() {
 				>
 					<Stack as="form" id="upload-document-form">
 						<FileUpload
-							accept={['image/jpeg', 'image/png']}
+							accept={['image/jpeg', 'application/pdf', 'image/png']}
 							buttonRef={fileUploadRef}
 							hideOptionalLabel
 							invalid={fileUploadInvalid}


### PR DESCRIPTION
Discovered that all Date Pickers in Drawers closed the Drawer instead of the Calendar when pressing Escape.

Also allowing PDFs in Upload Documents in yourgov.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1949)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
