### PR TITLE
docs: fixed Card link address in patterns, search-filters

### DIFF
--- a/.changeset/pink-jokes-matter.md
+++ b/.changeset/pink-jokes-matter.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+docs: Fixed Card link on the page patterns > search-filters.

--- a/docs/content/patterns/search-filters/index.mdx
+++ b/docs/content/patterns/search-filters/index.mdx
@@ -11,7 +11,7 @@ Search filters help users find what they’re looking for by displaying options 
 
 Applied filters are displayed as tags, so users can quickly see which filters have been applied to the dataset. Filters can be removed by dismissing the tags.
 
-The dataset should be displayed in a [Table](/components/table) or a list of [Cards](/components/cards) under the search filters. Refer to the specific component guidance to help determine which is more suitable to display your dataset.
+The dataset should be displayed in a [Table](/components/table) or a list of [Cards](/components/card) under the search filters. Refer to the specific component guidance to help determine which is more suitable to display your dataset.
 
 ```jsx live
 <Stack gap={3}>


### PR DESCRIPTION
Fixed the Cards link address on the Doc page patterns -> search-filters. Link was directing to incorrect address

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1963)

[Patterns > Search filters page](https://design-system.agriculture.gov.au/pr-preview/pr-1963/patterns/search-filters)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
