### PR TITLE
status-badge: Update to match design & remove unnecessary whitespace

### DIFF
--- a/.changeset/forty-hats-learn.md
+++ b/.changeset/forty-hats-learn.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+status-badge: Update to match design and remove the unnecessary whitespace that was being added below.

--- a/packages/react/src/status-badge/StatusBadge.tsx
+++ b/packages/react/src/status-badge/StatusBadge.tsx
@@ -57,7 +57,8 @@ export const StatusBadge = ({
 					borderRadius,
 					'& svg': {
 						flexShrink: 0,
-						width: iconWidth,
+						height: iconSize,
+						width: iconSize,
 					},
 				}}
 				display="inline-flex"
@@ -92,12 +93,12 @@ export const StatusBadge = ({
 			borderColor={borderColor}
 			css={{
 				borderRadius,
+				// This used to be inline-flex, but it was creating addtional vertical space under the SVG so we changed it to flex & fit-content
+				width: 'fit-content',
 				'& svg': {
 					flexShrink: 0,
-					width: iconWidth,
 				},
 			}}
-			display="inline-flex"
 			gap={0.5}
 			{...appearanceStyleProps}
 		>
@@ -120,14 +121,14 @@ export const StatusBadge = ({
 
 const borderRadius = mapSpacing(1); // 16px
 const height = mapSpacing(2); // 32px
-const iconWidth = '1.375rem'; // 22px
+const iconSize = '1.375rem'; // 22px
 
 const regularAppearanceStyleProps = {
 	background: 'body',
 	border: true,
 	borderWidth: 'sm',
 	height,
-	paddingX: 1,
+	paddingX: 0.75,
 } as const;
 
 const toneMap = {

--- a/packages/react/src/status-badge/StatusBadge.tsx
+++ b/packages/react/src/status-badge/StatusBadge.tsx
@@ -93,12 +93,13 @@ export const StatusBadge = ({
 			borderColor={borderColor}
 			css={{
 				borderRadius,
-				// This used to be inline-flex, but it was creating addtional vertical space under the SVG so we changed it to flex & fit-content
-				width: 'fit-content',
+				// Ensures the status badge doesn't create descender whitespace
+				verticalAlign: 'bottom',
 				'& svg': {
 					flexShrink: 0,
 				},
 			}}
+			display="inline-flex"
 			gap={0.5}
 			{...appearanceStyleProps}
 		>

--- a/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StatusBadge Legacy weight: regular tone: error renders correctly 1`] = `
 <div>
   <div
-    class="css-1kwau38-boxStyles-StatusBadge"
+    class="css-udinth-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -40,7 +40,7 @@ exports[`StatusBadge Legacy weight: regular tone: error renders correctly 1`] = 
 exports[`StatusBadge Legacy weight: regular tone: info renders correctly 1`] = `
 <div>
   <div
-    class="css-d0fvsj-boxStyles-StatusBadge"
+    class="css-od9xoc-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -71,7 +71,7 @@ exports[`StatusBadge Legacy weight: regular tone: info renders correctly 1`] = `
 exports[`StatusBadge Legacy weight: regular tone: neutral renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-a8ch8w-boxStyles-StatusBadge"
   >
     <div
       class="css-1fa9oau-boxStyles-icon"
@@ -88,7 +88,7 @@ exports[`StatusBadge Legacy weight: regular tone: neutral renders correctly 1`] 
 exports[`StatusBadge Legacy weight: regular tone: success renders correctly 1`] = `
 <div>
   <div
-    class="css-1yao3c9-boxStyles-StatusBadge"
+    class="css-rnkegj-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -122,7 +122,7 @@ exports[`StatusBadge Legacy weight: regular tone: success renders correctly 1`] 
 exports[`StatusBadge Legacy weight: regular tone: warning renders correctly 1`] = `
 <div>
   <div
-    class="css-1t5js0n-boxStyles-StatusBadge"
+    class="css-1olh9l0-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -153,7 +153,7 @@ exports[`StatusBadge Legacy weight: regular tone: warning renders correctly 1`] 
 exports[`StatusBadge Legacy weight: subtle tone: error renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-rzla6p-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -190,7 +190,7 @@ exports[`StatusBadge Legacy weight: subtle tone: error renders correctly 1`] = `
 exports[`StatusBadge Legacy weight: subtle tone: info renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-rzla6p-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -221,7 +221,7 @@ exports[`StatusBadge Legacy weight: subtle tone: info renders correctly 1`] = `
 exports[`StatusBadge Legacy weight: subtle tone: neutral renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-rzla6p-boxStyles-StatusBadge"
   >
     <div
       class="css-1fa9oau-boxStyles-icon"
@@ -238,7 +238,7 @@ exports[`StatusBadge Legacy weight: subtle tone: neutral renders correctly 1`] =
 exports[`StatusBadge Legacy weight: subtle tone: success renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-rzla6p-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -272,7 +272,7 @@ exports[`StatusBadge Legacy weight: subtle tone: success renders correctly 1`] =
 exports[`StatusBadge Legacy weight: subtle tone: warning renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-rzla6p-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -303,7 +303,7 @@ exports[`StatusBadge Legacy weight: subtle tone: warning renders correctly 1`] =
 exports[`StatusBadge appearance: regular tone: cannotStartLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -334,7 +334,7 @@ exports[`StatusBadge appearance: regular tone: cannotStartLow renders correctly 
 exports[`StatusBadge appearance: regular tone: errorHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1kwau38-boxStyles-StatusBadge"
+    class="css-abt2vs-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -367,7 +367,7 @@ exports[`StatusBadge appearance: regular tone: errorHigh renders correctly 1`] =
 exports[`StatusBadge appearance: regular tone: errorLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -398,7 +398,7 @@ exports[`StatusBadge appearance: regular tone: errorLow renders correctly 1`] = 
 exports[`StatusBadge appearance: regular tone: errorMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1kwau38-boxStyles-StatusBadge"
+    class="css-abt2vs-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -435,7 +435,7 @@ exports[`StatusBadge appearance: regular tone: errorMedium renders correctly 1`]
 exports[`StatusBadge appearance: regular tone: inProgressLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -481,7 +481,7 @@ exports[`StatusBadge appearance: regular tone: inProgressLow renders correctly 1
 exports[`StatusBadge appearance: regular tone: infoHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-d0fvsj-boxStyles-StatusBadge"
+    class="css-1fdsdel-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -514,7 +514,7 @@ exports[`StatusBadge appearance: regular tone: infoHigh renders correctly 1`] = 
 exports[`StatusBadge appearance: regular tone: infoLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -545,7 +545,7 @@ exports[`StatusBadge appearance: regular tone: infoLow renders correctly 1`] = `
 exports[`StatusBadge appearance: regular tone: infoMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-d0fvsj-boxStyles-StatusBadge"
+    class="css-1fdsdel-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -576,7 +576,7 @@ exports[`StatusBadge appearance: regular tone: infoMedium renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: notStartedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -608,7 +608,7 @@ exports[`StatusBadge appearance: regular tone: notStartedLow renders correctly 1
 exports[`StatusBadge appearance: regular tone: pausedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -639,7 +639,7 @@ exports[`StatusBadge appearance: regular tone: pausedLow renders correctly 1`] =
 exports[`StatusBadge appearance: regular tone: successHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1yao3c9-boxStyles-StatusBadge"
+    class="css-1rj7qto-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -672,7 +672,7 @@ exports[`StatusBadge appearance: regular tone: successHigh renders correctly 1`]
 exports[`StatusBadge appearance: regular tone: successLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -706,7 +706,7 @@ exports[`StatusBadge appearance: regular tone: successLow renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: successMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1yao3c9-boxStyles-StatusBadge"
+    class="css-1rj7qto-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -740,7 +740,7 @@ exports[`StatusBadge appearance: regular tone: successMedium renders correctly 1
 exports[`StatusBadge appearance: regular tone: unknownLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -771,7 +771,7 @@ exports[`StatusBadge appearance: regular tone: unknownLow renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: warningHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1t5js0n-boxStyles-StatusBadge"
+    class="css-113w616-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -804,7 +804,7 @@ exports[`StatusBadge appearance: regular tone: warningHigh renders correctly 1`]
 exports[`StatusBadge appearance: regular tone: warningLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1o4iv6m-boxStyles-StatusBadge"
+    class="css-1u4th2n-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -835,7 +835,7 @@ exports[`StatusBadge appearance: regular tone: warningLow renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: warningMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1t5js0n-boxStyles-StatusBadge"
+    class="css-113w616-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -866,7 +866,7 @@ exports[`StatusBadge appearance: regular tone: warningMedium renders correctly 1
 exports[`StatusBadge appearance: subtle tone: cannotStartLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -897,7 +897,7 @@ exports[`StatusBadge appearance: subtle tone: cannotStartLow renders correctly 1
 exports[`StatusBadge appearance: subtle tone: errorHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -930,7 +930,7 @@ exports[`StatusBadge appearance: subtle tone: errorHigh renders correctly 1`] = 
 exports[`StatusBadge appearance: subtle tone: errorLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -961,7 +961,7 @@ exports[`StatusBadge appearance: subtle tone: errorLow renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: errorMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -998,7 +998,7 @@ exports[`StatusBadge appearance: subtle tone: errorMedium renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: inProgressLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1044,7 +1044,7 @@ exports[`StatusBadge appearance: subtle tone: inProgressLow renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: infoHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1077,7 +1077,7 @@ exports[`StatusBadge appearance: subtle tone: infoHigh renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: infoLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1108,7 +1108,7 @@ exports[`StatusBadge appearance: subtle tone: infoLow renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: infoMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1139,7 +1139,7 @@ exports[`StatusBadge appearance: subtle tone: infoMedium renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: notStartedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1171,7 +1171,7 @@ exports[`StatusBadge appearance: subtle tone: notStartedLow renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: pausedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1202,7 +1202,7 @@ exports[`StatusBadge appearance: subtle tone: pausedLow renders correctly 1`] = 
 exports[`StatusBadge appearance: subtle tone: successHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1235,7 +1235,7 @@ exports[`StatusBadge appearance: subtle tone: successHigh renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: successLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1269,7 +1269,7 @@ exports[`StatusBadge appearance: subtle tone: successLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: successMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1303,7 +1303,7 @@ exports[`StatusBadge appearance: subtle tone: successMedium renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: unknownLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1334,7 +1334,7 @@ exports[`StatusBadge appearance: subtle tone: unknownLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: warningHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1367,7 +1367,7 @@ exports[`StatusBadge appearance: subtle tone: warningHigh renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: warningLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1398,7 +1398,7 @@ exports[`StatusBadge appearance: subtle tone: warningLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: warningMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1ncy008-boxStyles-StatusBadge"
+    class="css-9ekoua-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"

--- a/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
@@ -303,7 +303,7 @@ exports[`StatusBadge Legacy weight: subtle tone: warning renders correctly 1`] =
 exports[`StatusBadge appearance: regular tone: cannotStartLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -334,7 +334,7 @@ exports[`StatusBadge appearance: regular tone: cannotStartLow renders correctly 
 exports[`StatusBadge appearance: regular tone: errorHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-abt2vs-boxStyles-StatusBadge"
+    class="css-a9ppia-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -367,7 +367,7 @@ exports[`StatusBadge appearance: regular tone: errorHigh renders correctly 1`] =
 exports[`StatusBadge appearance: regular tone: errorLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -398,7 +398,7 @@ exports[`StatusBadge appearance: regular tone: errorLow renders correctly 1`] = 
 exports[`StatusBadge appearance: regular tone: errorMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-abt2vs-boxStyles-StatusBadge"
+    class="css-a9ppia-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -435,7 +435,7 @@ exports[`StatusBadge appearance: regular tone: errorMedium renders correctly 1`]
 exports[`StatusBadge appearance: regular tone: inProgressLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -481,7 +481,7 @@ exports[`StatusBadge appearance: regular tone: inProgressLow renders correctly 1
 exports[`StatusBadge appearance: regular tone: infoHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1fdsdel-boxStyles-StatusBadge"
+    class="css-tqwyd6-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -514,7 +514,7 @@ exports[`StatusBadge appearance: regular tone: infoHigh renders correctly 1`] = 
 exports[`StatusBadge appearance: regular tone: infoLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -545,7 +545,7 @@ exports[`StatusBadge appearance: regular tone: infoLow renders correctly 1`] = `
 exports[`StatusBadge appearance: regular tone: infoMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1fdsdel-boxStyles-StatusBadge"
+    class="css-tqwyd6-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -576,7 +576,7 @@ exports[`StatusBadge appearance: regular tone: infoMedium renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: notStartedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -608,7 +608,7 @@ exports[`StatusBadge appearance: regular tone: notStartedLow renders correctly 1
 exports[`StatusBadge appearance: regular tone: pausedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -639,7 +639,7 @@ exports[`StatusBadge appearance: regular tone: pausedLow renders correctly 1`] =
 exports[`StatusBadge appearance: regular tone: successHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-1rj7qto-boxStyles-StatusBadge"
+    class="css-10wx6en-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -672,7 +672,7 @@ exports[`StatusBadge appearance: regular tone: successHigh renders correctly 1`]
 exports[`StatusBadge appearance: regular tone: successLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -706,7 +706,7 @@ exports[`StatusBadge appearance: regular tone: successLow renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: successMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-1rj7qto-boxStyles-StatusBadge"
+    class="css-10wx6en-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -740,7 +740,7 @@ exports[`StatusBadge appearance: regular tone: successMedium renders correctly 1
 exports[`StatusBadge appearance: regular tone: unknownLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -771,7 +771,7 @@ exports[`StatusBadge appearance: regular tone: unknownLow renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: warningHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-113w616-boxStyles-StatusBadge"
+    class="css-slmxiz-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -804,7 +804,7 @@ exports[`StatusBadge appearance: regular tone: warningHigh renders correctly 1`]
 exports[`StatusBadge appearance: regular tone: warningLow renders correctly 1`] = `
 <div>
   <div
-    class="css-1u4th2n-boxStyles-StatusBadge"
+    class="css-yd22py-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -835,7 +835,7 @@ exports[`StatusBadge appearance: regular tone: warningLow renders correctly 1`] 
 exports[`StatusBadge appearance: regular tone: warningMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-113w616-boxStyles-StatusBadge"
+    class="css-slmxiz-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -866,7 +866,7 @@ exports[`StatusBadge appearance: regular tone: warningMedium renders correctly 1
 exports[`StatusBadge appearance: subtle tone: cannotStartLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -897,7 +897,7 @@ exports[`StatusBadge appearance: subtle tone: cannotStartLow renders correctly 1
 exports[`StatusBadge appearance: subtle tone: errorHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -930,7 +930,7 @@ exports[`StatusBadge appearance: subtle tone: errorHigh renders correctly 1`] = 
 exports[`StatusBadge appearance: subtle tone: errorLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -961,7 +961,7 @@ exports[`StatusBadge appearance: subtle tone: errorLow renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: errorMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -998,7 +998,7 @@ exports[`StatusBadge appearance: subtle tone: errorMedium renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: inProgressLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1044,7 +1044,7 @@ exports[`StatusBadge appearance: subtle tone: inProgressLow renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: infoHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1077,7 +1077,7 @@ exports[`StatusBadge appearance: subtle tone: infoHigh renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: infoLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1108,7 +1108,7 @@ exports[`StatusBadge appearance: subtle tone: infoLow renders correctly 1`] = `
 exports[`StatusBadge appearance: subtle tone: infoMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1139,7 +1139,7 @@ exports[`StatusBadge appearance: subtle tone: infoMedium renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: notStartedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1171,7 +1171,7 @@ exports[`StatusBadge appearance: subtle tone: notStartedLow renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: pausedLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1202,7 +1202,7 @@ exports[`StatusBadge appearance: subtle tone: pausedLow renders correctly 1`] = 
 exports[`StatusBadge appearance: subtle tone: successHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1235,7 +1235,7 @@ exports[`StatusBadge appearance: subtle tone: successHigh renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: successLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1269,7 +1269,7 @@ exports[`StatusBadge appearance: subtle tone: successLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: successMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1303,7 +1303,7 @@ exports[`StatusBadge appearance: subtle tone: successMedium renders correctly 1`
 exports[`StatusBadge appearance: subtle tone: unknownLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1334,7 +1334,7 @@ exports[`StatusBadge appearance: subtle tone: unknownLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: warningHigh renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1367,7 +1367,7 @@ exports[`StatusBadge appearance: subtle tone: warningHigh renders correctly 1`] 
 exports[`StatusBadge appearance: subtle tone: warningLow renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"
@@ -1398,7 +1398,7 @@ exports[`StatusBadge appearance: subtle tone: warningLow renders correctly 1`] =
 exports[`StatusBadge appearance: subtle tone: warningMedium renders correctly 1`] = `
 <div>
   <div
-    class="css-9ekoua-boxStyles-StatusBadge"
+    class="css-1pp8pns-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="false"


### PR DESCRIPTION
The StatusBadge wasn't quite right:

1. The non-legacy icon shouldn't have been 22px wide
2. The paddingX should have been 12px
3. It created whitespace underneath the badge in certain circumstance, especially visible in table cells.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1958)

You can see the whitespace fix here: https://design-system.agriculture.gov.au/pr-preview/pr-1958/components/table#actions and all status badge examples here for comparison: https://design-system.agriculture.gov.au/pr-preview/pr-1958/components/status-badge#high-emphasis


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
