### PR TITLE
chore: Fix all act/state warnings in tests

### DIFF
--- a/.changeset/calm-cats-yell.md
+++ b/.changeset/calm-cats-yell.md
@@ -25,4 +25,3 @@ tabs: Fix all `act`/state warnings in tests.
 time-input: Fix all `act`/state warnings in tests.
 
 time-picker: Fix all `act`/state warnings in tests.
-

--- a/.changeset/calm-cats-yell.md
+++ b/.changeset/calm-cats-yell.md
@@ -1,0 +1,28 @@
+---
+'@ag.ds-next/react': patch
+---
+
+accordion: Fix all `act`/state warnings in tests.
+
+autocomplete: Fix all `act`/state warnings in tests.
+
+combobox: Fix all `act`/state warnings in tests.
+
+drawer: Fix all `act`/state warnings in tests.
+
+dropdown-menu: Fix all `act`/state warnings in tests.
+
+modal: Fix all `act`/state warnings in tests.
+
+password-input: Fix all `act`/state warnings in tests.
+
+search-input: Fix all `act`/state warnings in tests.
+
+side-nav: Fix all `act`/state warnings in tests.
+
+tabs: Fix all `act`/state warnings in tests.
+
+time-input: Fix all `act`/state warnings in tests.
+
+time-picker: Fix all `act`/state warnings in tests.
+

--- a/packages/react/src/accordion/Accordion.test.tsx
+++ b/packages/react/src/accordion/Accordion.test.tsx
@@ -3,7 +3,7 @@ import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { Text } from '../text';
-import { cleanup, render, screen } from '../../../../test-utils';
+import { act, cleanup, render, screen } from '../../../../test-utils';
 import { Accordion } from './Accordion';
 import { AccordionItem, AccordionItemContent } from './AccordionItem';
 
@@ -60,7 +60,7 @@ describe('Accordion', () => {
 		expect(titleEl.tagName).toBe('BUTTON');
 		expect(titleEl).toHaveAccessibleName('Accordion 1');
 		expect(titleEl).toHaveAttribute('aria-expanded', 'false');
-		await userEvent.click(titleEl);
+		await act(() => userEvent.click(titleEl));
 		expect(titleEl).toHaveAttribute('aria-expanded', 'true');
 	});
 });

--- a/packages/react/src/autocomplete/Autocomplete.test.tsx
+++ b/packages/react/src/autocomplete/Autocomplete.test.tsx
@@ -63,14 +63,16 @@ describe('Autocomplete', () => {
 		if (!input) return;
 
 		// Focus the input
-		await act(async () => await input.focus());
+		act(() => input.focus());
 		expect(input).toHaveFocus();
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 
 		expect(loadOptions).not.toHaveBeenCalled();
 
+		const user = userEvent.setup();
+
 		// Start typing a search term
-		await userEvent.type(input, 'qld');
+		await act(() => user.type(input, 'qld'));
 
 		// Loading state should be visible
 		expect(container.querySelectorAll('li').length).toBe(1);
@@ -88,7 +90,7 @@ describe('Autocomplete', () => {
 
 		// Select the QLD option
 		const options = container.querySelectorAll('li');
-		await userEvent.click(options[0]);
+		await act(() => user.click(options[0]));
 
 		// Expect the input to be updated
 		expect(input.value).toBe('Queensland');
@@ -96,7 +98,7 @@ describe('Autocomplete', () => {
 		expect(input).toHaveFocus();
 
 		// Since the input is focused, use the arrow down key to open the menu
-		await userEvent.keyboard('[ArrowDown]');
+		await act(() => user.keyboard('[ArrowDown]'));
 
 		// Loading state should be visible
 		expect(container.querySelectorAll('li').length).toBe(1);
@@ -113,7 +115,7 @@ describe('Autocomplete', () => {
 		});
 
 		// Press escape to close the menu
-		await userEvent.keyboard('[Escape]');
+		await act(() => user.keyboard('[Escape]'));
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 		expect(input).toHaveFocus();
 
@@ -122,7 +124,7 @@ describe('Autocomplete', () => {
 		expect(clearButton).toBeInTheDocument();
 		expect(clearButton).toHaveAttribute('aria-label', 'Clear input');
 
-		if (clearButton) await userEvent.click(clearButton);
+		if (clearButton) await act(() => user.click(clearButton));
 
 		// Expect the input to be updated
 		expect(input.value).toBe('');

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import { render, act, screen } from '../../../../test-utils';
+import { act, render, screen } from '../../../../test-utils';
 import { Combobox, ComboboxProps } from './Combobox';
 import { STATE_OPTIONS, Option } from './test-utils';
 
@@ -55,16 +55,19 @@ describe('Combobox', () => {
 			const input = screen.getByRole('combobox');
 
 			const user = userEvent.setup();
-			await user.click(input);
-			user.type(input, 'capital');
+			await act(() => user.click(input));
+			await act(() => user.type(input, 'capital'));
 
 			const option = screen.getByRole('option', {
 				name: 'Australian Capital Territory',
 			});
 
 			// userEvent.click(option) does not fire the change event in downshift - using direct click method on the option as a workaround
-			option.click();
-			const updatedInput = await screen.findByRole('combobox');
+			let updatedInput;
+			await act(async () => {
+				option.click();
+				updatedInput = await screen.findByRole('combobox');
+			});
 
 			expect(updatedInput).toHaveValue('Australian Capital Territory');
 		});

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -63,11 +63,10 @@ describe('Combobox', () => {
 			});
 
 			// userEvent.click(option) does not fire the change event in downshift - using direct click method on the option as a workaround
-			let updatedInput;
-			await act(async () => {
+			act(() => {
 				option.click();
-				updatedInput = await screen.findByRole('combobox');
 			});
+			const updatedInput = await screen.findByRole('combobox');
 
 			expect(updatedInput).toHaveValue('Australian Capital Territory');
 		});

--- a/packages/react/src/combobox/ComboboxAsync.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.test.tsx
@@ -56,6 +56,7 @@ describe('ComboboxAsync', () => {
 	it('can load async options', async () => {
 		const loadOptions = jest.fn().mockResolvedValue(STATE_OPTIONS);
 		const { container } = renderComboboxAsync({ loadOptions });
+		const user = userEvent.setup();
 
 		const input = container.querySelector('input');
 		expect(input).toBeInTheDocument();
@@ -63,7 +64,7 @@ describe('ComboboxAsync', () => {
 		if (!input) return;
 
 		// Click the input, which should focus the element
-		await act(async () => await input.click());
+		act(() => input.click());
 		await waitFor(() => expect(input).toHaveFocus());
 		expect(input).toHaveAttribute('aria-expanded', 'true');
 
@@ -77,7 +78,7 @@ describe('ComboboxAsync', () => {
 		expect(container.querySelectorAll('li').length).toBe(STATE_OPTIONS.length);
 
 		// Start typing a search term
-		await userEvent.type(input, 'qld');
+		await act(() => user.type(input, 'qld'));
 
 		// Typing a search term should trigger `loadOptions` to be called and 1 option to appear
 		await waitFor(() => {
@@ -91,7 +92,7 @@ describe('ComboboxAsync', () => {
 
 		// Select the QLD option
 		const options = container.querySelectorAll('li');
-		await userEvent.click(options[0]);
+		await act(() => user.click(options[0]));
 
 		// Expect the input to be updated
 		expect(input.value).toBe('Queensland');
@@ -99,7 +100,7 @@ describe('ComboboxAsync', () => {
 		expect(input).toHaveFocus();
 
 		// Since the input is focused, use the arrow down key to open the menu
-		await userEvent.keyboard('[ArrowDown]');
+		await act(() => user.keyboard('[ArrowDown]'));
 
 		// Loading state should be visible
 		expect(container.querySelectorAll('li').length).toBe(1);
@@ -116,7 +117,7 @@ describe('ComboboxAsync', () => {
 		});
 
 		// Press escape to close the menu
-		await userEvent.keyboard('[Escape]');
+		await act(() => user.keyboard('[Escape]'));
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 		expect(input).toHaveFocus();
 
@@ -147,12 +148,12 @@ describe('ComboboxAsync', () => {
 		if (!input) return;
 
 		// After focus of the input, check the events have been called correctly
-		await act(async () => await input.focus());
+		act(() => input.focus());
 		expect(onFocus).toHaveBeenCalledTimes(1);
 		expect(onBlur).toHaveBeenCalledTimes(0);
 
 		// After blur of the input, // check the events have been called correctly
-		await act(async () => await input.blur());
+		act(() => input.blur());
 		expect(input).not.toHaveAttribute('aria-expanded', 'true');
 		expect(onFocus).toHaveBeenCalledTimes(1);
 		expect(onBlur).toHaveBeenCalledTimes(1);

--- a/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
@@ -145,7 +145,8 @@ describe('ComboboxAsyncMulti', () => {
 	});
 
 	describe('when a search term is entered', () => {
-		test('then the loadOptions prop is called with the input value', async () => {
+		// FIXME: This test fails in CI
+		test.skip('then the loadOptions prop is called with the input value', async () => {
 			const loadOptions = jest.fn().mockResolvedValue(STATE_OPTIONS);
 			render(
 				<ComboboxAsyncMulti

--- a/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
@@ -66,7 +66,7 @@ describe('ComboboxAsyncMulti', () => {
 				name: 'Find your state (optional)',
 			});
 			const user = userEvent.setup();
-			await user.click(input);
+			await act(() => user.click(input));
 
 			const menu = screen.getByRole('listbox', {
 				name: 'Find your state (optional)',
@@ -89,7 +89,7 @@ describe('ComboboxAsyncMulti', () => {
 				name: 'Find your state (optional)',
 			});
 			const user = userEvent.setup();
-			await user.click(input);
+			await act(() => user.click(input));
 
 			const listItem = screen.getByRole('listitem');
 
@@ -110,7 +110,7 @@ describe('ComboboxAsyncMulti', () => {
 				name: 'Find your state (optional)',
 			});
 			const user = userEvent.setup();
-			await user.click(input);
+			await act(() => user.click(input));
 
 			// Focusing the input should trigger `loadOptions`
 			await waitFor(() => {
@@ -133,7 +133,7 @@ describe('ComboboxAsyncMulti', () => {
 				name: 'Find your state (optional)',
 			});
 			const user = userEvent.setup();
-			await user.click(input);
+			await act(() => user.click(input));
 
 			const stateOptionsText = STATE_OPTIONS.map((option) => option.label);
 			const optionsText = (await screen.findAllByRole('option')).map(
@@ -145,7 +145,7 @@ describe('ComboboxAsyncMulti', () => {
 	});
 
 	describe('when a search term is entered', () => {
-		test.skip('then the loadOptions prop is called with the input value', async () => {
+		test('then the loadOptions prop is called with the input value', async () => {
 			const loadOptions = jest.fn().mockResolvedValue(STATE_OPTIONS);
 			render(
 				<ComboboxAsyncMulti
@@ -158,10 +158,12 @@ describe('ComboboxAsyncMulti', () => {
 			const input = screen.getByRole('combobox', {
 				name: 'Find your state (optional)',
 			});
-			const user = userEvent.setup();
-			user.click(input);
 
-			user.type(input, 'qld');
+			const user = userEvent.setup();
+			act(() => {
+				user.click(input);
+				user.type(input, 'qld');
+			});
 
 			await waitFor(() => {
 				expect(loadOptions).toHaveBeenCalledTimes(1);
@@ -184,7 +186,7 @@ describe('ComboboxAsyncMulti', () => {
 			});
 			const user = userEvent.setup();
 			user.click(input);
-			await user.type(input, 'qld');
+			await act(() => user.type(input, 'qld'));
 
 			const options = (await screen.findAllByRole('option')).map(
 				(option) => option.textContent
@@ -210,13 +212,13 @@ describe('ComboboxAsyncMulti', () => {
 			});
 			const user = userEvent.setup();
 			user.click(input);
-			await user.type(input, 'qld');
+			await act(() => user.type(input, 'qld'));
 
 			const option = await screen.findByRole('option', {
 				name: 'Queensland',
 			});
-			option.click();
 
+			act(() => option.click());
 			const tag = await screen.findByText('Queensland');
 			expect(tag).toBeVisible();
 		});
@@ -236,12 +238,12 @@ describe('ComboboxAsyncMulti', () => {
 			});
 			const user = userEvent.setup();
 			user.click(input);
-			await user.type(input, 'qld');
+			await act(() => user.type(input, 'qld'));
 
 			const option = await screen.findByRole('option', {
 				name: 'Queensland',
 			});
-			await user.click(option);
+			await act(() => user.click(option));
 
 			const updatedOptions = (await screen.findAllByRole('option')).map(
 				(option) => option.textContent
@@ -266,8 +268,8 @@ describe('ComboboxAsyncMulti', () => {
 			);
 
 			const user = userEvent.setup();
-			await user.tab();
-			await user.keyboard('[ArrowDown]');
+			await act(() => user.tab());
+			await act(() => user.keyboard('[ArrowDown]'));
 
 			const options = (await screen.findAllByRole('option')).map(
 				(option) => option.textContent
@@ -288,8 +290,8 @@ describe('ComboboxAsyncMulti', () => {
 			);
 
 			const user = userEvent.setup();
-			await user.tab();
-			await userEvent.keyboard('[Escape]');
+			await act(() => user.tab());
+			await act(() => user.keyboard('[Escape]'));
 
 			expect(screen.getByRole('listbox', { hidden: true })).not.toBeVisible();
 		});

--- a/packages/react/src/combobox/ComboboxMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.test.tsx
@@ -72,7 +72,7 @@ describe('ComboboxMulti', () => {
 		if (!input) return;
 
 		// Click the input, which should focus the element
-		await act(async () => await input.click());
+		act(() => input.click());
 		await waitFor(() => expect(input).toHaveFocus());
 		expect(input).toHaveAttribute('aria-expanded', 'true');
 
@@ -88,7 +88,7 @@ describe('ComboboxMulti', () => {
 
 		// Select the QLD option
 		const options = container.querySelectorAll('li');
-		await userEvent.click(options[0]);
+		await act(() => userEvent.click(options[0]));
 
 		// After selecting an item, input should have focus
 		expect(input).toHaveFocus();

--- a/packages/react/src/drawer/Drawer.test.tsx
+++ b/packages/react/src/drawer/Drawer.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { useTernaryState } from '../core';
 import { Button } from '../button';
 import { Text } from '../text';
-import { render, screen, cleanup, waitFor } from '../../../../test-utils';
+import { render, screen, cleanup, waitFor, act } from '../../../../test-utils';
 import { Drawer } from './Drawer';
 
 expect.extend(toHaveNoViolations);
@@ -100,14 +100,14 @@ describe('Drawer', () => {
 		renderDrawer();
 
 		// Open the Drawer by clicking the "Open" button
-		await userEvent.click(screen.getByTestId('open-button'));
+		await act(() => userEvent.click(screen.getByTestId('open-button')));
 		expect(await screen.findByRole('dialog')).toBeInTheDocument();
 
 		// Title should have focus
-		expect(await screen.getByText('Drawer title')).toHaveFocus();
+		expect(screen.getByText('Drawer title')).toHaveFocus();
 
 		// Close the Drawer by clicking the "Close" button
-		await userEvent.click(screen.getByTestId('close-button'));
+		await act(() => userEvent.click(screen.getByTestId('close-button')));
 
 		// After closing the Drawer, the "Open" button should be focused
 		// Note: We need to wait for the closing animation
@@ -115,18 +115,19 @@ describe('Drawer', () => {
 			expect(screen.getByTestId('open-button')).toHaveFocus()
 		);
 	});
+
 	it('onDismiss draw focuses the correct elements when opening and closing', async () => {
 		renderOnDismissDrawer();
 
 		// Open the Drawer by clicking the "Open" button
-		await userEvent.click(screen.getByTestId('open-button'));
+		await act(() => userEvent.click(screen.getByTestId('open-button')));
 		expect(await screen.findByRole('dialog')).toBeInTheDocument();
 
 		// Title should have focus
-		expect(await screen.getByText('Drawer title')).toHaveFocus();
+		expect(screen.getByText('Drawer title')).toHaveFocus();
 
 		// Close the Drawer by clicking the "Close" button
-		await userEvent.click(screen.getByTestId('close-button'));
+		await act(() => userEvent.click(screen.getByTestId('close-button')));
 
 		// After closing the Drawer, the "Open" button should be focused
 		// Note: We need to wait for the closing animation

--- a/packages/react/src/dropdown-menu/DropdownMenu.test.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.test.tsx
@@ -35,7 +35,7 @@ async function openDropdownMenu() {
 	const menuButton = await getDropdownMenuButton();
 	menuButton.focus();
 	expect(menuButton).toHaveFocus();
-	await userEvent.click(menuButton);
+	await act(() => userEvent.click(menuButton));
 }
 
 function renderBasicDropdownMenu() {
@@ -94,7 +94,8 @@ describe('DropdownMenu', () => {
 		expect(menuList).toHaveAttribute('aria-labelledby', menuButton.id);
 
 		// Close the dropdown menu
-		await userEvent.keyboard('{Escape}');
+		const user = userEvent.setup();
+		await act(() => user.keyboard('{Escape}'));
 
 		expect(menuButton).toHaveAttribute('aria-expanded', 'false');
 	});
@@ -103,16 +104,16 @@ describe('DropdownMenu', () => {
 		renderBasicDropdownMenu();
 
 		const menuButton = await getDropdownMenuButton();
-
+		const user = userEvent.setup();
 		// Open the dropdown menu
-		await userEvent.click(menuButton);
+		await act(() => user.click(menuButton));
 
 		// Once the dropdown menu is opened, the menu list should be focused
 		const list = await screen.findByRole('menu');
 		expect(list).toHaveFocus();
 
 		// When closing the dropdown menu, the the trigger should be focused again
-		await userEvent.keyboard('{Escape}');
+		await act(() => user.keyboard('{Escape}'));
 		expect(menuButton).toHaveFocus();
 	});
 
@@ -136,28 +137,30 @@ describe('DropdownMenu', () => {
 		// aria-activedescendant should be empty
 		expect(menuList).not.toHaveAttribute('aria-activedescendant');
 
+		const user = userEvent.setup();
+
 		// Pressing the down key should activate the first descendant
-		await userEvent.keyboard('[ArrowDown]');
+		await act(() => user.keyboard('[ArrowDown]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-1');
 
 		// Pressing the down key should activate the next menu item
-		await userEvent.keyboard('[ArrowDown]');
+		await act(() => user.keyboard('[ArrowDown]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-2');
 
 		// Pressing the down key should activate the previous menu item
-		await userEvent.keyboard('[ArrowUp]');
+		await act(() => user.keyboard('[ArrowUp]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-1');
 
-		await userEvent.keyboard('[ArrowDown]');
-		await userEvent.keyboard('[ArrowDown]');
+		await act(() => user.keyboard('[ArrowDown]'));
+		await act(() => user.keyboard('[ArrowDown]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-3');
 
 		// Pressing the down key at the last menu item should activate the first menu item
-		await userEvent.keyboard('[ArrowDown]');
+		await act(() => user.keyboard('[ArrowDown]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-1');
 
 		// Pressing the up key at the first menu item should activate the last menu item
-		await userEvent.keyboard('[ArrowUp]');
+		await act(() => user.keyboard('[ArrowUp]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-3');
 	});
 
@@ -178,15 +181,17 @@ describe('DropdownMenu', () => {
 
 		const menuList = await screen.findByRole('menu');
 
+		const user = userEvent.setup();
+
 		// aria-activedescendant should be empty
 		expect(menuList).not.toHaveAttribute('aria-activedescendant');
 
 		// Pressing the down key should activate the first descendant
-		await userEvent.keyboard('[Home]');
+		await act(() => user.keyboard('[Home]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-1');
 
 		// Pressing the down key should activate the next menu item
-		await userEvent.keyboard('[End]');
+		await act(() => user.keyboard('[End]'));
 		expect(menuList).toHaveAttribute('aria-activedescendant', 'item-3');
 	});
 
@@ -207,7 +212,7 @@ describe('DropdownMenu', () => {
 
 		// Once the dropdown menu is opened, the menu list should be focused
 		const firstListItem = await screen.findByText('Item 1');
-		await userEvent.click(firstListItem);
+		await act(() => userEvent.click(firstListItem));
 
 		// When closing the dropdown menu, the the trigger should be focused again
 		const menuButton = await getDropdownMenuButton();
@@ -239,7 +244,7 @@ describe('DropdownMenu', () => {
 		expect(menuButton).toHaveTextContent('Open');
 
 		// Open the dropdown menu
-		await userEvent.click(menuButton);
+		await act(() => userEvent.click(menuButton));
 
 		expect(menuButton).toHaveTextContent('Close');
 	});
@@ -506,7 +511,7 @@ describe('DropdownMenu Radio Group', () => {
 
 		// Once the dropdown menu is opened, the menu list should be focused
 		const firstListItem = await screen.findByText('Antfix');
-		await userEvent.click(firstListItem);
+		await act(() => userEvent.click(firstListItem));
 
 		// When closing the dropdown menu, the the trigger should be focused again
 		expect(menuButton).toHaveFocus();

--- a/packages/react/src/modal/Modal.test.tsx
+++ b/packages/react/src/modal/Modal.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { useTernaryState } from '../core';
 import { Button } from '../button';
 import { Text } from '../text';
-import { render, screen, cleanup } from '../../../../test-utils';
+import { act, cleanup, render, screen } from '../../../../test-utils';
 import { Modal } from './Modal';
 
 expect.extend(toHaveNoViolations);
@@ -98,25 +98,25 @@ describe('Modal', () => {
 	it('focuses the correct elements when opening and closing', async () => {
 		renderModal();
 		// Open the modal by clicking the "Open modal" button
-		await userEvent.click(await screen.getByTestId('open-modal-button'));
+		await act(() => userEvent.click(screen.getByTestId('open-modal-button')));
 		expect(await screen.findByRole('dialog')).toBeInTheDocument();
 		// Title should have focus
-		expect(await screen.getByText('Modal title')).toHaveFocus();
+		expect(screen.getByText('Modal title')).toHaveFocus();
 		// Close the modal
-		await userEvent.click(await screen.getByTestId('close-modal-button'));
+		await act(() => userEvent.click(screen.getByTestId('close-modal-button')));
 		// After closing the modal, the "Open modal" button should be focused
-		expect(await screen.getByTestId('open-modal-button')).toHaveFocus();
+		expect(screen.getByTestId('open-modal-button')).toHaveFocus();
 	});
 	it('onDismiss modal focuses the correct elements when opening and closing', async () => {
 		renderDismissModal();
 		// Open the modal by clicking the "Open modal" button
-		await userEvent.click(await screen.getByTestId('open-modal-button'));
+		await act(() => userEvent.click(screen.getByTestId('open-modal-button')));
 		expect(await screen.findByRole('dialog')).toBeInTheDocument();
 		// Title should have focus
-		expect(await screen.getByText('Modal title')).toHaveFocus();
+		expect(screen.getByText('Modal title')).toHaveFocus();
 		// Close the modal
-		await userEvent.click(await screen.getByTestId('close-modal-button'));
+		await act(() => userEvent.click(screen.getByTestId('close-modal-button')));
 		// After closing the modal, the "Open modal" button should be focused
-		expect(await screen.getByTestId('open-modal-button')).toHaveFocus();
+		expect(screen.getByTestId('open-modal-button')).toHaveFocus();
 	});
 });

--- a/packages/react/src/password-input/PasswordInput.test.tsx
+++ b/packages/react/src/password-input/PasswordInput.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { cleanup, render } from '../../../../test-utils';
+import { act, cleanup, render } from '../../../../test-utils';
 import { PasswordInput, PasswordInputProps } from './PasswordInput';
 
 expect.extend(toHaveNoViolations);
@@ -34,25 +34,23 @@ describe('PasswordInput', () => {
 			label: 'Password',
 		});
 
-		const inputElement = await container.querySelector('input');
+		const inputElement = container.querySelector('input');
 		expect(inputElement).toBeInTheDocument();
 		expect(inputElement).toHaveAttribute('type', 'password');
 
 		if (!inputElement) return;
 
-		const checkboxElement = await container.querySelector(
-			'input[type="checkbox"]'
-		);
+		const checkboxElement = container.querySelector('input[type="checkbox"]');
 		expect(checkboxElement).toBeInTheDocument();
 		expect(checkboxElement).toHaveAttribute('aria-controls', inputElement.id);
 		if (!checkboxElement) return;
 
 		// Clicking the Checkbox once should change the input type to "text"
-		await userEvent.click(checkboxElement);
+		await act(() => userEvent.click(checkboxElement));
 		expect(inputElement).toHaveAttribute('type', 'text');
 
 		// Clicking the Checkbox again should change the input type back to "password"
-		await userEvent.click(checkboxElement);
+		await act(() => userEvent.click(checkboxElement));
 		expect(inputElement).toHaveAttribute('type', 'password');
 	});
 });

--- a/packages/react/src/search-input/SearchInput.test.tsx
+++ b/packages/react/src/search-input/SearchInput.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import { cleanup, render } from '../../../../test-utils';
+import { act, cleanup, render } from '../../../../test-utils';
 import { SearchInput, SearchInputProps } from './SearchInput';
 
 expect.extend(toHaveNoViolations);
@@ -84,14 +84,15 @@ describe('SearchInput', () => {
 		const onClear = jest.fn();
 		renderSearchInput({ label: 'Search', onClear });
 
+		const user = userEvent.setup();
 		const input = document.querySelector('input');
 		let clearButton = document.querySelector('[role="button"]');
 
 		expect(input).toHaveValue('');
 		expect(clearButton).not.toBeInTheDocument();
 
-		await input?.focus();
-		await userEvent.keyboard('Hello world');
+		input?.focus();
+		await act(() => user.keyboard('Hello world'));
 
 		clearButton = document.querySelector('[role="button"]');
 
@@ -99,7 +100,7 @@ describe('SearchInput', () => {
 		expect(clearButton).toBeInTheDocument();
 		expect(clearButton).toHaveAccessibleName('Clear search');
 
-		if (clearButton) await userEvent.click(clearButton);
+		if (clearButton) await act(() => user.click(clearButton));
 
 		expect(input).toHaveFocus();
 		expect(input).toHaveValue('');
@@ -109,14 +110,15 @@ describe('SearchInput', () => {
 	it('Clears input when escape is pressed', async () => {
 		const onClear = jest.fn();
 		renderSearchInput({ label: 'Search', onClear });
+		const user = userEvent.setup();
 		const input = document.querySelector('input');
 
-		await input?.focus();
-		await userEvent.keyboard('Hello world');
+		input?.focus();
+		await act(() => user.keyboard('Hello world'));
 		expect(input).toHaveValue('Hello world');
 
-		await input?.focus();
-		await userEvent.keyboard('{Escape}');
+		input?.focus();
+		await act(() => user.keyboard('{Escape}'));
 
 		expect(input).toHaveFocus();
 		expect(input).toHaveValue('');

--- a/packages/react/src/search-input/SearchInput.test.tsx
+++ b/packages/react/src/search-input/SearchInput.test.tsx
@@ -94,13 +94,14 @@ describe('SearchInput', () => {
 		input?.focus();
 		await act(() => user.keyboard('Hello world'));
 
+		expect(input).toHaveValue('Hello world');
+
 		clearButton = document.querySelector('[role="button"]');
 
-		expect(input).toHaveValue('Hello world');
 		expect(clearButton).toBeInTheDocument();
 		expect(clearButton).toHaveAccessibleName('Clear search');
 
-		if (clearButton) await act(() => user.click(clearButton));
+		await act(() => user.click(clearButton as Element));
 
 		expect(input).toHaveFocus();
 		expect(input).toHaveValue('');

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import { render, screen, within } from '../../../../test-utils';
+import { act, render, screen, within } from '../../../../test-utils';
 import { SideNav, SideNavProps } from './SideNav';
 import { alwaysOpenItems, defaultTestingProps } from './test-utils';
 
@@ -61,7 +61,7 @@ describe('SideNav', () => {
 				const button = screen.getByRole('button', {
 					name: defaultTestingProps.title,
 				});
-				await user.click(button);
+				await act(() => user.click(button));
 
 				const titleAsLink = await screen.findByRole('link', {
 					name: defaultTestingProps.title,
@@ -102,7 +102,7 @@ describe('SideNav', () => {
 				const button = screen.getByRole('button', {
 					name: defaultTestingProps.title,
 				});
-				await user.click(button);
+				await act(() => user.click(button));
 
 				expect(
 					screen.queryByRole('link', { name: defaultTestingProps.title })

--- a/packages/react/src/tabs/Tabs.test.tsx
+++ b/packages/react/src/tabs/Tabs.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import { render, cleanup, screen } from '../../../../test-utils';
+import { render, cleanup, screen, act } from '../../../../test-utils';
 import { TabButton } from './TabButton';
 import { TabList } from './TabList';
 import { TabPanel } from './TabPanel';
@@ -30,8 +30,8 @@ function renderTabs() {
 	);
 }
 
-async function getTabByText(text: string) {
-	return (await screen.getByText(text).parentNode) as HTMLButtonElement;
+function getTabByText(text: string) {
+	return screen.getByText(text).parentNode as HTMLButtonElement;
 }
 
 describe('Tabs', () => {
@@ -92,8 +92,8 @@ describe('Tabs', () => {
 	it('renders the correct ARIA tags', async () => {
 		renderTabs();
 
-		const firstTab = await getTabByText('Tab 1');
-		const firstPanel = await screen.getByText('Tab panel 1');
+		const firstTab = getTabByText('Tab 1');
+		const firstPanel = screen.getByText('Tab panel 1');
 
 		expect(firstTab).toBeInTheDocument();
 		expect(firstTab).toHaveAttribute('role', 'tab');
@@ -106,8 +106,8 @@ describe('Tabs', () => {
 		expect(firstPanel).toHaveAttribute('tabIndex', '0');
 		expect(firstPanel).toHaveAttribute('aria-labelledby', firstTab.id);
 
-		const secondTab = await getTabByText('Tab 2');
-		const secondPanel = await screen.getByText('Tab panel 2');
+		const secondTab = getTabByText('Tab 2');
+		const secondPanel = screen.getByText('Tab panel 2');
 
 		expect(secondTab).toBeInTheDocument();
 		expect(secondTab).toHaveAttribute('role', 'tab');
@@ -120,8 +120,8 @@ describe('Tabs', () => {
 		expect(secondPanel).toHaveAttribute('tabIndex', '-1');
 		expect(secondPanel).toHaveAttribute('aria-labelledby', secondTab.id);
 
-		const thirdTab = await getTabByText('Tab 3');
-		const thirdPanel = await screen.getByText('Tab panel 3');
+		const thirdTab = getTabByText('Tab 3');
+		const thirdPanel = screen.getByText('Tab panel 3');
 
 		expect(thirdTab).toBeInTheDocument();
 		expect(thirdTab).toHaveAttribute('role', 'tab');
@@ -137,51 +137,52 @@ describe('Tabs', () => {
 
 	it('responds to arrow keys keyboard events', async () => {
 		renderTabs();
+		const user = userEvent.setup();
 
-		const tab1 = await getTabByText('Tab 1');
-		const tab2 = await getTabByText('Tab 2');
-		const tab3 = await getTabByText('Tab 3');
+		const tab1 = getTabByText('Tab 1');
+		const tab2 = getTabByText('Tab 2');
+		const tab3 = getTabByText('Tab 3');
 
 		// Focus the first tab to activate keyboard navigation
-		await tab1.focus();
+		tab1.focus();
 		expect(tab1).toHaveAttribute('aria-selected', 'true');
 		expect(tab1).toHaveFocus();
 		expect(tab2).toHaveAttribute('aria-selected', 'false');
 		expect(tab3).toHaveAttribute('aria-selected', 'false');
 
 		// After pressing the "Right" arrow key, the second tab should be selected
-		await userEvent.keyboard('[ArrowRight]');
+		await act(() => user.keyboard('[ArrowRight]'));
 		expect(tab1).toHaveAttribute('aria-selected', 'false');
 		expect(tab2).toHaveAttribute('aria-selected', 'true');
 		expect(tab2).toHaveFocus();
 		expect(tab3).toHaveAttribute('aria-selected', 'false');
 
 		// After pressing the "Left" arrow key, the first tab should be selected
-		await userEvent.keyboard('[ArrowLeft]');
+		await act(() => user.keyboard('[ArrowLeft]'));
 		expect(tab1).toHaveAttribute('aria-selected', 'true');
 		expect(tab1).toHaveFocus();
 		expect(tab2).toHaveAttribute('aria-selected', 'false');
 		expect(tab3).toHaveAttribute('aria-selected', 'false');
 
 		// After pressing the "Right" arrow key twice, the third tab should be selected
-		await userEvent.keyboard('[ArrowRight]');
+		await act(() => user.keyboard('[ArrowRight]'));
 		expect(tab2).toHaveFocus();
 
-		await userEvent.keyboard('[ArrowRight]');
+		await act(() => user.keyboard('[ArrowRight]'));
 		expect(tab1).toHaveAttribute('aria-selected', 'false');
 		expect(tab2).toHaveAttribute('aria-selected', 'false');
 		expect(tab3).toHaveAttribute('aria-selected', 'true');
 		expect(tab3).toHaveFocus();
 
 		// When you are on the last tab and press the "Right" arrow key, the first tab should be selected
-		await userEvent.keyboard('[ArrowRight]');
+		await act(() => user.keyboard('[ArrowRight]'));
 		expect(tab1).toHaveAttribute('aria-selected', 'true');
 		expect(tab1).toHaveFocus();
 		expect(tab2).toHaveAttribute('aria-selected', 'false');
 		expect(tab3).toHaveAttribute('aria-selected', 'false');
 
 		// When you are on the first tab and press the "Left" arrow key, the last tab should be selected
-		await userEvent.keyboard('[ArrowLeft]');
+		await act(() => user.keyboard('[ArrowLeft]'));
 		expect(tab1).toHaveAttribute('aria-selected', 'false');
 		expect(tab2).toHaveAttribute('aria-selected', 'false');
 		expect(tab3).toHaveAttribute('aria-selected', 'true');
@@ -190,21 +191,23 @@ describe('Tabs', () => {
 
 	it('responds to home/end keys keyboard events', async () => {
 		renderTabs();
-		const firstTab = await getTabByText('Tab 1');
-		const lastTab = await getTabByText('Tab 3');
+		const user = userEvent.setup();
+
+		const firstTab = getTabByText('Tab 1');
+		const lastTab = getTabByText('Tab 3');
 
 		// Focus the first tab to activate keyboard navigation
-		await firstTab.focus();
+		firstTab.focus();
 		expect(firstTab).toHaveAttribute('aria-selected', 'true');
 
 		// Pressing the "End" key should select the last tab
-		await userEvent.keyboard('[END]');
+		await act(() => user.keyboard('[END]'));
 		expect(lastTab).toHaveAttribute('aria-selected', 'true');
 		expect(lastTab).toHaveFocus();
 		expect(firstTab).toHaveAttribute('aria-selected', 'false');
 
 		// Pressing the "Home" key should select the first tab
-		await userEvent.keyboard('[HOME]');
+		await act(() => user.keyboard('[HOME]'));
 		expect(firstTab).toHaveAttribute('aria-selected', 'true');
 		expect(firstTab).toHaveFocus();
 		expect(lastTab).toHaveAttribute('aria-selected', 'false');

--- a/packages/react/src/time-input/TimeInput.test.tsx
+++ b/packages/react/src/time-input/TimeInput.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import 'html-validate/jest';
 import { useState } from 'react';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { cleanup, render, screen } from '../../../../test-utils';
+import { act, cleanup, render, screen } from '../../../../test-utils';
 import { TimeInput, type TimeInputProps, type TimeValue } from './TimeInput';
 
 expect.extend(toHaveNoViolations);
@@ -92,8 +92,8 @@ describe('TimeInput', () => {
 		});
 		const input = getInput();
 
-		await user.type(input, '930');
-		await user.keyboard('{Tab}');
+		await act(() => user.type(input, '930'));
+		await act(() => user.keyboard('{Tab}'));
 
 		expect(onChange).toHaveBeenCalledWith({
 			formatted: '9:30 am',
@@ -107,8 +107,8 @@ describe('TimeInput', () => {
 		renderTimeInput();
 		const input = getInput();
 
-		await user.type(input, '09:30');
-		await user.keyboard('{Tab}');
+		await act(() => user.type(input, '09:30'));
+		await act(() => user.keyboard('{Tab}'));
 
 		expect(input).toHaveValue('9:30 am');
 	});
@@ -121,8 +121,8 @@ describe('TimeInput', () => {
 		});
 		const input = getInput();
 
-		await user.type(input, '9:30 pm');
-		await user.keyboard('{Tab}');
+		await act(() => user.type(input, '9:30 pm'));
+		await act(() => user.keyboard('{Tab}'));
 
 		expect(input).toHaveValue('21:30');
 	});

--- a/packages/react/src/time-picker/TimePicker.test.tsx
+++ b/packages/react/src/time-picker/TimePicker.test.tsx
@@ -29,7 +29,7 @@ describe('TimePicker', () => {
 			name: 'Select a time (optional)',
 		});
 		const user = userEvent.setup();
-		await user.click(input);
+		await act(() => user.click(input));
 		expect(container).toMatchSnapshot();
 	});
 
@@ -60,14 +60,14 @@ describe('TimePicker', () => {
 		await waitFor(() => expect(input).toHaveFocus());
 		expect(input).toHaveAttribute('aria-expanded', 'true');
 
-		await userEvent.type(input, '1245');
+		await act(() => userEvent.type(input, '1245'));
 		expect(input.value).toBe('1245');
 
 		const options = container.querySelectorAll('li');
 		expect(options.length).toBe(2);
 		expect(options[0].textContent).toBe('12:45 am');
 		expect(options[1].textContent).toBe('12:45 pm');
-		await userEvent.click(options[0]);
+		await act(() => userEvent.click(options[0]));
 		expect(input.value).toBe('12:45 am');
 	});
 });


### PR DESCRIPTION
When running tests, many components produced noisy warnings like so:

```
 Warning: An update to ForwardRef(SearchInput) inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
```

This PR fixes that.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1956)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
