### PR TITLE
core: fix print exactColor hydration error with kebab case

### DIFF
--- a/.changeset/six-jars-share.md
+++ b/.changeset/six-jars-share.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+core: modified css parameter name from `'-webkit-print-color-adjust'` -> `WebkitPrintColorAdjust` to resolve hydration warning for using kebab case. 

--- a/packages/react/src/core/packs.ts
+++ b/packages/react/src/core/packs.ts
@@ -58,14 +58,14 @@ export const print = {
 			height: 'auto !important',
 		},
 	},
-	// for context that requires background on print (eg. white text on dark background)
+	// For context that requires background on print (eg. white text on dark background)
 	exactColor: {
 		'@media print': {
-			'-webkit-print-color-adjust': 'exact',
+			WebkitPrintColorAdjust: 'exact',
 			printColorAdjust: 'exact',
 		},
 	},
-};
+} as const;
 
 export const packs = {
 	control,


### PR DESCRIPTION
Using kebab case cause hydration warnings to appear where used. Changed to cammel case.  No functional or style changes. Added `const` type for `print` to fix Typescript error.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1971)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
