### PR TITLE
Change various deprecation warnings to not appear in prod envs

### DIFF
--- a/.changeset/rare-masks-love.md
+++ b/.changeset/rare-masks-love.md
@@ -1,0 +1,13 @@
+---
+'@ag.ds-next/react': minor
+---
+
+drawer: Change deprecation warnings to not appear in production environments.
+
+global-alert: Change deprecation warnings to not appear in production environments.
+
+modal: Change deprecation warnings to not appear in production environments.
+
+page-alert: Change deprecation warnings to not appear in production environments.
+
+section-alert: Change deprecation warnings to not appear in production environments.

--- a/packages/react/src/getCloseHandler.ts
+++ b/packages/react/src/getCloseHandler.ts
@@ -29,9 +29,11 @@ export function getOptionalCloseHandler(
 }
 
 function handleWarnings(onClose: Fn | undefined, onDismiss: Fn | undefined) {
-	if (onClose && onDismiss) {
-		console.warn(closeHandlerWarningMessage);
-	} else if (onDismiss) {
-		console.warn('onDismiss is deprecated. Use onClose instead.');
+	if (process.env.NODE_ENV !== 'production') {
+		if (onClose && onDismiss) {
+			console.warn(closeHandlerWarningMessage);
+		} else if (onDismiss) {
+			console.warn('onDismiss is deprecated. Use onClose instead.');
+		}
 	}
 }

--- a/packages/react/src/page-alert/PageAlertTitle.tsx
+++ b/packages/react/src/page-alert/PageAlertTitle.tsx
@@ -15,7 +15,7 @@ export const PageAlertTitle = ({
 	hasDismissButton,
 	hasCloseButton,
 }: PageAlertTitleProps) => {
-	if (hasDismissButton !== undefined) {
+	if (process.env.NODE_ENV !== 'production' && hasDismissButton !== undefined) {
 		console.warn('hasDismissButton is deprecated. Use hasCloseButton instead.');
 	}
 	return (


### PR DESCRIPTION
Loads of our deprecation warnings were only happening in non-prod environments, but these ones weren't… so now they're consistent.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1974)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
