### PR TITLE
file-upload: Add download support for uploaded and existing files

### DIFF
--- a/.changeset/gentle-games-hug.md
+++ b/.changeset/gentle-games-hug.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+file-upload: Add `download` support for uploaded and existing files.

--- a/packages/react/src/file-upload/FileUpload.stories.tsx
+++ b/packages/react/src/file-upload/FileUpload.stories.tsx
@@ -274,7 +274,7 @@ export const ExistingFiles: Story = {
 			{
 				name: 'example.png',
 				size: 123456,
-				thumbnailSrc: 'https://via.placeholder.com/150',
+				thumbnailSrc: 'https://placehold.co/144',
 				href: '#',
 				// Use the meta key to keep track of any extra file info
 				// This can be useful info when deleting the file

--- a/packages/react/src/file-upload/FileUpload.test.tsx
+++ b/packages/react/src/file-upload/FileUpload.test.tsx
@@ -129,7 +129,7 @@ describe('FileUpload', () => {
 			{
 				name: 'example.png',
 				size: 123456,
-				thumbnailSrc: 'https://via.placeholder.com/150',
+				thumbnailSrc: 'https://placehold.co/144',
 				href: '#',
 				// Use the meta key to keep track of any extra file info
 				// This can be useful info when deleting the file

--- a/packages/react/src/file-upload/FileUploadExistingFile.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.stories.tsx
@@ -36,7 +36,7 @@ export const WithThumbnail: Story = {
 	args: {
 		file: {
 			name: 'example.jpg',
-			thumbnailSrc: 'https://via.placeholder.com/150',
+			thumbnailSrc: 'https://placehold.co/144',
 			size: 123456,
 		},
 	},
@@ -48,7 +48,7 @@ export const WithHref: Story = {
 		file: {
 			name: 'example.jpg',
 			href: '#',
-			thumbnailSrc: 'https://via.placeholder.com/150',
+			thumbnailSrc: 'https://placehold.co/144',
 			size: 123456,
 		},
 	},

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -19,7 +19,7 @@ export const FileUploadExistingFile = ({
 	hideThumbnails,
 	onRemove,
 }: FileUploadExistingFileProps) => {
-	const { name, size, href, thumbnailSrc } = file;
+	const { download, href, name, size, thumbnailSrc } = file;
 	const showThumbnail = !hideThumbnails;
 	return (
 		<Flex
@@ -43,7 +43,12 @@ export const FileUploadExistingFile = ({
 					</Box>
 					{href ? (
 						<Text breakWords paddingY={1.5}>
-							<TextLink href={href} rel="noopener noreferrer" target="_blank">
+							<TextLink
+								download={download}
+								href={href}
+								rel="noopener noreferrer"
+								target="_blank"
+							>
 								{name}
 								{size ? ` (${formatFileSize(size)})` : null}
 							</TextLink>

--- a/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
@@ -23,7 +23,7 @@ export const Basic: Story = {
 			{
 				name: 'example.jpg',
 				size: 123456,
-				thumbnailSrc: 'https://via.placeholder.com/150',
+				thumbnailSrc: 'https://placehold.co/144',
 			},
 		],
 	},

--- a/packages/react/src/file-upload/FileUploadFile.tsx
+++ b/packages/react/src/file-upload/FileUploadFile.tsx
@@ -20,7 +20,7 @@ export const FileUploadFile = ({
 	hideThumbnails,
 	onRemove,
 }: FileUploadFileProps) => {
-	const { name, size, status = 'none', href } = file;
+	const { download, href, name, size, status = 'none' } = file;
 	const showThumbnail = !hideThumbnails;
 	const imagePreview = useMemo(() => getImageThumbnail(file), [file]);
 	return (
@@ -47,7 +47,12 @@ export const FileUploadFile = ({
 					)}
 					{href ? (
 						<Text breakWords paddingY={1.5}>
-							<TextLink href={href} rel="noopener noreferrer" target="_blank">
+							<TextLink
+								download={download}
+								href={href}
+								rel="noopener noreferrer"
+								target="_blank"
+							>
 								{name}
 								{size ? ` (${formatFileSize(size)})` : null}
 							</TextLink>

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -469,7 +469,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
               class="css-1jhrbpg-boxStyles"
             >
               <div
-                class="css-v42gao-boxStyles-FileUploadFileThumbnail"
+                class="css-v9fqu3-boxStyles-FileUploadFileThumbnail"
               />
               <div
                 class="css-w79ye0-boxStyles"

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -176,7 +176,7 @@ Unlike the `value` prop, which expects an array of `File` objects, `existingFile
 
 If a user attempts to delete an existing file, a destructive confirmation modal should be displayed. If confirmed, the file should be deleted on the server.
 
-Image files should be displayed with thumbnails which are 72px by 72px. Passing full-size images to `thumbnailSrc` prop will result with long load times.
+Image files should be displayed with thumbnails which are 144px by 144px. Passing full-size images to `thumbnailSrc` prop will result in unnecessarily longer load times.
 
 ```jsx live
 () => {
@@ -184,7 +184,7 @@ Image files should be displayed with thumbnails which are 72px by 72px. Passing 
 		{
 			name: 'example.png',
 			size: 123456,
-			thumbnailSrc: 'https://via.placeholder.com/150',
+			thumbnailSrc: 'https://placehold.co/144',
 			href: '#',
 			// Use the meta key to keep track of any extra file info
 			// This can be useful info when deleting the file
@@ -196,7 +196,17 @@ Image files should be displayed with thumbnails which are 72px by 72px. Passing 
 			href: '#',
 			// Use the meta key to keep track of any extra file info
 			// This can be useful info when deleting the file
-			meta: { uid: 'fed=cba', bucketId: '654-321' },
+			meta: { uid: 'fed-cba', bucketId: '654-321' },
+		},
+		{
+			name: 'example-download-this-page.html',
+			size: 999,
+			href: '/components/file-upload',
+			// Instructs the browser to treat the link as a download
+			download: true,
+			// Use the meta key to keep track of any extra file info
+			// This can be useful info when deleting the file
+			meta: { uid: 'zyx-wvu', bucketId: '999-888' },
 		},
 	]);
 

--- a/packages/react/src/file-upload/test-utils.ts
+++ b/packages/react/src/file-upload/test-utils.ts
@@ -1,20 +1,22 @@
 import { FileStatus, FileWithStatus } from './utils';
 
 export function createExampleFile(args?: {
-	status?: FileStatus;
-	name?: string;
-	type?: string;
+	download?: boolean;
 	href?: string;
 	lastModified?: number;
+	name?: string;
 	size?: number;
+	status?: FileStatus;
+	type?: string;
 }): FileWithStatus {
 	const {
-		status,
-		name = 'example.txt',
-		type = 'text/plain',
+		download,
 		href,
 		lastModified = new Date().getMilliseconds(),
+		name = 'example.txt',
 		size = 100,
+		status,
+		type = 'text/plain',
 	} = args || {};
 
 	const bits = ['examplefilecontent'];
@@ -24,21 +26,24 @@ export function createExampleFile(args?: {
 
 	const file: Omit<FileWithStatus, 'prototype'> = {
 		...baseFile,
-		name,
-		type,
 		lastModified,
+		name,
 		size,
+		type,
 	};
-	file.status = status;
+	file.download = download;
 	file.href = href;
+	file.status = status;
 	return file as FileWithStatus;
 }
 
 export function createExampleImageFile(args?: {
+	download?: boolean;
+	href?: string;
 	name?: string;
 	status?: FileStatus;
 }): FileWithStatus {
-	const { name = 'example.jpg', status } = args || {};
+	const { download, href, name = 'example.jpg', status } = args || {};
 
 	// Created by passing a 72x72 jpg to onlinejpgtools.com/convert-jpg-to-base64
 	const imageBase64 =
@@ -49,6 +54,8 @@ export function createExampleImageFile(args?: {
 	const file: FileWithStatus = new File(blob, name, {
 		type: 'image/jpg',
 	});
+	file.download = download;
+	file.href = href;
 	file.status = status;
 	return file;
 }

--- a/packages/react/src/file-upload/utils.test.tsx
+++ b/packages/react/src/file-upload/utils.test.tsx
@@ -35,10 +35,10 @@ describe('createExampleFile', () => {
 			)
 		).toBe(
 			JSON.stringify({
-				name: 'example.txt',
-				type: 'text/plain',
 				lastModified: 100,
+				name: 'example.txt',
 				size: 100,
+				type: 'text/plain',
 			})
 		);
 	});
@@ -46,21 +46,23 @@ describe('createExampleFile', () => {
 		expect(
 			JSON.stringify(
 				createExampleFile({
+					download: true,
 					href: '/',
+					lastModified: 100,
 					name: 'example',
 					status: 'success',
 					type: 'image/png',
-					lastModified: 100,
 				})
 			)
 		).toBe(
 			JSON.stringify({
-				name: 'example',
-				type: 'image/png',
 				lastModified: 100,
+				name: 'example',
 				size: 100,
-				status: 'success',
+				type: 'image/png',
+				download: true,
 				href: '/',
+				status: 'success',
 			})
 		);
 	});

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -4,10 +4,12 @@ import { filesize } from './filesize';
 export type FileStatus = 'none' | 'uploading' | 'success';
 
 export type FileWithStatus = FileWithPath & {
-	/** Use to indicate the upload status of a file. */
-	status?: FileStatus;
+	/** If true, causes the browser to treat the linked href as a download. */
+	download?: boolean;
 	/** Used to link to a webpage where the user can view/download the existing file. */
 	href?: string;
+	/** Use to indicate the upload status of a file. */
+	status?: FileStatus;
 };
 
 export type RejectedFile = {
@@ -16,6 +18,8 @@ export type RejectedFile = {
 };
 
 export type ExistingFile = {
+	/** If true, causes the browser to treat the linked href as a download. */
+	download?: boolean;
 	/** The file name. */
 	name: string;
 	/** Link to a webpage where the user can view/download the existing file (optional) */


### PR DESCRIPTION
A team needed the option to make existing files downloadable (using the `download` attribute).

Also found that placeholder.com no longer works, so updated these to a different service.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1950)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
