### PR TITLE
drawer, modal: Remove deprecated internal onDismiss props on dialogs

### DIFF
--- a/.changeset/rare-yaks-type.md
+++ b/.changeset/rare-yaks-type.md
@@ -3,3 +3,5 @@
 ---
 
 drawer: Remove deprecated, internal `onDismiss` prop on `DrawerDialog`.
+
+modal: Remove deprecated, internal `onDismiss` prop on `ModalDialog`.

--- a/.changeset/rare-yaks-type.md
+++ b/.changeset/rare-yaks-type.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+drawer: Remove deprecated, internal `onDismiss` prop on `DrawerDialog`.

--- a/packages/react/src/drawer/DrawerDialog.tsx
+++ b/packages/react/src/drawer/DrawerDialog.tsx
@@ -7,7 +7,6 @@ import { mapResponsiveProp, mapSpacing, mq, tokens } from '../core';
 import { CloseIcon } from '../icon';
 import { Button } from '../button';
 import { Text } from '../text';
-import { getRequiredCloseHandler } from '../getCloseHandler';
 import { useDrawerId } from './utils';
 import { DrawerProps } from './Drawer';
 
@@ -16,8 +15,6 @@ export type DrawerDialogProps = PropsWithChildren<{
 	actions?: ReactNode;
 	/** On close of the drawer, this element will be focused, rather than the trigger element. */
 	elementToFocusOnClose?: DrawerProps['elementToFocusOnClose'];
-	/** @deprecated use `onClose` instead. */
-	onDismiss?: () => void;
 	/** Function to be called when the 'Close' button is pressed. */
 	onClose?: () => void;
 	style: { translateX: SpringValue<string> };
@@ -41,13 +38,11 @@ export function DrawerDialog({
 	children,
 	elementToFocusOnClose,
 	onClose,
-	onDismiss,
 	style,
 	title,
 	width,
 }: DrawerDialogProps) {
 	const { titleId } = useDrawerId();
-	const handleClose = getRequiredCloseHandler(onClose, onDismiss);
 
 	return (
 		<FocusLock
@@ -98,7 +93,7 @@ export function DrawerDialog({
 						}),
 					})}
 					iconAfter={CloseIcon}
-					onClick={handleClose}
+					onClick={onClose}
 					variant="text"
 				>
 					Close

--- a/packages/react/src/modal/Modal.tsx
+++ b/packages/react/src/modal/Modal.tsx
@@ -9,6 +9,8 @@ import { ModalDialog, ModalDialogProps } from './ModalDialog';
 export type ModalProps = ModalDialogProps & {
 	/** If true, the modal will be rendered.  */
 	isOpen?: boolean;
+	/** @deprecated use `onClose` instead */
+	onDismiss?: () => void;
 };
 
 export const Modal: FunctionComponent<ModalProps> = ({

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -6,7 +6,6 @@ import { Stack } from '../stack';
 import { mapSpacing, tokens } from '../core';
 import { CloseIcon } from '../icon';
 import { Button } from '../button';
-import { getRequiredCloseHandler } from '../getCloseHandler';
 import { ModalTitle } from './ModalTitle';
 import { useModalId } from './utils';
 
@@ -15,8 +14,6 @@ export type ModalDialogProps = PropsWithChildren<{
 	actions?: ReactNode;
 	/** Function to be called when the 'Close' button is pressed. */
 	onClose?: () => void;
-	/** @deprecated use `onClose` instead */
-	onDismiss?: () => void;
 	/** The title of the modal dialog. It can span lines but should not be too long. */
 	title: string;
 }>;
@@ -27,10 +24,8 @@ export const ModalDialog = ({
 	actions,
 	children,
 	onClose,
-	onDismiss,
 	title,
 }: ModalDialogProps) => {
-	const closeHandler = getRequiredCloseHandler(onClose, onDismiss);
 	const { titleId } = useModalId();
 	return (
 		<FocusLock returnFocus>
@@ -64,7 +59,7 @@ export const ModalDialog = ({
 					aria-label="Close modal"
 					css={{ alignSelf: 'flex-end' }}
 					iconAfter={CloseIcon}
-					onClick={closeHandler}
+					onClick={onClose}
 					variant="text"
 				>
 					Close


### PR DESCRIPTION
Ages ago we deprecated the `onDismiss` prop in Drawer in favour of `onClose`. For some reason, we kept the `onDimiss` logic within in the internal `DrawerDialog` even though it's not available to consumers and we pass it through as `onClose`

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1969)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.