### PR TITLE
card: update card docs and snippets

### DIFF
--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -1137,17 +1137,303 @@ const snippets: Array<Snippet> = [
 	{
 		group: 'Card',
 		name: 'Basic',
-		code: `<Card shadow clickable>
+		code: `<Card>
 			<CardInner>
 				<Stack gap={1}>
-				<H3>
-					<CardLink href="#">Card heading</CardLink>
-				</H3>
+					<H3>Card heading</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Image',
+		code: `<Card>
+			<img alt="" role="presentation" src="/img/placeholder/hero-banner.jpeg" style={{width: '100%'}}/>
+			<CardInner>
+				<TextLink href="#">Action</TextLink>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Footer (external)',
+		code: `<Card 
+			clickable // NOTE: This feels off
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>Card heading</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Footer (internal)',
+		code: `<Card 
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>Card heading</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Image and footer (internal)',
+		code: `<Card
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<img alt="" role="presentation" src="/img/placeholder/hero-banner.jpeg" style={{width: '100%'}}/>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>Card heading</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Image and footer (external)',
+		code: `<Card
+			clickable
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<img alt="" role="presentation" src="/img/placeholder/hero-banner.jpeg" style={{width: '100%'}}/>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>Card heading</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Clickable',
+		code: `<Card clickable shadow>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>
+						<CardLink href="#">Card heading</CardLink>
+					</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Clickable with Image',
+		code: `<Card clickable shadow>
+			<img alt="" role="presentation" src="/img/placeholder/hero-banner.jpeg" style={{width: '100%'}}/>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>
+						<CardLink href="#">Title of article</CardLink>
+					</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Clickable with footer (external)',
+		code: `<Card 
+			shadow 
+			clickable 
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>
+						<CardLink href="#">Card heading</CardLink>
+					</H3>
+					<Text as="p">Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptat</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Clickable with footer (internal)',
+		code: `<Card 
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+			shadow
+		>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>
+						<CardLink href="#">Card heading</CardLink>
+					</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Clickable with image and footer (internal)', // NOTE: This doesn't work right? Limitation?
+		code: `<Card
+			//clickable // NOTE: This is wierd
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+			shadow
+		>
+			<img alt="" role="presentation" src="/img/placeholder/hero-banner.jpeg" style={{width: '100%'}}/>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>
+						<CardLink href="#">Card heading</CardLink>
+					</H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Clickable with image and footer (external)',
+		code: `<Card
+			clickable
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+			shadow
+		>
+			<img alt="" role="presentation" src="/img/placeholder/hero-banner.jpeg" style={{width: '100%'}}/>
+			<CardInner>
+				<Stack gap={1}>
+					<H3>
+						<CardLink href="#">Card heading</CardLink>
+					<H3>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+		</Card>`,
+	},
+	{
+		group: 'Card',
+		name: 'Feature headers',
+		code: `<Card>
+			<CardHeader background="bodyAlt">
+				<Heading as="h3" type="h4">
+					Feature card title
+				</Heading>
+			</CardHeader>
+			<CardInner>
 				<Text as="p">
 					Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
 					voluptat
 				</Text>
-				</Stack>
 			</CardInner>
 		</Card>`,
 	},

--- a/packages/react/src/card/docs/overview.mdx
+++ b/packages/react/src/card/docs/overview.mdx
@@ -87,181 +87,102 @@ Clickable cards can also have additional footer actions. A common use-case allow
 
 From v1.27.0, you must use the `footer` prop to pass `CardFooter` content to ensure that the “clickable” region doesn’t overlap anything in the footer.
 
-While `Card` still supports `CardFooter` as a child (as per v1.26.0 and below), it cannot support the clickable footer actions use-case in full, so we recommend migrating to `footer` for all cases.
+While `Card` still supports `CardFooter` as a child (as per v1.26.0 and below), it cannot support the clickable footer actions use-case in full, so we recommend migrating to `footer` for all cases. [Read more about the changes](/components/card/rationale#card-footer-changes)
 
 ```jsx live
 <Stack gap={2}>
-	<Card
-		shadow
-		clickable
-		footer={
-			<CardFooter>
-				<ToggleButton
-					iconType="star"
-					label="Add to favourites"
-					onClick={console.log}
-					pressedLabel="Remove from favourites"
-				/>
-			</CardFooter>
-		}
-	>
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-	</Card>
-	<Card shadow clickable>
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">LEGACY Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-		<CardFooter>
-			<ToggleButton
-				iconType="star"
-				label="Add to favourites"
-				onClick={console.log}
-				pressedLabel="Remove from favourites"
-			/>
-		</CardFooter>
-	</Card>
-	<Card
-		shadow
-		clickable
-		footer={
-			<CardFooter>
-				<ToggleButton
-					iconType="star"
-					label="Add to favourites"
-					onClick={console.log}
-					pressedLabel="Remove from favourites"
-				/>
-			</CardFooter>
-		}
-	>
-		<PlaceholderImage />
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-	</Card>
-	<Card shadow clickable>
-		<PlaceholderImage />
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">LEGACY Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-		<CardFooter>
-			<ToggleButton
-				iconType="star"
-				label="Add to favourites"
-				onClick={console.log}
-				pressedLabel="Remove from favourites"
-			/>
-		</CardFooter>
-	</Card>
-</Stack>
-```
-
-### DEMO Standard Cards
-
-```jsx live
-<Stack gap={2}>
-	<Card
-		footer={
-			<CardFooter>
-				<ToggleButton
-					iconType="star"
-					label="Add to favourites"
-					onClick={console.log}
-					pressedLabel="Remove from favourites"
-				/>
-			</CardFooter>
-		}
-	>
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-	</Card>
-	<Card>
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">LEGACY Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-		<CardFooter>
-			<ToggleButton
-				iconType="star"
-				label="Add to favourites"
-				onClick={console.log}
-				pressedLabel="Remove from favourites"
-			/>
-		</CardFooter>
-	</Card>
-	<Card
-		footer={
-			<CardFooter>
-				<ToggleButton
-					iconType="star"
-					label="Add to favourites"
-					onClick={console.log}
-					pressedLabel="Remove from favourites"
-				/>
-			</CardFooter>
-		}
-	>
-		<PlaceholderImage />
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-	</Card>
-	<Card>
-		<PlaceholderImage />
-		<CardInner>
-			<Stack gap={1}>
-				<Heading type="h3">
-					<CardLink href="#">LEGACY Title of article</CardLink>
-				</Heading>
-				<Text as="p">Some text</Text>
-			</Stack>
-		</CardInner>
-		<CardFooter>
-			<ToggleButton
-				iconType="star"
-				label="Add to favourites"
-				onClick={console.log}
-				pressedLabel="Remove from favourites"
-			/>
-		</CardFooter>
-	</Card>
+	<Columns as="ul" cols={{ xs: 2 }}>
+		<Card
+			shadow
+			clickable
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">Title of article</CardLink>
+					</Heading>
+					<Text as="p">Some text</Text>
+				</Stack>
+			</CardInner>
+		</Card>
+		<Card
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">Title of article</CardLink>
+					</Heading>
+					<Text as="p">Some text</Text>
+				</Stack>
+			</CardInner>
+		</Card>
+		<Card
+			shadow
+			clickable
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<PlaceholderImage />
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">Title of article</CardLink>
+					</Heading>
+					<Text as="p">Some text</Text>
+				</Stack>
+			</CardInner>
+		</Card>
+		<Card
+			footer={
+				<CardFooter>
+					<ToggleButton
+						iconType="star"
+						label="Add to favourites"
+						onClick={console.log}
+						pressedLabel="Remove from favourites"
+					/>
+				</CardFooter>
+			}
+		>
+			<PlaceholderImage />
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">Title of article</CardLink>
+					</Heading>
+					<Text as="p">Some text</Text>
+				</Stack>
+			</CardInner>
+		</Card>
+	</Columns>
 </Stack>
 ```
 

--- a/packages/react/src/card/docs/rationale.mdx
+++ b/packages/react/src/card/docs/rationale.mdx
@@ -1,0 +1,127 @@
+## Card footer changes
+
+Teams using the Agriculture Design System requested support to add card footers to be displayed below the `Card` component. The `CardFooter` component in v1.26.0 only supported footers inside the Card itself. A clickable card will also place a hover link covering the entire card container that would also cover any footer actions.
+
+In v1.27.0 changes were made to the Card component to accept a `footer` prop that passes `CardFooter` content to ensure that the “clickable” region doesn’t overlap anything in the footer (internal and external). Passing a `CardFooter` as a prop into the card enables us to have more control over the stylings and layout of the overall component.
+
+```
+// Before v1.27.0, `CardFooter` inside the `Card` component as its child
+<Card>
+    <CardInner>
+        ...
+    </CardInner>
+    <CardFooter>
+        ...
+    </CardFooter>
+</Card>
+
+// After v1.27.0, `CardFooter` provided as a prop of `Card`
+<Card
+    footer={
+        <CardFooter>
+            ...
+        </CardFooter>
+    }
+>
+    <CardInner>
+        ...
+    </CardInner>
+</Card>
+```
+
+While Card still supports `CardFooter` as a child (as per v1.26.0 and below), it cannot support the clickable footer actions use-case in full, so we recommend migrating to footer for all cases.
+
+```jsx live
+<Stack gap={2}>
+	<H2>Legacy footer examples (do not use)</H2>
+	<Columns as="ul" cols={{ xs: 2 }}>
+		<Card shadow clickable>
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">LEGACY Title of article</CardLink>
+					</Heading>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+			<CardFooter>
+				<ToggleButton
+					iconType="star"
+					label="Add to favourites"
+					onClick={console.log}
+					pressedLabel="Remove from favourites"
+				/>
+			</CardFooter>
+		</Card>
+		<Card>
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">LEGACY Title of article</CardLink>
+					</Heading>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+			<CardFooter>
+				<ToggleButton
+					iconType="star"
+					label="Add to favourites"
+					onClick={console.log}
+					pressedLabel="Remove from favourites"
+				/>
+			</CardFooter>
+		</Card>
+
+		<Card shadow clickable>
+			<PlaceholderImage />
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">LEGACY Title of article</CardLink>
+					</Heading>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+			<CardFooter>
+				<ToggleButton
+					iconType="star"
+					label="Add to favourites"
+					onClick={console.log}
+					pressedLabel="Remove from favourites"
+				/>
+			</CardFooter>
+		</Card>
+		<Card>
+			<PlaceholderImage />
+			<CardInner>
+				<Stack gap={1}>
+					<Heading type="h3">
+						<CardLink href="#">LEGACY Title of article</CardLink>
+					</Heading>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+				</Stack>
+			</CardInner>
+			<CardFooter>
+				<ToggleButton
+					iconType="star"
+					label="Add to favourites"
+					onClick={console.log}
+					pressedLabel="Remove from favourites"
+				/>
+			</CardFooter>
+		</Card>
+	</Columns>
+</Stack>
+```


### PR DESCRIPTION
Updated docs (and snippets) for the PR-1990, have not updated Storybook docs

- Created a snippet for different variations
- Created `rationale` docs and moved legacy code snippets to new page

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1991)

## Checklist

**Preflight**

- [ ] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [ ] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
