### PR TITLE
core, box, file-upload, pagination: hide URLs for internal hash links and links in components for print format

### DIFF
--- a/.changeset/short-zebras-yell.md
+++ b/.changeset/short-zebras-yell.md
@@ -2,10 +2,10 @@
 '@ag.ds-next/react': patch
 ---
 
-box: applied link styling to hide URL on print media for internal hash anchors.
+box: Applied link styling to hide URL on print media for internal hash anchors.
 
-core: added styling to hide print URL on link elements.
+core: Added new style option to hide print URL on link elements.
 
-file-upload: applied link styling to hide URL on print media for existing file uploads.
+file-upload: Applied link styling to hide URL on print media for existing file uploads. Existing file URLs should not be displayed and are not required.
 
-pagination: applied link styling to hide URL for directions and pagination link elements.
+pagination: Applied link styling to hide URL for directions and pagination link elements. Pagination links are not functional on print

--- a/.changeset/short-zebras-yell.md
+++ b/.changeset/short-zebras-yell.md
@@ -2,10 +2,10 @@
 '@ag.ds-next/react': patch
 ---
 
-box: Applied link styling to hide URL on print media for internal hash anchors.
+box: Apply link style to hide URL on print media for internal hash anchors.
 
-core: Added new style option to hide print URL on link elements.
+core: Add new style option to hide print URL on link elements.
 
-file-upload: Applied link styling to hide URL on print media for existing file uploads. Existing file URLs should not be displayed and are not required.
+file-upload: Apply link style to hide URL on print media for existing file uploads. Existing file URLs should not be displayed and are not required.
 
-pagination: Applied link styling to hide URL for directions and pagination link elements. Pagination links are not functional on print
+pagination: Apply link style to hide URL for directions and numeric link elements. Pagination links are not functional on print.

--- a/.changeset/short-zebras-yell.md
+++ b/.changeset/short-zebras-yell.md
@@ -4,7 +4,7 @@
 
 box: Apply link style to hide URL on print media for internal hash anchors.
 
-core: Add new style option to hide print URL on link elements.
+core: Add new `hideHref` `print` pack to prevent a link’s `href` from being appended when printed.
 
 file-upload: Apply link style to hide URL on print media for existing file uploads. Existing file URLs should not be displayed and are not required.
 

--- a/.changeset/short-zebras-yell.md
+++ b/.changeset/short-zebras-yell.md
@@ -1,0 +1,11 @@
+---
+'@ag.ds-next/react': patch
+---
+
+box: applied link styling to hide URL on print media for internal hash anchors.
+
+core: added styling to hide print URL on link elements.
+
+file-upload: applied link styling to hide URL on print media for existing file uploads.
+
+pagination: applied link styling to hide URL for directions and pagination link elements.

--- a/packages/react/src/a11y/__snapshots__/ExternalLinkCallout.test.tsx.snap
+++ b/packages/react/src/a11y/__snapshots__/ExternalLinkCallout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ExternalLinkCallout renders correctly 1`] = `
 <div>
   <a
-    class="css-koqz57-TextLink"
+    class="css-1geyz1r-TextLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/a11y/__snapshots__/ExternalLinkCallout.test.tsx.snap
+++ b/packages/react/src/a11y/__snapshots__/ExternalLinkCallout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ExternalLinkCallout renders correctly 1`] = `
 <div>
   <a
-    class="css-1geyz1r-TextLink"
+    class="css-july2n-TextLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/a11y/__snapshots__/VisuallyHidden.test.tsx.snap
+++ b/packages/react/src/a11y/__snapshots__/VisuallyHidden.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`VisuallyHidden renders correctly 1`] = `
 <div>
   <a
-    class="css-koqz57-TextLink"
+    class="css-1geyz1r-TextLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/a11y/__snapshots__/VisuallyHidden.test.tsx.snap
+++ b/packages/react/src/a11y/__snapshots__/VisuallyHidden.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`VisuallyHidden renders correctly 1`] = `
 <div>
   <a
-    class="css-1geyz1r-TextLink"
+    class="css-july2n-TextLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r0:-body"
           aria-expanded="false"
-          class="css-1om6ji7-BaseButton-boxStyles-AccordionTitle"
+          class="css-guw37u-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r0:-title"
           type="button"
         >
@@ -66,7 +66,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r1:-body"
           aria-expanded="false"
-          class="css-1om6ji7-BaseButton-boxStyles-AccordionTitle"
+          class="css-guw37u-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r1:-title"
           type="button"
         >

--- a/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r0:-body"
           aria-expanded="false"
-          class="css-guw37u-BaseButton-boxStyles-AccordionTitle"
+          class="css-1y8bkn8-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r0:-title"
           type="button"
         >
@@ -66,7 +66,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r1:-body"
           aria-expanded="false"
-          class="css-guw37u-BaseButton-boxStyles-AccordionTitle"
+          class="css-1y8bkn8-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r1:-title"
           type="button"
         >

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -620,7 +620,7 @@ exports[`AppLayout renders correctly 1`] = `
                     class="css-79i25n-boxStyles"
                   >
                     <a
-                      class="css-koqz57-TextLink"
+                      class="css-1geyz1r-TextLink"
                       href="/"
                     >
                       Home

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -620,7 +620,7 @@ exports[`AppLayout renders correctly 1`] = `
                     class="css-79i25n-boxStyles"
                   >
                     <a
-                      class="css-1geyz1r-TextLink"
+                      class="css-july2n-TextLink"
                       href="/"
                     >
                       Home

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -556,7 +556,7 @@ export const linkStyles = {
 			content: '" (" attr(href) ")" !important',
 		},
 
-		// Hide local anchor links
+		// Hide internal hash link URLs
 		'&[href^="#"]:after': {
 			display: 'none',
 		},

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -556,7 +556,7 @@ export const linkStyles = {
 			content: '" (" attr(href) ")" !important',
 		},
 
-		// Hide local anchors links
+		// Hide local anchor links
 		'&[href^="#"]:after': {
 			display: 'none',
 		},

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -555,6 +555,11 @@ export const linkStyles = {
 		'&[href]::after': {
 			content: '" (" attr(href) ")" !important',
 		},
+
+		// Hide local anchors links
+		'&[href^="#"]:after': {
+			display: 'none',
+		},
 	},
 };
 

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -557,7 +557,7 @@ export const linkStyles = {
 		},
 
 		// Hide internal hash link URLs
-		'&[href^="#"]:after': {
+		'&[href^="#"]::after': {
 			display: 'none',
 		},
 	},

--- a/packages/react/src/breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/react/src/breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
           />
         </svg>
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#home"
         >
           Home
@@ -56,7 +56,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
         <button
           aria-expanded="false"
           aria-label="Show all breadcrumbs"
-          class="css-1q0rx3c-BaseButton-boxStyles"
+          class="css-1dlzu3n-BaseButton-boxStyles"
           type="button"
         >
           …
@@ -82,7 +82,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
           />
         </svg>
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#establishments"
         >
           Establishments

--- a/packages/react/src/breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/react/src/breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
           />
         </svg>
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#home"
         >
           Home
@@ -56,7 +56,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
         <button
           aria-expanded="false"
           aria-label="Show all breadcrumbs"
-          class="css-eqfuua-BaseButton-boxStyles"
+          class="css-1q0rx3c-BaseButton-boxStyles"
           type="button"
         >
           …
@@ -82,7 +82,7 @@ exports[`Breadcrumbs renders correctly 1`] = `
           />
         </svg>
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#establishments"
         >
           Establishments

--- a/packages/react/src/call-to-action/__snapshots__/CallToAction.test.tsx.snap
+++ b/packages/react/src/call-to-action/__snapshots__/CallToAction.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CallToActionButton renders correctly 1`] = `
     class="css-zce95a-boxStyles-CallToAction"
   >
     <button
-      class="css-148cyb0-BaseButton-boxStyles"
+      class="css-1h1daqg-BaseButton-boxStyles"
       data-testid="example"
       type="button"
     >
@@ -38,7 +38,7 @@ exports[`CallToActionLink renders correctly 1`] = `
     class="css-zce95a-boxStyles-CallToAction"
   >
     <a
-      class="css-1i5mag6-TextLink-boxStyles"
+      class="css-40ijub-TextLink-boxStyles"
       data-testid="example"
       href="#"
     >

--- a/packages/react/src/call-to-action/__snapshots__/CallToAction.test.tsx.snap
+++ b/packages/react/src/call-to-action/__snapshots__/CallToAction.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CallToActionButton renders correctly 1`] = `
     class="css-zce95a-boxStyles-CallToAction"
   >
     <button
-      class="css-fp5x03-BaseButton-boxStyles"
+      class="css-148cyb0-BaseButton-boxStyles"
       data-testid="example"
       type="button"
     >
@@ -38,7 +38,7 @@ exports[`CallToActionLink renders correctly 1`] = `
     class="css-zce95a-boxStyles-CallToAction"
   >
     <a
-      class="css-19iivh0-TextLink-boxStyles"
+      class="css-1i5mag6-TextLink-boxStyles"
       data-testid="example"
       href="#"
     >

--- a/packages/react/src/card/__snapshots__/Card.test.tsx.snap
+++ b/packages/react/src/card/__snapshots__/Card.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Card With link renders correctly 1`] = `
           Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptat
         </p>
         <a
-          class="css-1akraft-CardLink"
+          class="css-1x2pup-CardLink"
           href="#"
         >
           Linking out

--- a/packages/react/src/card/__snapshots__/Card.test.tsx.snap
+++ b/packages/react/src/card/__snapshots__/Card.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Card With link renders correctly 1`] = `
           Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptat
         </p>
         <a
-          class="css-2leob8-CardLink"
+          class="css-1akraft-CardLink"
           href="#"
         >
           Linking out

--- a/packages/react/src/core/packs.ts
+++ b/packages/react/src/core/packs.ts
@@ -66,9 +66,9 @@ export const print = {
 		},
 	},
 	// Hide URL rendered for links in print
-	hideLinkURL: {
+	hideHref: {
 		'@media print': {
-			'&[href]:after': {
+			'&[href]::after': {
 				display: 'none',
 			},
 		},

--- a/packages/react/src/core/packs.ts
+++ b/packages/react/src/core/packs.ts
@@ -65,7 +65,7 @@ export const print = {
 			printColorAdjust: 'exact',
 		},
 	},
-	// hide URL for link in print media type
+	// Hide URL rendered for links in print
 	hideLinkURL: {
 		'@media print': {
 			'&[href]:after': {

--- a/packages/react/src/core/packs.ts
+++ b/packages/react/src/core/packs.ts
@@ -65,7 +65,7 @@ export const print = {
 			printColorAdjust: 'exact',
 		},
 	},
-	// hide element if it contains href
+	// hide URL for link in print media type
 	hideLinkURL: {
 		'@media print': {
 			'&[href]:after': {

--- a/packages/react/src/core/packs.ts
+++ b/packages/react/src/core/packs.ts
@@ -65,6 +65,14 @@ export const print = {
 			printColorAdjust: 'exact',
 		},
 	},
+	// hide element if it contains href
+	hideLinkURL: {
+		'@media print': {
+			'&[href]:after': {
+				display: 'none',
+			},
+		},
+	},
 };
 
 export const packs = {

--- a/packages/react/src/details/__snapshots__/Details.test.tsx.snap
+++ b/packages/react/src/details/__snapshots__/Details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details renders correctly 1`] = `
     class="css-jx8h3p-Details"
   >
     <summary
-      class="css-1yhr1zj-boxStyles-Details"
+      class="css-19kiqdk-boxStyles-Details"
     >
       Details
       <svg

--- a/packages/react/src/details/__snapshots__/Details.test.tsx.snap
+++ b/packages/react/src/details/__snapshots__/Details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details renders correctly 1`] = `
     class="css-jx8h3p-Details"
   >
     <summary
-      class="css-1pb4m7j-boxStyles-Details"
+      class="css-1yhr1zj-boxStyles-Details"
     >
       Details
       <svg

--- a/packages/react/src/direction-link/__snapshots__/DirectionLink.test.tsx.snap
+++ b/packages/react/src/direction-link/__snapshots__/DirectionLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DirectionButton direction: down renders correctly 1`] = `
 <div>
   <button
-    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1fpnmlv-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Skip to footer
@@ -33,7 +33,7 @@ exports[`DirectionButton direction: down renders correctly 1`] = `
 exports[`DirectionButton direction: left renders correctly 1`] = `
 <div>
   <button
-    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1fpnmlv-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     <svg
@@ -63,7 +63,7 @@ exports[`DirectionButton direction: left renders correctly 1`] = `
 exports[`DirectionButton direction: right renders correctly 1`] = `
 <div>
   <button
-    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1fpnmlv-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Next
@@ -93,7 +93,7 @@ exports[`DirectionButton direction: right renders correctly 1`] = `
 exports[`DirectionButton direction: up renders correctly 1`] = `
 <div>
   <button
-    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1fpnmlv-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Top
@@ -123,7 +123,7 @@ exports[`DirectionButton direction: up renders correctly 1`] = `
 exports[`DirectionLink direction: down renders correctly 1`] = `
 <div>
   <a
-    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
+    class="css-1ku3z9l-TextLink-boxStyles-BaseDirectionLink"
   >
     Skip to footer
     <svg
@@ -152,7 +152,7 @@ exports[`DirectionLink direction: down renders correctly 1`] = `
 exports[`DirectionLink direction: left renders correctly 1`] = `
 <div>
   <a
-    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
+    class="css-1ku3z9l-TextLink-boxStyles-BaseDirectionLink"
   >
     <svg
       aria-hidden="true"
@@ -181,7 +181,7 @@ exports[`DirectionLink direction: left renders correctly 1`] = `
 exports[`DirectionLink direction: right renders correctly 1`] = `
 <div>
   <a
-    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
+    class="css-1ku3z9l-TextLink-boxStyles-BaseDirectionLink"
   >
     Next
     <svg
@@ -210,7 +210,7 @@ exports[`DirectionLink direction: right renders correctly 1`] = `
 exports[`DirectionLink direction: up renders correctly 1`] = `
 <div>
   <a
-    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
+    class="css-1ku3z9l-TextLink-boxStyles-BaseDirectionLink"
   >
     Top
     <svg

--- a/packages/react/src/direction-link/__snapshots__/DirectionLink.test.tsx.snap
+++ b/packages/react/src/direction-link/__snapshots__/DirectionLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DirectionButton direction: down renders correctly 1`] = `
 <div>
   <button
-    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Skip to footer
@@ -33,7 +33,7 @@ exports[`DirectionButton direction: down renders correctly 1`] = `
 exports[`DirectionButton direction: left renders correctly 1`] = `
 <div>
   <button
-    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     <svg
@@ -63,7 +63,7 @@ exports[`DirectionButton direction: left renders correctly 1`] = `
 exports[`DirectionButton direction: right renders correctly 1`] = `
 <div>
   <button
-    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Next
@@ -93,7 +93,7 @@ exports[`DirectionButton direction: right renders correctly 1`] = `
 exports[`DirectionButton direction: up renders correctly 1`] = `
 <div>
   <button
-    class="css-hcufce-BaseButton-boxStyles-BaseDirectionLink"
+    class="css-1jfzxu5-BaseButton-boxStyles-BaseDirectionLink"
     type="button"
   >
     Top
@@ -123,7 +123,7 @@ exports[`DirectionButton direction: up renders correctly 1`] = `
 exports[`DirectionLink direction: down renders correctly 1`] = `
 <div>
   <a
-    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
+    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
   >
     Skip to footer
     <svg
@@ -152,7 +152,7 @@ exports[`DirectionLink direction: down renders correctly 1`] = `
 exports[`DirectionLink direction: left renders correctly 1`] = `
 <div>
   <a
-    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
+    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
   >
     <svg
       aria-hidden="true"
@@ -181,7 +181,7 @@ exports[`DirectionLink direction: left renders correctly 1`] = `
 exports[`DirectionLink direction: right renders correctly 1`] = `
 <div>
   <a
-    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
+    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
   >
     Next
     <svg
@@ -210,7 +210,7 @@ exports[`DirectionLink direction: right renders correctly 1`] = `
 exports[`DirectionLink direction: up renders correctly 1`] = `
 <div>
   <a
-    class="css-162twio-TextLink-boxStyles-BaseDirectionLink"
+    class="css-5fo29w-TextLink-boxStyles-BaseDirectionLink"
   >
     Top
     <svg

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:rv:"
       role="menuitem"
       tabindex="-1"
@@ -86,7 +86,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r10:"
       role="menuitem"
       tabindex="-1"
@@ -137,7 +137,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       class="css-1th2zfi-Divider"
     />
     <div
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r11:"
       role="menuitem"
       tabindex="-1"
@@ -226,7 +226,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     tabindex="-1"
   >
     <a
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       href="/about"
       id="dropdown-menu-:r16:-item-:r17:"
       role="menuitem"
@@ -246,7 +246,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       />
     </a>
     <a
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       href="/contact"
       id="dropdown-menu-:r16:-item-:r18:"
       role="menuitem"
@@ -447,7 +447,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r1:"
       role="menuitem"
       tabindex="-1"
@@ -466,7 +466,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r2:"
       role="menuitem"
       tabindex="-1"
@@ -485,7 +485,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-1jn0u66-boxStyles-DropdownMenuItem"
+      class="css-u8rnjc-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r3:"
       role="menuitem"
       tabindex="-1"

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:rv:"
       role="menuitem"
       tabindex="-1"
@@ -86,7 +86,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r10:"
       role="menuitem"
       tabindex="-1"
@@ -137,7 +137,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       class="css-1th2zfi-Divider"
     />
     <div
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r11:"
       role="menuitem"
       tabindex="-1"
@@ -226,7 +226,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     tabindex="-1"
   >
     <a
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       href="/about"
       id="dropdown-menu-:r16:-item-:r17:"
       role="menuitem"
@@ -246,7 +246,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       />
     </a>
     <a
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       href="/contact"
       id="dropdown-menu-:r16:-item-:r18:"
       role="menuitem"
@@ -447,7 +447,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r1:"
       role="menuitem"
       tabindex="-1"
@@ -466,7 +466,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r2:"
       role="menuitem"
       tabindex="-1"
@@ -485,7 +485,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       />
     </div>
     <div
-      class="css-u8rnjc-boxStyles-DropdownMenuItem"
+      class="css-1we45ed-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r3:"
       role="menuitem"
       tabindex="-1"

--- a/packages/react/src/feature-link-list/__snapshots__/FeatureLinkList.test.tsx.snap
+++ b/packages/react/src/feature-link-list/__snapshots__/FeatureLinkList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FeatureLinkList renders correctly 1`] = `
     class="css-1goluyv-boxStyles"
   >
     <li
-      class="css-1m8049u-boxStyles-FeatureLinkListItem"
+      class="css-1cthg4x-boxStyles-FeatureLinkListItem"
     >
       <div
         class="css-1cqkcqi-boxStyles-FeatureLinkListItem"
@@ -19,7 +19,7 @@ exports[`FeatureLinkList renders correctly 1`] = `
           >
             <a
               aria-describedby="feature-link-list-description-:r0:"
-              class="css-3oy6gb-TextLink-FeatureLinkListItem"
+              class="css-wcmdnv-TextLink-FeatureLinkListItem"
               href="#"
             >
               Add a business with RAM
@@ -63,7 +63,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
     class="css-1goluyv-boxStyles"
   >
     <li
-      class="css-1m8049u-boxStyles-FeatureLinkListItem"
+      class="css-1cthg4x-boxStyles-FeatureLinkListItem"
     >
       <div
         class="css-1cqkcqi-boxStyles-FeatureLinkListItem"
@@ -75,7 +75,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
             class="css-1esljmy-boxStyles"
           >
             <a
-              class="css-3oy6gb-TextLink-FeatureLinkListItem"
+              class="css-wcmdnv-TextLink-FeatureLinkListItem"
               href="#"
             >
               Add a business with RAM
@@ -104,7 +104,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
       </div>
     </li>
     <li
-      class="css-1m8049u-boxStyles-FeatureLinkListItem"
+      class="css-1cthg4x-boxStyles-FeatureLinkListItem"
     >
       <div
         class="css-1cqkcqi-boxStyles-FeatureLinkListItem"
@@ -116,7 +116,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
             class="css-1esljmy-boxStyles"
           >
             <a
-              class="css-3oy6gb-TextLink-FeatureLinkListItem"
+              class="css-wcmdnv-TextLink-FeatureLinkListItem"
               href="#"
             >
               Accept an invite

--- a/packages/react/src/feature-link-list/__snapshots__/FeatureLinkList.test.tsx.snap
+++ b/packages/react/src/feature-link-list/__snapshots__/FeatureLinkList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FeatureLinkList renders correctly 1`] = `
     class="css-1goluyv-boxStyles"
   >
     <li
-      class="css-1cthg4x-boxStyles-FeatureLinkListItem"
+      class="css-1cw48f3-boxStyles-FeatureLinkListItem"
     >
       <div
         class="css-1cqkcqi-boxStyles-FeatureLinkListItem"
@@ -19,7 +19,7 @@ exports[`FeatureLinkList renders correctly 1`] = `
           >
             <a
               aria-describedby="feature-link-list-description-:r0:"
-              class="css-wcmdnv-TextLink-FeatureLinkListItem"
+              class="css-1utb7kq-TextLink-FeatureLinkListItem"
               href="#"
             >
               Add a business with RAM
@@ -63,7 +63,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
     class="css-1goluyv-boxStyles"
   >
     <li
-      class="css-1cthg4x-boxStyles-FeatureLinkListItem"
+      class="css-1cw48f3-boxStyles-FeatureLinkListItem"
     >
       <div
         class="css-1cqkcqi-boxStyles-FeatureLinkListItem"
@@ -75,7 +75,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
             class="css-1esljmy-boxStyles"
           >
             <a
-              class="css-wcmdnv-TextLink-FeatureLinkListItem"
+              class="css-1utb7kq-TextLink-FeatureLinkListItem"
               href="#"
             >
               Add a business with RAM
@@ -104,7 +104,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
       </div>
     </li>
     <li
-      class="css-1cthg4x-boxStyles-FeatureLinkListItem"
+      class="css-1cw48f3-boxStyles-FeatureLinkListItem"
     >
       <div
         class="css-1cqkcqi-boxStyles-FeatureLinkListItem"
@@ -116,7 +116,7 @@ exports[`FeatureLinkList renders valid HTML with no a11y violations, when no des
             class="css-1esljmy-boxStyles"
           >
             <a
-              class="css-wcmdnv-TextLink-FeatureLinkListItem"
+              class="css-1utb7kq-TextLink-FeatureLinkListItem"
               href="#"
             >
               Accept an invite

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -45,7 +45,7 @@ export const FileUploadExistingFile = ({
 					{href ? (
 						<Text breakWords paddingY={1.5}>
 							<TextLink
-								css={{ ...print.hideLinkURL }}
+								css={{ ...print.hideHref }}
 								download={download}
 								href={href}
 								rel="noopener noreferrer"

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -1,5 +1,6 @@
 import { MouseEventHandler } from 'react';
 import { Box } from '../box';
+import { print } from '../core';
 import { Flex } from '../flex';
 import { Text } from '../text';
 import { Button } from '../button';
@@ -48,6 +49,7 @@ export const FileUploadExistingFile = ({
 								href={href}
 								rel="noopener noreferrer"
 								target="_blank"
+								css={{ ...print.hideLinkURL }}
 							>
 								{name}
 								{size ? ` (${formatFileSize(size)})` : null}

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -45,11 +45,11 @@ export const FileUploadExistingFile = ({
 					{href ? (
 						<Text breakWords paddingY={1.5}>
 							<TextLink
+								css={{ ...print.hideLinkURL }}
 								download={download}
 								href={href}
 								rel="noopener noreferrer"
 								target="_blank"
-								css={{ ...print.hideLinkURL }}
 							>
 								{name}
 								{size ? ` (${formatFileSize(size)})` : null}

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -501,7 +501,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
                   class="css-ayz5ov-boxStyles"
                 >
                   <a
-                    class="css-koqz57-TextLink"
+                    class="css-mjwpzq-TextLink-FileUploadExistingFile"
                     href="#"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -617,7 +617,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
                   class="css-ayz5ov-boxStyles"
                 >
                   <a
-                    class="css-koqz57-TextLink"
+                    class="css-mjwpzq-TextLink-FileUploadExistingFile"
                     href="#"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -501,7 +501,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
                   class="css-ayz5ov-boxStyles"
                 >
                   <a
-                    class="css-mjwpzq-TextLink-FileUploadExistingFile"
+                    class="css-4xsxs2-TextLink-FileUploadExistingFile"
                     href="#"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -617,7 +617,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
                   class="css-ayz5ov-boxStyles"
                 >
                   <a
-                    class="css-mjwpzq-TextLink-FileUploadExistingFile"
+                    class="css-4xsxs2-TextLink-FileUploadExistingFile"
                     href="#"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-koqz57-TextLink"
+              class="css-1geyz1r-TextLink"
               href="#"
             >
               Home
@@ -28,7 +28,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-koqz57-TextLink"
+              class="css-1geyz1r-TextLink"
               href="#"
             >
               Terms and conditions
@@ -38,7 +38,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-koqz57-TextLink"
+              class="css-1geyz1r-TextLink"
               href="#"
             >
               Privacy policy
@@ -48,7 +48,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-koqz57-TextLink"
+              class="css-1geyz1r-TextLink"
               href="#"
             >
               A really long link title

--- a/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-1geyz1r-TextLink"
+              class="css-july2n-TextLink"
               href="#"
             >
               Home
@@ -28,7 +28,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-1geyz1r-TextLink"
+              class="css-july2n-TextLink"
               href="#"
             >
               Terms and conditions
@@ -38,7 +38,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-1geyz1r-TextLink"
+              class="css-july2n-TextLink"
               href="#"
             >
               Privacy policy
@@ -48,7 +48,7 @@ exports[`Footer renders correctly 1`] = `
             class="css-79i25n-boxStyles"
           >
             <a
-              class="css-1geyz1r-TextLink"
+              class="css-july2n-TextLink"
               href="#"
             >
               A really long link title

--- a/packages/react/src/hero-banner/HeroSubcategoryBanner/__snapshots__/HeroSubCategoryBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroSubcategoryBanner/__snapshots__/HeroSubCategoryBanner.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                   />
                 </svg>
                 <a
-                  class="css-koqz57-TextLink"
+                  class="css-1geyz1r-TextLink"
                   href="#"
                 >
                   Section 1
@@ -68,7 +68,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                 <button
                   aria-expanded="false"
                   aria-label="Show all breadcrumbs"
-                  class="css-eqfuua-BaseButton-boxStyles"
+                  class="css-1q0rx3c-BaseButton-boxStyles"
                   type="button"
                 >
                   …
@@ -94,7 +94,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                   />
                 </svg>
                 <a
-                  class="css-koqz57-TextLink"
+                  class="css-1geyz1r-TextLink"
                   href="#"
                 >
                   Category page

--- a/packages/react/src/hero-banner/HeroSubcategoryBanner/__snapshots__/HeroSubCategoryBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroSubcategoryBanner/__snapshots__/HeroSubCategoryBanner.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                   />
                 </svg>
                 <a
-                  class="css-1geyz1r-TextLink"
+                  class="css-july2n-TextLink"
                   href="#"
                 >
                   Section 1
@@ -68,7 +68,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                 <button
                   aria-expanded="false"
                   aria-label="Show all breadcrumbs"
-                  class="css-1q0rx3c-BaseButton-boxStyles"
+                  class="css-1dlzu3n-BaseButton-boxStyles"
                   type="button"
                 >
                   …
@@ -94,7 +94,7 @@ exports[`HeroSubcategoryBanner renders correctly 1`] = `
                   />
                 </svg>
                 <a
-                  class="css-1geyz1r-TextLink"
+                  class="css-july2n-TextLink"
                   href="#"
                 >
                   Category page

--- a/packages/react/src/inpage-nav/__snapshots__/InpageNav.test.tsx.snap
+++ b/packages/react/src/inpage-nav/__snapshots__/InpageNav.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#section-1"
         >
           Section 1
@@ -23,7 +23,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#section-2"
         >
           Section 2
@@ -33,7 +33,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#section-3"
         >
           Section 3
@@ -43,7 +43,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#section-4"
         >
           Section 4
@@ -53,7 +53,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#section-5"
         >
           Section 5

--- a/packages/react/src/inpage-nav/__snapshots__/InpageNav.test.tsx.snap
+++ b/packages/react/src/inpage-nav/__snapshots__/InpageNav.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#section-1"
         >
           Section 1
@@ -23,7 +23,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#section-2"
         >
           Section 2
@@ -33,7 +33,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#section-3"
         >
           Section 3
@@ -43,7 +43,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#section-4"
         >
           Section 4
@@ -53,7 +53,7 @@ exports[`InpageNav renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#section-5"
         >
           Section 5

--- a/packages/react/src/link-list/__snapshots__/LinkList.test.tsx.snap
+++ b/packages/react/src/link-list/__snapshots__/LinkList.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-1geyz1r-TextLink"
+        class="css-july2n-TextLink"
         href="#"
       >
         Home
@@ -19,7 +19,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-1geyz1r-TextLink"
+        class="css-july2n-TextLink"
         href="#"
       >
         Establishments
@@ -29,7 +29,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-1geyz1r-TextLink"
+        class="css-july2n-TextLink"
         href="#"
       >
         Applications
@@ -39,7 +39,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-1geyz1r-TextLink"
+        class="css-july2n-TextLink"
         href="https://design-system.agriculture.gov.au"
         rel="noopener"
         target="_blank"

--- a/packages/react/src/link-list/__snapshots__/LinkList.test.tsx.snap
+++ b/packages/react/src/link-list/__snapshots__/LinkList.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-koqz57-TextLink"
+        class="css-1geyz1r-TextLink"
         href="#"
       >
         Home
@@ -19,7 +19,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-koqz57-TextLink"
+        class="css-1geyz1r-TextLink"
         href="#"
       >
         Establishments
@@ -29,7 +29,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-koqz57-TextLink"
+        class="css-1geyz1r-TextLink"
         href="#"
       >
         Applications
@@ -39,7 +39,7 @@ exports[`LinkList renders correctly 1`] = `
       class="css-79i25n-boxStyles"
     >
       <a
-        class="css-koqz57-TextLink"
+        class="css-1geyz1r-TextLink"
         href="https://design-system.agriculture.gov.au"
         rel="noopener"
         target="_blank"

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`PageAlert tone: error renders correctly 1`] = `
             class="css-1sudq1l-boxStyles-ListItem"
           >
             <a
-              class="css-1geyz1r-TextLink"
+              class="css-july2n-TextLink"
               href="#"
             >
               Full name must not be empty

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`PageAlert tone: error renders correctly 1`] = `
             class="css-1sudq1l-boxStyles-ListItem"
           >
             <a
-              class="css-koqz57-TextLink"
+              class="css-1geyz1r-TextLink"
               href="#"
             >
               Full name must not be empty

--- a/packages/react/src/pagination/PaginationItemDirection.tsx
+++ b/packages/react/src/pagination/PaginationItemDirection.tsx
@@ -1,5 +1,5 @@
 import { ElementType, MouseEventHandler, PropsWithChildren } from 'react';
-import { LinkProps } from '../core';
+import { LinkProps, print } from '../core';
 import { Box } from '../box';
 import { Flex } from '../flex';
 import { TextLink } from '../text-link';
@@ -108,6 +108,7 @@ const BaseDirectionLink = ({
 			as={as}
 			css={{
 				alignSelf: 'flex-start',
+				...print.hideLinkURL,
 			}}
 			focusRingFor="keyboard"
 			fontFamily="body"

--- a/packages/react/src/pagination/PaginationItemDirection.tsx
+++ b/packages/react/src/pagination/PaginationItemDirection.tsx
@@ -108,7 +108,7 @@ const BaseDirectionLink = ({
 			as={as}
 			css={{
 				alignSelf: 'flex-start',
-				...print.hideLinkURL,
+				...print.hideHref,
 			}}
 			focusRingFor="keyboard"
 			fontFamily="body"

--- a/packages/react/src/pagination/PaginationItemPage.tsx
+++ b/packages/react/src/pagination/PaginationItemPage.tsx
@@ -3,6 +3,7 @@ import {
 	boxPalette,
 	forwardRefWithAs,
 	LinkProps,
+	print,
 	useLinkComponent,
 } from '../core';
 import { Flex } from '../flex';
@@ -27,11 +28,12 @@ export function PaginationItemPage({
 				aria-current={isActive ? 'page' : undefined}
 				aria-label={`Go to page ${pageNumber}`}
 				as={Link}
-				css={
-					isActive
+				css={{
+					...(isActive
 						? { color: boxPalette.foregroundText, textDecoration: 'none' }
-						: undefined
-				}
+						: undefined),
+					...print.hideLinkURL,
+				}}
 				focusRingFor="keyboard"
 				fontWeight={isActive ? 'bold' : 'normal'}
 				height={{ xs: BUTTON_SIZE_XS, sm: BUTTON_SIZE_SM }}

--- a/packages/react/src/pagination/PaginationItemPage.tsx
+++ b/packages/react/src/pagination/PaginationItemPage.tsx
@@ -32,7 +32,7 @@ export function PaginationItemPage({
 					...(isActive
 						? { color: boxPalette.foregroundText, textDecoration: 'none' }
 						: undefined),
-					...print.hideLinkURL,
+					...print.hideHref,
 				}}
 				focusRingFor="keyboard"
 				fontWeight={isActive ? 'bold' : 'normal'}

--- a/packages/react/src/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react/src/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Pagination renders correctly 1`] = `
         >
           <a
             aria-label="Go to previous page"
-            class="css-snlovx-TextLink-boxStyles-BaseDirectionLink"
+            class="css-16wr18x-TextLink-boxStyles-BaseDirectionLink"
             href="page-4"
           >
             <svg
@@ -48,7 +48,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 1"
-            class="css-1dgolvi-boxStyles-PaginationItemPage"
+            class="css-xveacv-boxStyles-PaginationItemPage"
             href="page-1"
           >
             1
@@ -67,7 +67,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 4"
-            class="css-1dgolvi-boxStyles-PaginationItemPage"
+            class="css-xveacv-boxStyles-PaginationItemPage"
             href="page-4"
           >
             4
@@ -77,7 +77,7 @@ exports[`Pagination renders correctly 1`] = `
           <a
             aria-current="page"
             aria-label="Go to page 5"
-            class="css-e1ylyf-boxStyles-PaginationItemPage"
+            class="css-1rf1hht-boxStyles-PaginationItemPage"
             href="page-5"
           >
             5
@@ -86,7 +86,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 6"
-            class="css-1dgolvi-boxStyles-PaginationItemPage"
+            class="css-xveacv-boxStyles-PaginationItemPage"
             href="page-6"
           >
             6
@@ -105,7 +105,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 10"
-            class="css-1dgolvi-boxStyles-PaginationItemPage"
+            class="css-xveacv-boxStyles-PaginationItemPage"
             href="page-10"
           >
             10
@@ -116,7 +116,7 @@ exports[`Pagination renders correctly 1`] = `
         >
           <a
             aria-label="Go to next page"
-            class="css-snlovx-TextLink-boxStyles-BaseDirectionLink"
+            class="css-16wr18x-TextLink-boxStyles-BaseDirectionLink"
             href="page-6"
           >
             <span

--- a/packages/react/src/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react/src/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Pagination renders correctly 1`] = `
         >
           <a
             aria-label="Go to previous page"
-            class="css-1g4vex8-TextLink-boxStyles-BaseDirectionLink"
+            class="css-snlovx-TextLink-boxStyles-BaseDirectionLink"
             href="page-4"
           >
             <svg
@@ -48,7 +48,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 1"
-            class="css-uwmdrc-boxStyles"
+            class="css-1dgolvi-boxStyles-PaginationItemPage"
             href="page-1"
           >
             1
@@ -67,7 +67,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 4"
-            class="css-uwmdrc-boxStyles"
+            class="css-1dgolvi-boxStyles-PaginationItemPage"
             href="page-4"
           >
             4
@@ -77,7 +77,7 @@ exports[`Pagination renders correctly 1`] = `
           <a
             aria-current="page"
             aria-label="Go to page 5"
-            class="css-1m003dh-boxStyles-PaginationItemPage"
+            class="css-e1ylyf-boxStyles-PaginationItemPage"
             href="page-5"
           >
             5
@@ -86,7 +86,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 6"
-            class="css-uwmdrc-boxStyles"
+            class="css-1dgolvi-boxStyles-PaginationItemPage"
             href="page-6"
           >
             6
@@ -105,7 +105,7 @@ exports[`Pagination renders correctly 1`] = `
         <li>
           <a
             aria-label="Go to page 10"
-            class="css-uwmdrc-boxStyles"
+            class="css-1dgolvi-boxStyles-PaginationItemPage"
             href="page-10"
           >
             10
@@ -116,7 +116,7 @@ exports[`Pagination renders correctly 1`] = `
         >
           <a
             aria-label="Go to next page"
-            class="css-1g4vex8-TextLink-boxStyles-BaseDirectionLink"
+            class="css-snlovx-TextLink-boxStyles-BaseDirectionLink"
             href="page-6"
           >
             <span

--- a/packages/react/src/pagination/__snapshots__/PaginationButtons.test.tsx.snap
+++ b/packages/react/src/pagination/__snapshots__/PaginationButtons.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         >
           <button
             aria-label="Go to previous page"
-            class="css-z22iwe-BaseButton-boxStyles-BaseDirectionLink"
+            class="css-1fdgfpf-BaseButton-boxStyles-BaseDirectionLink"
             type="button"
           >
             <svg
@@ -48,7 +48,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 1"
-            class="css-ne4x5c-BaseButton-boxStyles"
+            class="css-1z0ukgx-BaseButton-boxStyles"
             type="button"
           >
             1
@@ -67,7 +67,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 4"
-            class="css-ne4x5c-BaseButton-boxStyles"
+            class="css-1z0ukgx-BaseButton-boxStyles"
             type="button"
           >
             4
@@ -77,7 +77,7 @@ exports[`PaginationButtons renders correctly 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 5"
-            class="css-1vx8cjw-BaseButton-boxStyles-PaginationItemPageButton"
+            class="css-zt49g4-BaseButton-boxStyles-PaginationItemPageButton"
             type="button"
           >
             5
@@ -86,7 +86,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 6"
-            class="css-ne4x5c-BaseButton-boxStyles"
+            class="css-1z0ukgx-BaseButton-boxStyles"
             type="button"
           >
             6
@@ -105,7 +105,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 10"
-            class="css-ne4x5c-BaseButton-boxStyles"
+            class="css-1z0ukgx-BaseButton-boxStyles"
             type="button"
           >
             10
@@ -116,7 +116,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="css-z22iwe-BaseButton-boxStyles-BaseDirectionLink"
+            class="css-1fdgfpf-BaseButton-boxStyles-BaseDirectionLink"
             type="button"
           >
             <span

--- a/packages/react/src/pagination/__snapshots__/PaginationButtons.test.tsx.snap
+++ b/packages/react/src/pagination/__snapshots__/PaginationButtons.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         >
           <button
             aria-label="Go to previous page"
-            class="css-1svh3o-BaseButton-boxStyles-BaseDirectionLink"
+            class="css-z22iwe-BaseButton-boxStyles-BaseDirectionLink"
             type="button"
           >
             <svg
@@ -48,7 +48,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 1"
-            class="css-12wo8us-BaseButton-boxStyles"
+            class="css-ne4x5c-BaseButton-boxStyles"
             type="button"
           >
             1
@@ -67,7 +67,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 4"
-            class="css-12wo8us-BaseButton-boxStyles"
+            class="css-ne4x5c-BaseButton-boxStyles"
             type="button"
           >
             4
@@ -77,7 +77,7 @@ exports[`PaginationButtons renders correctly 1`] = `
           <button
             aria-current="page"
             aria-label="Go to page 5"
-            class="css-1rvez9h-BaseButton-boxStyles-PaginationItemPageButton"
+            class="css-1vx8cjw-BaseButton-boxStyles-PaginationItemPageButton"
             type="button"
           >
             5
@@ -86,7 +86,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 6"
-            class="css-12wo8us-BaseButton-boxStyles"
+            class="css-ne4x5c-BaseButton-boxStyles"
             type="button"
           >
             6
@@ -105,7 +105,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         <li>
           <button
             aria-label="Go to page 10"
-            class="css-12wo8us-BaseButton-boxStyles"
+            class="css-ne4x5c-BaseButton-boxStyles"
             type="button"
           >
             10
@@ -116,7 +116,7 @@ exports[`PaginationButtons renders correctly 1`] = `
         >
           <button
             aria-label="Go to next page"
-            class="css-1svh3o-BaseButton-boxStyles-BaseDirectionLink"
+            class="css-z22iwe-BaseButton-boxStyles-BaseDirectionLink"
             type="button"
           >
             <span

--- a/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -178,7 +178,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -252,7 +252,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
               </span>
               <a
                 aria-current="true"
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -316,7 +316,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -377,7 +377,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -450,7 +450,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -509,7 +509,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1722,7 +1722,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1781,7 +1781,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
               </span>
               <a
                 aria-current="true"
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1854,7 +1854,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1918,7 +1918,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1979,7 +1979,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2052,7 +2052,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2111,7 +2111,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2790,7 +2790,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2848,7 +2848,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2922,7 +2922,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
               </span>
               <a
                 aria-current="true"
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2986,7 +2986,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3047,7 +3047,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3120,7 +3120,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3179,7 +3179,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3858,7 +3858,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3916,7 +3916,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3989,7 +3989,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4053,7 +4053,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4114,7 +4114,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4188,7 +4188,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
               </span>
               <a
                 aria-current="true"
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4247,7 +4247,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-j7i2l9-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >

--- a/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -178,7 +178,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -252,7 +252,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
               </span>
               <a
                 aria-current="true"
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -316,7 +316,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -377,7 +377,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -450,7 +450,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -509,7 +509,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1722,7 +1722,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1781,7 +1781,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
               </span>
               <a
                 aria-current="true"
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1854,7 +1854,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1918,7 +1918,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -1979,7 +1979,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2052,7 +2052,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2111,7 +2111,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2790,7 +2790,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2848,7 +2848,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2922,7 +2922,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
               </span>
               <a
                 aria-current="true"
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -2986,7 +2986,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3047,7 +3047,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3120,7 +3120,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3179,7 +3179,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3858,7 +3858,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3916,7 +3916,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -3989,7 +3989,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4053,7 +4053,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4114,7 +4114,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4188,7 +4188,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
               </span>
               <a
                 aria-current="true"
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >
@@ -4247,7 +4247,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
                 />
               </span>
               <a
-                class="css-15x7w6m-TextLink-boxStyles-ProgressIndicatorItem"
+                class="css-103hp5d-TextLink-boxStyles-ProgressIndicatorItem"
                 data-agds-progress-indicator-item-text-container=""
                 href="#"
               >

--- a/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
+++ b/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#"
         >
           Change
@@ -46,7 +46,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#"
         >
           Change
@@ -72,7 +72,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#"
         >
           Change
@@ -96,7 +96,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-koqz57-TextLink"
+          class="css-1geyz1r-TextLink"
           href="#"
         >
           Change

--- a/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
+++ b/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#"
         >
           Change
@@ -46,7 +46,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#"
         >
           Change
@@ -72,7 +72,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#"
         >
           Change
@@ -96,7 +96,7 @@ exports[`SummaryList renders correctly 1`] = `
         class="css-vspen0-boxStyles"
       >
         <a
-          class="css-1geyz1r-TextLink"
+          class="css-july2n-TextLink"
           href="#"
         >
           Change

--- a/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
+++ b/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-nnw7y0-TextLink-boxStyles"
+            class="css-4w3gkw-TextLink-boxStyles"
             href="#"
           >
             Foo
@@ -34,7 +34,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-nnw7y0-TextLink-boxStyles"
+            class="css-4w3gkw-TextLink-boxStyles"
             href="#"
           >
             Bar
@@ -48,7 +48,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-nnw7y0-TextLink-boxStyles"
+            class="css-4w3gkw-TextLink-boxStyles"
             href="#"
           >
             Baz
@@ -80,7 +80,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-nnw7y0-TextLink-boxStyles"
+            class="css-4w3gkw-TextLink-boxStyles"
             href="#"
           >
             Foo
@@ -125,7 +125,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-nnw7y0-TextLink-boxStyles"
+            class="css-4w3gkw-TextLink-boxStyles"
             href="#"
           >
             Bar
@@ -170,7 +170,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-nnw7y0-TextLink-boxStyles"
+            class="css-4w3gkw-TextLink-boxStyles"
             href="#"
           >
             Baz

--- a/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
+++ b/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-1qb2lpt-TextLink-boxStyles"
+            class="css-nnw7y0-TextLink-boxStyles"
             href="#"
           >
             Foo
@@ -34,7 +34,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-1qb2lpt-TextLink-boxStyles"
+            class="css-nnw7y0-TextLink-boxStyles"
             href="#"
           >
             Bar
@@ -48,7 +48,7 @@ exports[`Tags With links renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-1qb2lpt-TextLink-boxStyles"
+            class="css-nnw7y0-TextLink-boxStyles"
             href="#"
           >
             Baz
@@ -80,7 +80,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-1qb2lpt-TextLink-boxStyles"
+            class="css-nnw7y0-TextLink-boxStyles"
             href="#"
           >
             Foo
@@ -125,7 +125,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-1qb2lpt-TextLink-boxStyles"
+            class="css-nnw7y0-TextLink-boxStyles"
             href="#"
           >
             Bar
@@ -170,7 +170,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
           class="css-1l8g3ew-boxStyles-Tag"
         >
           <a
-            class="css-1qb2lpt-TextLink-boxStyles"
+            class="css-nnw7y0-TextLink-boxStyles"
             href="#"
           >
             Baz

--- a/packages/react/src/task-list/__snapshots__/TaskList.test.tsx.snap
+++ b/packages/react/src/task-list/__snapshots__/TaskList.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-15ywwdc-TextLink-boxStyles-TaskListItem"
+          class="css-x293iw-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -133,7 +133,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-15ywwdc-TextLink-boxStyles-TaskListItem"
+          class="css-x293iw-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -237,7 +237,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-aoyeso-TextLink-boxStyles-TaskListItem"
+          class="css-2iy1vr-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -367,7 +367,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-15ywwdc-TextLink-boxStyles-TaskListItem"
+          class="css-x293iw-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span

--- a/packages/react/src/task-list/__snapshots__/TaskList.test.tsx.snap
+++ b/packages/react/src/task-list/__snapshots__/TaskList.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-1htue7x-TextLink-boxStyles-TaskListItem"
+          class="css-15ywwdc-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -133,7 +133,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-1htue7x-TextLink-boxStyles-TaskListItem"
+          class="css-15ywwdc-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -237,7 +237,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-1992mal-TextLink-boxStyles-TaskListItem"
+          class="css-aoyeso-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span
@@ -367,7 +367,7 @@ exports[`TaskList With anchors renders correctly 1`] = `
         class="css-16jufl0-TaskListItem"
       >
         <a
-          class="css-1htue7x-TextLink-boxStyles-TaskListItem"
+          class="css-15ywwdc-TextLink-boxStyles-TaskListItem"
           href="#"
         >
           <span

--- a/packages/react/src/text-link/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/react/src/text-link/__snapshots__/TextLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextLink renders correctly 1`] = `
 <div>
   <a
-    class="css-1geyz1r-TextLink"
+    class="css-july2n-TextLink"
     data-testid="example"
     href="/example"
   >

--- a/packages/react/src/text-link/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/react/src/text-link/__snapshots__/TextLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextLink renders correctly 1`] = `
 <div>
   <a
-    class="css-koqz57-TextLink"
+    class="css-1geyz1r-TextLink"
     data-testid="example"
     href="/example"
   >

--- a/packages/react/src/text-link/__snapshots__/TextLinkExternal.test.tsx.snap
+++ b/packages/react/src/text-link/__snapshots__/TextLinkExternal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextLinkExternal renders correctly 1`] = `
 <div>
   <a
-    class="css-1geyz1r-TextLink"
+    class="css-july2n-TextLink"
     data-testid="example"
     href="https://design-system.agriculture.gov.au"
     rel="noopener"

--- a/packages/react/src/text-link/__snapshots__/TextLinkExternal.test.tsx.snap
+++ b/packages/react/src/text-link/__snapshots__/TextLinkExternal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextLinkExternal renders correctly 1`] = `
 <div>
   <a
-    class="css-koqz57-TextLink"
+    class="css-1geyz1r-TextLink"
     data-testid="example"
     href="https://design-system.agriculture.gov.au"
     rel="noopener"


### PR DESCRIPTION
Links had URLs rendered after the text in print formats to assist users who want to access the address after printed. Internal hash links are redundant in print. These changes hide hash links when printing. Additionally some components had their links hidden because it was causing clutter or not required.

Components changed:

**box:** appended print rule for hiding URLs displayed for internal hash links,
![Screenshot 2025-03-12 at 3 58 20 pm](https://github.com/user-attachments/assets/e5d9f53e-7346-49b5-a96d-f28694829a27)
![Screenshot 2025-03-12 at 3 17 07 pm](https://github.com/user-attachments/assets/092ba07f-5495-4fb5-9fdf-23e7f5bb9579)

**file-upload:** hide URL rendering of existing file uploads on print media,
![Screenshot 2025-03-12 at 2 56 40 pm](https://github.com/user-attachments/assets/2b55cad5-c9fa-47fb-84c2-8b5c704c2cdb)
![Screenshot 2025-03-12 at 3 16 34 pm](https://github.com/user-attachments/assets/d5cb9e6d-f340-45fb-b27b-60304f7d3509)


**pagination:** hide URL rendering for link numbers and direction links on print media.
![Screenshot 2025-03-12 at 2 57 37 pm](https://github.com/user-attachments/assets/705ed936-8420-4a71-be3f-84be71ec3ef6)
![Screenshot 2025-03-12 at 3 44 41 pm](https://github.com/user-attachments/assets/2b4fd32f-d2b9-469d-8b90-ad168f70a2e1)


[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1970)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
