### PR TITLE
section-alert: add `info` tone and level variants to tone

### DIFF
--- a/.changeset/heavy-moose-marry.md
+++ b/.changeset/heavy-moose-marry.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+section-alert: Add `info` tone. Added `high`, `medium` and `low` variants to all tones. Increase border left width from `xl` to `xxl`.

--- a/.changeset/heavy-moose-marry.md
+++ b/.changeset/heavy-moose-marry.md
@@ -2,4 +2,8 @@
 '@ag.ds-next/react': minor
 ---
 
+docs: fix page ordering of related components and patterns in 'table of contents' for components documents.
+
+icon: revert `WarningIcon` to previous version to fix missing path.
+
 section-alert: Add `info` tone. Added `high`, `medium` and `low` variants to all tones. Increase border left width from `xl` to `xxl`. Legacy tones `success`, `error` and `warning` will now render to `successHigh`, `errorHigh` and `warningHigh` respectively.

--- a/.changeset/heavy-moose-marry.md
+++ b/.changeset/heavy-moose-marry.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': minor
 ---
 
-section-alert: Add `info` tone. Added `high`, `medium` and `low` variants to all tones. Increase border left width from `xl` to `xxl`.
+section-alert: Add `info` tone. Added `high`, `medium` and `low` variants to all tones. Increase border left width from `xl` to `xxl`. Legacy tones `success`, `error` and `warning` will now render to `successHigh`, `errorHigh` and `warningHigh` respectively.

--- a/docs/pages/components/[slug]/index.tsx
+++ b/docs/pages/components/[slug]/index.tsx
@@ -104,20 +104,6 @@ export const getStaticProps: GetStaticProps<
 	const breadcrumbs = await getPkgBreadcrumbs(slug);
 	const toc = generateToc(pkgContent.content);
 
-	// Get related patterns
-	const relatedPatterns = pkg.relatedPatterns?.length
-		? await Promise.all(pkg.relatedPatterns.sort().map(getPattern))
-		: null;
-	if (relatedPatterns?.length) {
-		toc.push({
-			title: 'Related patterns',
-			slug: 'related-patterns',
-			id: 'related-patterns',
-			level: 2,
-			items: [],
-		});
-	}
-
 	// Get related components
 	const relatedComponents = pkg.relatedComponents?.length
 		? await Promise.all(pkg.relatedComponents.sort().map(getPkg))
@@ -127,6 +113,20 @@ export const getStaticProps: GetStaticProps<
 			title: 'Related components',
 			slug: 'related-components',
 			id: 'related-components',
+			level: 2,
+			items: [],
+		});
+	}
+
+	// Get related patterns
+	const relatedPatterns = pkg.relatedPatterns?.length
+		? await Promise.all(pkg.relatedPatterns.sort().map(getPattern))
+		: null;
+	if (relatedPatterns?.length) {
+		toc.push({
+			title: 'Related patterns',
+			slug: 'related-patterns',
+			id: 'related-patterns',
 			level: 2,
 			items: [],
 		});

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -1306,43 +1306,33 @@ const snippets: Array<Snippet> = [
 	},
 	{
 		group: 'SectionAlert',
-		name: 'Dismissable',
-		code: `<SectionAlert tone="successHigh" title="Info" onClose={console.log} />`,
-	},
-	{
-		group: 'SectionAlert',
-		name: 'With description',
-		code: `	<SectionAlert title="Section alert title" tone="success"><Text as="p">Description</Text></SectionAlert>`,
-	},
-	{
-		group: 'SectionAlert',
-		name: 'Success high',
+		name: 'Success high with description',
 		code: `<SectionAlert tone="successHigh" title="Success"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
 	},
 	{
 		group: 'SectionAlert',
 		name: 'Success medium',
-		code: `<SectionAlert tone="successMedium" title="Success"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		code: `<SectionAlert tone="successMedium" title="Success"></SectionAlert>`,
 	},
 	{
 		group: 'SectionAlert',
 		name: 'Success low',
-		code: `<SectionAlert tone="successLow" title="Success"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		code: `<SectionAlert tone="successLow" title="Success"></SectionAlert>`,
 	},
 	{
 		group: 'SectionAlert',
 		name: 'Error high',
-		code: `<SectionAlert tone="errorHigh" title="Error"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		code: `<SectionAlert tone="errorHigh" title="Error"></SectionAlert>`,
 	},
 	{
 		group: 'SectionAlert',
 		name: 'Warning high',
-		code: `<SectionAlert tone="warningHigh" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		code: `<SectionAlert tone="warningHigh" title="Warning"></SectionAlert>`,
 	},
 	{
 		group: 'SectionAlert',
-		name: 'Info high',
-		code: `<SectionAlert tone="infoHigh" title="Info"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		name: 'Info high with dismissable',
+		code: `<SectionAlert tone="infoHigh" title="Info" onClose={console.log}></SectionAlert>`,
 	},
 	{
 		group: 'PasswordInput',

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -1336,43 +1336,13 @@ const snippets: Array<Snippet> = [
 	},
 	{
 		group: 'SectionAlert',
-		name: 'Error medium',
-		code: `<SectionAlert tone="errorMedium" title="Error"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
-	},
-	{
-		group: 'SectionAlert',
-		name: 'Error low',
-		code: `<SectionAlert tone="errorLow" title="Error"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
-	},
-	{
-		group: 'SectionAlert',
 		name: 'Warning high',
 		code: `<SectionAlert tone="warningHigh" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
 	},
 	{
 		group: 'SectionAlert',
-		name: 'Warning medium',
-		code: `<SectionAlert tone="warningMedium" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
-	},
-	{
-		group: 'SectionAlert',
-		name: 'Warning low',
-		code: `<SectionAlert tone="warningLow" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
-	},
-	{
-		group: 'SectionAlert',
 		name: 'Info high',
 		code: `<SectionAlert tone="infoHigh" title="Info"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
-	},
-	{
-		group: 'SectionAlert',
-		name: 'Info medium',
-		code: `<SectionAlert tone="infoMedium" title="Info"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
-	},
-	{
-		group: 'SectionAlert',
-		name: 'Info low',
-		code: `<SectionAlert tone="infoLow" title="Info"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
 	},
 	{
 		group: 'PasswordInput',

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -1306,18 +1306,73 @@ const snippets: Array<Snippet> = [
 	},
 	{
 		group: 'SectionAlert',
-		name: 'Success',
-		code: `<SectionAlert tone="success" title="Success"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		name: 'Dismissable',
+		code: `<SectionAlert tone="successHigh" title="Info" onClose={console.log} />`,
 	},
 	{
 		group: 'SectionAlert',
-		name: 'Error',
-		code: `<SectionAlert tone="error" title="Error"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		name: 'With description',
+		code: `	<SectionAlert title="Section alert title" tone="success"><Text as="p">Description</Text></SectionAlert>`,
 	},
 	{
 		group: 'SectionAlert',
-		name: 'Warning',
-		code: `<SectionAlert tone="warning" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+		name: 'Success high',
+		code: `<SectionAlert tone="successHigh" title="Success"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Success medium',
+		code: `<SectionAlert tone="successMedium" title="Success"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Success low',
+		code: `<SectionAlert tone="successLow" title="Success"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Error high',
+		code: `<SectionAlert tone="errorHigh" title="Error"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Error medium',
+		code: `<SectionAlert tone="errorMedium" title="Error"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Error low',
+		code: `<SectionAlert tone="errorLow" title="Error"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Warning high',
+		code: `<SectionAlert tone="warningHigh" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Warning medium',
+		code: `<SectionAlert tone="warningMedium" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Warning low',
+		code: `<SectionAlert tone="warningLow" title="Warning"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Info high',
+		code: `<SectionAlert tone="infoHigh" title="Info"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Info medium',
+		code: `<SectionAlert tone="infoMedium" title="Info"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
+	},
+	{
+		group: 'SectionAlert',
+		name: 'Info low',
+		code: `<SectionAlert tone="infoLow" title="Info"><Text as="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Text></SectionAlert>`,
 	},
 	{
 		group: 'PasswordInput',

--- a/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
@@ -1916,7 +1916,7 @@ exports[`Icon WarningIcon renders correctly 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9"
+      d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5ZM12 14V9m0 9h0"
     />
   </svg>
 </div>

--- a/packages/react/src/icon/icons/WarningIcon.tsx
+++ b/packages/react/src/icon/icons/WarningIcon.tsx
@@ -1,6 +1,6 @@
 import { createIcon } from '../Icon';
 
 export const WarningIcon = createIcon(
-	<path d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9" />,
+	<path d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5ZM12 14V9m0 9h0" />,
 	'WarningIcon'
 );

--- a/packages/react/src/section-alert/SectionAlert.stories.tsx
+++ b/packages/react/src/section-alert/SectionAlert.stories.tsx
@@ -1,5 +1,6 @@
-import { StoryObj, Meta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { SectionAlert } from './SectionAlert';
+import { sectionAlertToneMap } from './utils';
 
 const meta: Meta<typeof SectionAlert> = {
 	title: 'Content/SectionAlert',
@@ -7,6 +8,12 @@ const meta: Meta<typeof SectionAlert> = {
 	args: {
 		onDismiss: undefined,
 		onClose: undefined,
+	},
+	argTypes: {
+		tone: {
+			control: { type: 'select' },
+			options: Object.keys(sectionAlertToneMap),
+		},
 	},
 };
 
@@ -17,21 +24,52 @@ type Story = StoryObj<typeof SectionAlert>;
 export const Success: Story = {
 	args: {
 		title: 'Your changes have been saved',
-		tone: 'success',
+		tone: 'successHigh',
+	},
+	argTypes: {
+		tone: {
+			control: { type: 'select' },
+			options: ['successHigh', 'successMedium', 'successLow'],
+		},
 	},
 };
 
 export const Warning: Story = {
 	args: {
 		title: 'A warning message for this section',
-		tone: 'warning',
+		tone: 'warningHigh',
+	},
+	argTypes: {
+		tone: {
+			control: { type: 'select' },
+			options: ['warningHigh', 'warningMedium', 'warningLow'],
+		},
 	},
 };
 
 export const Error: Story = {
 	args: {
 		title: 'There was an error saving your changes',
-		tone: 'error',
+		tone: 'errorHigh',
+	},
+	argTypes: {
+		tone: {
+			control: { type: 'select' },
+			options: ['errorHigh', 'errorMedium', 'errorLow'],
+		},
+	},
+};
+
+export const Info: Story = {
+	args: {
+		title: 'Please read the comments carefully',
+		tone: 'infoHigh',
+	},
+	argTypes: {
+		tone: {
+			control: { type: 'select' },
+			options: ['infoHigh', 'infoMedium', 'infoLow'],
+		},
 	},
 };
 

--- a/packages/react/src/section-alert/SectionAlert.test.tsx
+++ b/packages/react/src/section-alert/SectionAlert.test.tsx
@@ -6,7 +6,7 @@ import type { SectionAlertProps } from './SectionAlert';
 import { SectionAlert } from './SectionAlert';
 import {
 	SectionAlertTone,
-	sectionAlertLegacyTonesMap,
+	sectionAlertLegacyToneMap,
 	sectionAlertToneMap,
 } from './utils';
 
@@ -14,8 +14,8 @@ const sectionAlertTones = Object.keys(
 	sectionAlertToneMap
 ) as Array<SectionAlertTone>;
 
-const sectionAlertLegacyToneMap = Object.keys(
-	sectionAlertLegacyTonesMap
+const sectionAlertLegacyTonesMap = Object.keys(
+	sectionAlertLegacyToneMap
 ) as Array<SectionAlertTone>;
 
 afterEach(cleanup);
@@ -50,7 +50,7 @@ describe('SectionAlert', () => {
 	}
 
 	{
-		sectionAlertLegacyToneMap.forEach((tone) => {
+		sectionAlertLegacyTonesMap.forEach((tone) => {
 			describe(`with legacy ${tone}`, () => {
 				const { container } = renderSectionAlert({ tone });
 				expect(container).toMatchSnapshot();

--- a/packages/react/src/section-alert/SectionAlert.test.tsx
+++ b/packages/react/src/section-alert/SectionAlert.test.tsx
@@ -1,13 +1,21 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { Text } from '../text';
 import { cleanup, render } from '../../../../test-utils';
-import { SectionAlert } from './SectionAlert';
+import { Text } from '../text';
 import type { SectionAlertProps } from './SectionAlert';
-import { sectionAlertIconMap, SectionAlertTone } from './utils';
+import { SectionAlert } from './SectionAlert';
+import {
+	SectionAlertTone,
+	sectionAlertLegacyTonesMap,
+	sectionAlertToneMap,
+} from './utils';
 
 const sectionAlertTones = Object.keys(
-	sectionAlertIconMap
+	sectionAlertToneMap
+) as Array<SectionAlertTone>;
+
+const sectionAlertLegacyToneMap = Object.keys(
+	sectionAlertLegacyTonesMap
 ) as Array<SectionAlertTone>;
 
 afterEach(cleanup);
@@ -36,6 +44,26 @@ describe('SectionAlert', () => {
 							'valid-id': 'off',
 						},
 					});
+				});
+			});
+		});
+	}
+
+	{
+		sectionAlertLegacyToneMap.forEach((tone) => {
+			describe(`with legacy ${tone}`, () => {
+				const { container } = renderSectionAlert({ tone });
+				expect(container).toMatchSnapshot();
+			});
+			it('renders a valid HTML structure', () => {
+				const { container } = renderSectionAlert({ tone });
+				expect(container).toHTMLValidate({
+					extends: ['html-validate:recommended'],
+					rules: {
+						'prefer-native-element': 'off',
+						// react 18s `useId` break this rule
+						'valid-id': 'off',
+					},
 				});
 			});
 		});

--- a/packages/react/src/section-alert/SectionAlert.tsx
+++ b/packages/react/src/section-alert/SectionAlert.tsx
@@ -67,7 +67,7 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 		const { childrenId, titleId, toneId } = useSectionAlertIds(id);
 
 		const updatedTone = getUpdatedLegacyTone(tone);
-		const { background, border, borderColor, Icon, iconColor } =
+		const { background, border, borderColor, Icon, iconColor, iconLabel } =
 			sectionAlertToneMap[updatedTone];
 
 		const closeHandler = getOptionalCloseHandler(onClose, onDismiss);
@@ -80,7 +80,6 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 				background={background}
 				border
 				borderColor={borderColor}
-				borderLeft={true}
 				borderLeftWidth="xxl"
 				borderWidth={border ? 'sm' : 'none'}
 				focusRingFor="all"
@@ -103,7 +102,7 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 					>
 						<Icon color={iconColor} />
 						<span css={visuallyHiddenStyles} id={toneId}>
-							{tone}
+							{iconLabel}
 						</span>
 					</span>
 					<Flex flexDirection="column" gap={0.25}>

--- a/packages/react/src/section-alert/SectionAlert.tsx
+++ b/packages/react/src/section-alert/SectionAlert.tsx
@@ -11,11 +11,7 @@ import { Flex } from '../flex';
 import { getOptionalCloseHandler } from '../getCloseHandler';
 import { Text } from '../text';
 import { SectionAlertDismissButton } from './SectionAlertDismissButton';
-import {
-	getUpdatedLegacyTone,
-	sectionAlertToneMap,
-	type SectionAlertTone,
-} from './utils';
+import { getTone, sectionAlertToneMap, type SectionAlertTone } from './utils';
 
 type DivProps = HTMLAttributes<HTMLDivElement>;
 
@@ -66,9 +62,15 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 		});
 		const { childrenId, titleId, toneId } = useSectionAlertIds(id);
 
-		const updatedTone = getUpdatedLegacyTone(tone);
-		const { background, border, borderColor, Icon, iconColor, iconLabel } =
-			sectionAlertToneMap[updatedTone];
+		const updatedTone = getTone(tone);
+		const {
+			background,
+			borderColor,
+			enclosedBorder,
+			icon: Icon,
+			iconColor,
+			iconLabel,
+		} = sectionAlertToneMap[updatedTone];
 
 		const closeHandler = getOptionalCloseHandler(onClose, onDismiss);
 
@@ -81,7 +83,7 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 				border
 				borderColor={borderColor}
 				borderLeftWidth="xxl"
-				borderWidth={border ? 'sm' : 'none'}
+				borderWidth={enclosedBorder ? 'sm' : 'none'}
 				focusRingFor="all"
 				gap={0.5}
 				highContrastOutline

--- a/packages/react/src/section-alert/SectionAlert.tsx
+++ b/packages/react/src/section-alert/SectionAlert.tsx
@@ -11,7 +11,11 @@ import { Flex } from '../flex';
 import { getOptionalCloseHandler } from '../getCloseHandler';
 import { Text } from '../text';
 import { SectionAlertDismissButton } from './SectionAlertDismissButton';
-import { sectionAlertIconMap, type SectionAlertTone } from './utils';
+import {
+	getUpdatedLegacyTone,
+	sectionAlertToneMap,
+	type SectionAlertTone,
+} from './utils';
 
 type DivProps = HTMLAttributes<HTMLDivElement>;
 
@@ -62,7 +66,10 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 		});
 		const { childrenId, titleId, toneId } = useSectionAlertIds(id);
 
-		const icon = sectionAlertIconMap[tone];
+		const updatedTone = getUpdatedLegacyTone(tone);
+		const { background, border, borderColor, Icon, iconColor } =
+			sectionAlertToneMap[updatedTone];
+
 		const closeHandler = getOptionalCloseHandler(onClose, onDismiss);
 
 		return (
@@ -70,10 +77,12 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 				{...props}
 				alignItems="center"
 				aria-labelledby={`${toneId} ${titleId} ${children ? childrenId : ''}`}
-				background={tone}
-				borderColor={tone}
-				borderLeft
-				borderLeftWidth="xl"
+				background={background}
+				border
+				borderColor={borderColor}
+				borderLeft={true}
+				borderLeftWidth="xxl"
+				borderWidth={border ? 'sm' : 'none'}
 				focusRingFor="all"
 				gap={0.5}
 				highContrastOutline
@@ -92,7 +101,7 @@ export const SectionAlert = forwardRef<HTMLDivElement, SectionAlertProps>(
 							display: 'inline-flex',
 						}}
 					>
-						{icon}
+						<Icon color={iconColor} />
 						<span css={visuallyHiddenStyles} id={toneId}>
 							{tone}
 						</span>

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -1,157 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SectionAlert which is closable renders correctly 1`] = `
-<div>
-  <div
-    aria-labelledby="section-alert-icon-:r8: section-alert-title-:r8: "
-    class="css-1td0tl7-boxStyles"
-    role="region"
-  >
-    <div
-      class="css-1urm0li-boxStyles"
-    >
-      <span
-        class="css-1lb5yh3-SectionAlert"
-      >
-        <svg
-          aria-hidden="true"
-          class="css-vvfklf-Icon"
-          clip-rule="evenodd"
-          fill-rule="evenodd"
-          focusable="false"
-          height="24"
-          role="img"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 23c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Zm5.707-13.293a1 1 0 0 0-1.414-1.414L10 14.586l-2.293-2.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l7-7Z"
-            fill="currentColor"
-            stroke="none"
-          />
-        </svg>
-        <span
-          class="css-1qt259f-SectionAlert"
-          id="section-alert-icon-:r8:"
-        >
-          success
-        </span>
-      </span>
-      <div
-        class="css-1i7cdx8-boxStyles"
-      >
-        <span
-          class="css-1jywj6f-boxStyles"
-          id="section-alert-title-:r8:"
-        >
-          Title of Section alert
-        </span>
-      </div>
-    </div>
-    <button
-      aria-label="Close"
-      class="css-1xr7ch-BaseButton-SectionAlertDismissButton"
-      type="button"
-    >
-      <span>
-        <span
-          class="css-oobk4c-Button"
-        >
-          Close
-        </span>
-        <span
-          aria-live="assertive"
-        />
-      </span>
-      <svg
-        aria-hidden="true"
-        class="css-sbsftc-Button"
-        clip-rule="evenodd"
-        fill-rule="evenodd"
-        focusable="false"
-        height="24"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M18 6 6 18M6 6l12 12"
-        />
-      </svg>
-    </button>
-  </div>
-</div>
-`;
-
-exports[`SectionAlert with a description renders correctly 1`] = `
-<div>
-  <div
-    aria-labelledby="section-alert-icon-:r6: section-alert-title-:r6: section-alert-children-:r6:"
-    class="css-1td0tl7-boxStyles"
-    role="region"
-  >
-    <div
-      class="css-1urm0li-boxStyles"
-    >
-      <span
-        class="css-1lb5yh3-SectionAlert"
-      >
-        <svg
-          aria-hidden="true"
-          class="css-vvfklf-Icon"
-          clip-rule="evenodd"
-          fill-rule="evenodd"
-          focusable="false"
-          height="24"
-          role="img"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 23c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Zm5.707-13.293a1 1 0 0 0-1.414-1.414L10 14.586l-2.293-2.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l7-7Z"
-            fill="currentColor"
-            stroke="none"
-          />
-        </svg>
-        <span
-          class="css-1qt259f-SectionAlert"
-          id="section-alert-icon-:r6:"
-        >
-          success
-        </span>
-      </span>
-      <div
-        class="css-1i7cdx8-boxStyles"
-      >
-        <span
-          class="css-1jywj6f-boxStyles"
-          id="section-alert-title-:r6:"
-        >
-          Title of Section alert
-        </span>
-        <div
-          id="section-alert-children-:r6:"
-        >
-          <p
-            class="css-dbscsh-boxStyles"
-          >
-            Section alert description text
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`SectionAlert with error tone renders correctly 1`] = `
+exports[` 1`] = `
 <div>
   <div
     aria-labelledby="section-alert-icon-:r0: section-alert-title-:r0: "
-    class="css-3ieit4-boxStyles"
+    class="css-17u5dk6-boxStyles"
     role="region"
   >
     <div
@@ -200,11 +53,11 @@ exports[`SectionAlert with error tone renders correctly 1`] = `
 </div>
 `;
 
-exports[`SectionAlert with success tone renders correctly 1`] = `
+exports[` 2`] = `
 <div>
   <div
-    aria-labelledby="section-alert-icon-:r2: section-alert-title-:r2: "
-    class="css-1td0tl7-boxStyles"
+    aria-labelledby="section-alert-icon-:r1: section-alert-title-:r1: "
+    class="css-r2n3u-boxStyles"
     role="region"
   >
     <div
@@ -233,7 +86,7 @@ exports[`SectionAlert with success tone renders correctly 1`] = `
         </svg>
         <span
           class="css-1qt259f-SectionAlert"
-          id="section-alert-icon-:r2:"
+          id="section-alert-icon-:r1:"
         >
           success
         </span>
@@ -243,7 +96,7 @@ exports[`SectionAlert with success tone renders correctly 1`] = `
       >
         <span
           class="css-1jywj6f-boxStyles"
-          id="section-alert-title-:r2:"
+          id="section-alert-title-:r1:"
         >
           Title of Section alert
         </span>
@@ -253,11 +106,11 @@ exports[`SectionAlert with success tone renders correctly 1`] = `
 </div>
 `;
 
-exports[`SectionAlert with warning tone renders correctly 1`] = `
+exports[` 3`] = `
 <div>
   <div
-    aria-labelledby="section-alert-icon-:r4: section-alert-title-:r4: "
-    class="css-9xmjo1-boxStyles"
+    aria-labelledby="section-alert-icon-:r2: section-alert-title-:r2: "
+    class="css-14l7ajk-boxStyles"
     role="region"
   >
     <div
@@ -286,7 +139,7 @@ exports[`SectionAlert with warning tone renders correctly 1`] = `
         </svg>
         <span
           class="css-1qt259f-SectionAlert"
-          id="section-alert-icon-:r4:"
+          id="section-alert-icon-:r2:"
         >
           warning
         </span>
@@ -296,7 +149,780 @@ exports[`SectionAlert with warning tone renders correctly 1`] = `
       >
         <span
           class="css-1jywj6f-boxStyles"
-          id="section-alert-title-:r4:"
+          id="section-alert-title-:r2:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert which is closable renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:r10: section-alert-title-:r10: "
+    class="css-r2n3u-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-vvfklf-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 23c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Zm5.707-13.293a1 1 0 0 0-1.414-1.414L10 14.586l-2.293-2.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l7-7Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r10:"
+        >
+          success
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r10:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+    <button
+      aria-label="Close"
+      class="css-1xr7ch-BaseButton-SectionAlertDismissButton"
+      type="button"
+    >
+      <span>
+        <span
+          class="css-oobk4c-Button"
+        >
+          Close
+        </span>
+        <span
+          aria-live="assertive"
+        />
+      </span>
+      <svg
+        aria-hidden="true"
+        class="css-sbsftc-Button"
+        clip-rule="evenodd"
+        fill-rule="evenodd"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M18 6 6 18M6 6l12 12"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with a description renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:ru: section-alert-title-:ru: section-alert-children-:ru:"
+    class="css-r2n3u-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-vvfklf-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 23c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Zm5.707-13.293a1 1 0 0 0-1.414-1.414L10 14.586l-2.293-2.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l7-7Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:ru:"
+        >
+          success
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:ru:"
+        >
+          Title of Section alert
+        </span>
+        <div
+          id="section-alert-children-:ru:"
+        >
+          <p
+            class="css-dbscsh-boxStyles"
+          >
+            Section alert description text
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with errorHigh tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:r3: section-alert-title-:r3: "
+    class="css-17u5dk6-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-1w78ld0-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8.472 1h7.056c.19 0 .43-.001.665.055.204.05.399.13.578.24.206.126.375.296.509.43l.036.037 4.922 4.922.037.036c.134.134.304.303.43.51.11.178.19.373.24.577.056.236.055.475.055.665v7.056c0 .19.001.43-.055.665-.05.204-.13.399-.24.578a2.799 2.799 0 0 1-.43.509l-.037.036-4.922 4.922-.036.037a2.799 2.799 0 0 1-.51.43c-.178.11-.373.19-.577.24a2.795 2.795 0 0 1-.665.055H8.472c-.19 0-.43.001-.665-.055-.204-.05-.399-.13-.578-.24-.206-.126-.375-.296-.509-.43l-.036-.037-4.922-4.922-.036-.036c-.135-.134-.305-.303-.431-.51a1.999 1.999 0 0 1-.24-.577A2.795 2.795 0 0 1 1 15.528V8.472c0-.19-.001-.43.055-.665a2 2 0 0 1 .24-.578c.126-.206.296-.375.43-.509l.037-.036 4.922-4.922.036-.036c.134-.135.303-.305.51-.431a2 2 0 0 1 .577-.24C8.043 1 8.282 1 8.472 1Zm.235 6.293a1 1 0 1 0-1.414 1.414L10.586 12l-3.293 3.293a1 1 0 0 0 1.414 1.414L12 13.414l3.293 3.293a1 1 0 0 0 1.414-1.414L13.414 12l3.293-3.293a1 1 0 0 0-1.414-1.414L12 10.586 8.707 7.293Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r3:"
+        >
+          errorHigh
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r3:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with errorLow tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:r5: section-alert-title-:r5: "
+    class="css-1hkg0u7-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-16t9tz1-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.753 1.797a1 1 0 0 0-.712-.297H8.05a1 1 0 0 0-.706.291l-5.55 5.525a1 1 0 0 0-.294.709v7.86a1 1 0 0 0 .289.703l5.554 5.615a1 1 0 0 0 .711.297h7.896a1 1 0 0 0 .706-.291l5.55-5.525a1 1 0 0 0 .294-.709V8.02a1 1 0 0 0-.289-.703l-5.458-5.52ZM8 16l8-8M16 16 8 8"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r5:"
+        >
+          errorLow
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r5:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with errorMedium tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:r7: section-alert-title-:r7: "
+    class="css-1nd9vbs-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-1w78ld0-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.753 1.797a1 1 0 0 0-.712-.297H8.05a1 1 0 0 0-.706.291l-5.55 5.525a1 1 0 0 0-.294.709v7.86a1 1 0 0 0 .289.703l5.554 5.615a1 1 0 0 0 .711.297h7.896a1 1 0 0 0 .706-.291l5.55-5.525a1 1 0 0 0 .294-.709V8.02a1 1 0 0 0-.289-.703l-5.458-5.52ZM8 16l8-8M16 16 8 8"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r7:"
+        >
+          errorMedium
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r7:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with infoHigh tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:r9: section-alert-title-:r9: "
+    class="css-s1p38e-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-1fy6eq9-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1Zm0 17a1 1 0 0 1-1-1v-6a1 1 0 1 1 2 0v6a1 1 0 0 1-1 1Zm0-10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:r9:"
+        >
+          infoHigh
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:r9:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with infoLow tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rb: section-alert-title-:rb: "
+    class="css-1hkg0u7-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-16t9tz1-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Zm-10 5v-6m0-4h.01"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rb:"
+        >
+          infoLow
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rb:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with infoMedium tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rd: section-alert-title-:rd: "
+    class="css-1ib5mre-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-1fy6eq9-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Zm-10 5v-6m0-4h.01"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rd:"
+        >
+          infoMedium
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rd:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with successHigh tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rf: section-alert-title-:rf: "
+    class="css-r2n3u-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-vvfklf-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 23c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Zm5.707-13.293a1 1 0 0 0-1.414-1.414L10 14.586l-2.293-2.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l7-7Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rf:"
+        >
+          successHigh
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rf:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with successLow tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rh: section-alert-title-:rh: "
+    class="css-1hkg0u7-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-16t9tz1-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Z"
+          />
+          <path
+            d="m7 13 3 3 7-7"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rh:"
+        >
+          successLow
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rh:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with successMedium tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rj: section-alert-title-:rj: "
+    class="css-1df7i9s-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-vvfklf-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Z"
+          />
+          <path
+            d="m7 13 3 3 7-7"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rj:"
+        >
+          successMedium
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rj:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with warningHigh tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rl: section-alert-title-:rl: "
+    class="css-14l7ajk-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-15hefj6-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m23.1 20.1-9.3-18C13.4 1.4 12.7 1 12 1s-1.4.4-1.8 1.1l-9.3 18c-.3.6-.3 1.4.1 2 .4.6 1 1 1.7 1h18.7c.7 0 1.31-.33 1.7-1 .36-.6.3-1.4 0-2ZM12 19c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1Zm1-5c0 .6-.4 1-1 1s-1-.4-1-1V9c0-.6.4-1 1-1s1 .4 1 1v5Z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rl:"
+        >
+          warningHigh
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rl:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with warningLow tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rn: section-alert-title-:rn: "
+    class="css-1hkg0u7-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-16t9tz1-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 7v6m0 4h-.01M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Z"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rn:"
+        >
+          warningLow
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rn:"
+        >
+          Title of Section alert
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SectionAlert with warningMedium tone renders correctly 1`] = `
+<div>
+  <div
+    aria-labelledby="section-alert-icon-:rp: section-alert-title-:rp: "
+    class="css-kdahuh-boxStyles"
+    role="region"
+  >
+    <div
+      class="css-1urm0li-boxStyles"
+    >
+      <span
+        class="css-1lb5yh3-SectionAlert"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-15hefj6-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9"
+          />
+        </svg>
+        <span
+          class="css-1qt259f-SectionAlert"
+          id="section-alert-icon-:rp:"
+        >
+          warningMedium
+        </span>
+      </span>
+      <div
+        class="css-1i7cdx8-boxStyles"
+      >
+        <span
+          class="css-1jywj6f-boxStyles"
+          id="section-alert-title-:rp:"
         >
           Title of Section alert
         </span>

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`SectionAlert with errorHigh tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:r3:"
         >
-          errorHigh
+          error
         </span>
       </span>
       <div
@@ -385,14 +385,14 @@ exports[`SectionAlert with errorLow tone renders correctly 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M16.753 1.797a1 1 0 0 0-.712-.297H8.05a1 1 0 0 0-.706.291l-5.55 5.525a1 1 0 0 0-.294.709v7.86a1 1 0 0 0 .289.703l5.554 5.615a1 1 0 0 0 .711.297h7.896a1 1 0 0 0 .706-.291l5.55-5.525a1 1 0 0 0 .294-.709V8.02a1 1 0 0 0-.289-.703l-5.458-5.52ZM8 16l8-8M16 16 8 8"
+            d="m16 8-4 4m0 0-4 4m4-4L8 8m4 4 4 4m6-4c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Z"
           />
         </svg>
         <span
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:r5:"
         >
-          errorLow
+          error
         </span>
       </span>
       <div
@@ -443,7 +443,7 @@ exports[`SectionAlert with errorMedium tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:r7:"
         >
-          errorMedium
+          error
         </span>
       </span>
       <div
@@ -496,7 +496,7 @@ exports[`SectionAlert with infoHigh tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:r9:"
         >
-          infoHigh
+          information
         </span>
       </span>
       <div
@@ -547,7 +547,7 @@ exports[`SectionAlert with infoLow tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rb:"
         >
-          infoLow
+          information
         </span>
       </span>
       <div
@@ -598,7 +598,7 @@ exports[`SectionAlert with infoMedium tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rd:"
         >
-          infoMedium
+          information
         </span>
       </span>
       <div
@@ -651,7 +651,7 @@ exports[`SectionAlert with successHigh tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rf:"
         >
-          successHigh
+          success
         </span>
       </span>
       <div
@@ -705,7 +705,7 @@ exports[`SectionAlert with successLow tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rh:"
         >
-          successLow
+          success
         </span>
       </span>
       <div
@@ -759,7 +759,7 @@ exports[`SectionAlert with successMedium tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rj:"
         >
-          successMedium
+          success
         </span>
       </span>
       <div
@@ -812,7 +812,7 @@ exports[`SectionAlert with warningHigh tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rl:"
         >
-          warningHigh
+          warning
         </span>
       </span>
       <div
@@ -863,7 +863,7 @@ exports[`SectionAlert with warningLow tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rn:"
         >
-          warningLow
+          warning
         </span>
       </span>
       <div
@@ -914,7 +914,7 @@ exports[`SectionAlert with warningMedium tone renders correctly 1`] = `
           class="css-1qt259f-SectionAlert"
           id="section-alert-icon-:rp:"
         >
-          warningMedium
+          warning
         </span>
       </span>
       <div

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -907,7 +907,7 @@ exports[`SectionAlert with warningMedium tone renders correctly 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9"
+            d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5ZM12 14V9m0 9h0"
           />
         </svg>
         <span

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`SectionAlert with errorLow tone renders correctly 1`] = `
 <div>
   <div
     aria-labelledby="section-alert-icon-:r5: section-alert-title-:r5: "
-    class="css-1hkg0u7-boxStyles"
+    class="css-orf1v6-boxStyles"
     role="region"
   >
     <div
@@ -518,7 +518,7 @@ exports[`SectionAlert with infoLow tone renders correctly 1`] = `
 <div>
   <div
     aria-labelledby="section-alert-icon-:rb: section-alert-title-:rb: "
-    class="css-1hkg0u7-boxStyles"
+    class="css-orf1v6-boxStyles"
     role="region"
   >
     <div
@@ -673,7 +673,7 @@ exports[`SectionAlert with successLow tone renders correctly 1`] = `
 <div>
   <div
     aria-labelledby="section-alert-icon-:rh: section-alert-title-:rh: "
-    class="css-1hkg0u7-boxStyles"
+    class="css-orf1v6-boxStyles"
     role="region"
   >
     <div
@@ -834,7 +834,7 @@ exports[`SectionAlert with warningLow tone renders correctly 1`] = `
 <div>
   <div
     aria-labelledby="section-alert-icon-:rn: section-alert-title-:rn: "
-    class="css-1hkg0u7-boxStyles"
+    class="css-orf1v6-boxStyles"
     role="region"
   >
     <div

--- a/packages/react/src/section-alert/docs/content.mdx
+++ b/packages/react/src/section-alert/docs/content.mdx
@@ -38,3 +38,52 @@ Refer to the glossary for more information.
 ## Voice and tone
 
 Go to the [TFTM Voice and tone guide](/content/voice-and-tone) for guidance.
+
+## Alert examples
+
+Some common examples of labels for each tone.
+
+### High emphasis
+
+```jsx live
+<Stack gap={1}>
+	<SectionAlert title="Your changes have been saved" tone="successHigh" />
+	<SectionAlert
+		title="There was an error saving your changes"
+		tone="errorHigh"
+	/>
+	<SectionAlert title="A warning message for this section" tone="warningHigh" />
+	<SectionAlert title="Please read the comments carefully" tone="infoHigh" />
+</Stack>
+```
+
+### Medium emphasis
+
+```jsx live
+<Stack gap={1}>
+	<SectionAlert title="Your changes have been saved" tone="successMedium" />
+	<SectionAlert
+		title="There was an error saving your changes"
+		tone="errorMedium"
+	/>
+	<SectionAlert
+		title="A warning message for this section"
+		tone="warningMedium"
+	/>
+	<SectionAlert title="Please read the comments carefully" tone="infoMedium" />
+</Stack>
+```
+
+### Low emphasis
+
+```jsx live
+<Stack gap={1}>
+	<SectionAlert title="Your changes have been saved" tone="successLow" />
+	<SectionAlert
+		title="There was an error saving your changes"
+		tone="errorLow"
+	/>
+	<SectionAlert title="A warning message for this section" tone="warningLow" />
+	<SectionAlert title="Please read the comments carefully" tone="infoLow" />
+</Stack>
+```

--- a/packages/react/src/section-alert/docs/overview.mdx
+++ b/packages/react/src/section-alert/docs/overview.mdx
@@ -39,14 +39,18 @@ Section alerts appear inside of the main content area of the page and are used t
 
 Section alert can be used to communicate different types of messages. Choosing a tone for a Section alert allows the user to understand the importance and severity of the message at a glance.
 
-The three supported tones are `success`, `error` and `warning`.
+The four tones are `success`, `error`, `warning` and `info` that each have three supported levels: high, medium and low variants and are used by applying a suffix eg. `successHigh`, `successMedium`, `successLow`.
 
 ### Success
 
 The success section alert (green) is used for notifying the user that a task is fully completed.
 
 ```jsx live
-<SectionAlert title="Your changes have been saved" tone="success" />
+<Stack gap={1}>
+	<SectionAlert title="Your changes have been saved" tone="successHigh" />
+	<SectionAlert title="Your changes have been saved" tone="successMedium" />
+	<SectionAlert title="Your changes have been saved" tone="successLow" />
+</Stack>
 ```
 
 ### Error
@@ -54,7 +58,20 @@ The success section alert (green) is used for notifying the user that a task is 
 The error section alert (red) should be used when something destructive or critical has happened.
 
 ```jsx live
-<SectionAlert title="There was an error saving your changes" tone="error" />
+<Stack gap={1}>
+	<SectionAlert
+		title="There was an error saving your changes"
+		tone="errorHigh"
+	/>
+	<SectionAlert
+		title="There was an error saving your changes"
+		tone="errorMedium"
+	/>
+	<SectionAlert
+		title="There was an error saving your changes"
+		tone="errorLow"
+	/>
+</Stack>
 ```
 
 ### Warning
@@ -62,7 +79,26 @@ The error section alert (red) should be used when something destructive or criti
 Use warning section alerts (orange) to tell the user something urgent. Only use an alert if the information will help the user avoid a problem.
 
 ```jsx live
-<SectionAlert title="A warning message for this section" tone="warning" />
+<Stack gap={1}>
+	<SectionAlert title="A warning message for this section" tone="warningHigh" />
+	<SectionAlert
+		title="A warning message for this section"
+		tone="warningMedium"
+	/>
+	<SectionAlert title="A warning message for this section" tone="warningLow" />
+</Stack>
+```
+
+### Info
+
+The information section alert (blue) can be used to alert the user on neutral informative messages.
+
+```jsx live
+<Stack gap={1}>
+	<SectionAlert title="Please read the comments carefully" tone="infoHigh" />
+	<SectionAlert title="Please read the comments carefully" tone="infoMedium" />
+	<SectionAlert title="Please read the comments carefully" tone="infoLow" />
+</Stack>
 ```
 
 ## Dismissable

--- a/packages/react/src/section-alert/docs/overview.mdx
+++ b/packages/react/src/section-alert/docs/overview.mdx
@@ -11,7 +11,7 @@ relatedPatterns: ['messaging']
 Section alerts appear inside of the main content area of the page and are used to alert users to a particular section of the screen. They should not be confused with Callouts.
 
 ```jsx live
-<SectionAlert title="Your changes have been saved" tone="success" />
+<SectionAlert title="Your changes have been saved" tone="successHigh" />
 ```
 
 <DoHeading />
@@ -43,7 +43,7 @@ The four tones are `success`, `error`, `warning` and `info`. Each tone has three
 
 ### Success
 
-The success section alert (green) is used for notifying the user that a task is fully completed.
+The success section alert is used for notifying the user that a task is fully completed.
 
 ```jsx live
 <Stack gap={1}>
@@ -55,7 +55,7 @@ The success section alert (green) is used for notifying the user that a task is 
 
 ### Error
 
-The error section alert (red) should be used when something destructive or critical has happened.
+The error section alert should be used when something destructive or critical has happened.
 
 ```jsx live
 <Stack gap={1}>
@@ -76,7 +76,7 @@ The error section alert (red) should be used when something destructive or criti
 
 ### Warning
 
-Use warning section alerts (orange) to tell the user something urgent. Only use an alert if the information will help the user avoid a problem.
+Use warning section alerts to tell the user something urgent. Only use an alert if the information will help the user avoid a problem.
 
 ```jsx live
 <Stack gap={1}>
@@ -91,7 +91,7 @@ Use warning section alerts (orange) to tell the user something urgent. Only use 
 
 ### Info
 
-The information section alert (blue) can be used to alert the user on neutral messages.
+The information section alert can be used to alert the user on neutral messages.
 
 ```jsx live
 <Stack gap={1}>
@@ -112,9 +112,9 @@ When a user dismisses an alert, it’s important to manage their focus appropria
 
 ```jsx live
 <SectionAlert
-	title="Section alert title"
-	tone="success"
 	onClose={console.log}
+	title="Section alert title"
+	tone="successHigh"
 />
 ```
 
@@ -127,16 +127,16 @@ The icon and title are mandatory and achieve a compact alert, but we encourage t
 ```jsx live
 <Stack gap={1}>
 	<SectionAlert
-		title="Section alert title"
-		tone="success"
 		onClose={console.log}
+		title="Section alert title"
+		tone="successHigh"
 	/>
 
-	<SectionAlert title="Section alert title" tone="success">
+	<SectionAlert title="Section alert title" tone="successHigh">
 		<Text as="p">Description</Text>
 	</SectionAlert>
 
-	<SectionAlert title="Section alert title" tone="warning">
+	<SectionAlert title="Section alert title" tone="warningHigh">
 		<Stack gap={0.5} alignItems="flex-start">
 			<Text as="p">Description</Text>
 			<ButtonGroup>
@@ -176,7 +176,11 @@ Press the "Toggle alert" button below to mount/unmount the alert. Notice that ea
 			</Button>
 
 			{showAlert && (
-				<SectionAlert focusOnMount title="Something went wrong" tone="error">
+				<SectionAlert
+					focusOnMount
+					title="Something went wrong"
+					tone="errorHigh"
+				>
 					<Text as="p">There was an error submitting the application.</Text>
 				</SectionAlert>
 			)}
@@ -224,7 +228,7 @@ Once the alert is displayed, try updating the content by pressing the "Update al
 				<SectionAlert
 					focusOnUpdate={errors}
 					title="Something went wrong"
-					tone="error"
+					tone="errorHigh"
 				>
 					<UnorderedList>
 						{errors.map((text) => (
@@ -258,7 +262,7 @@ Press the "Focus the alert" button below to set focus on the alert. To achieve t
 				ref={alertRef}
 				tabIndex={-1}
 				title="Submission successful"
-				tone="success"
+				tone="successHigh"
 			>
 				<Text as="p">Your application has been received.</Text>
 			</SectionAlert>

--- a/packages/react/src/section-alert/docs/overview.mdx
+++ b/packages/react/src/section-alert/docs/overview.mdx
@@ -39,7 +39,7 @@ Section alerts appear inside of the main content area of the page and are used t
 
 Section alert can be used to communicate different types of messages. Choosing a tone for a Section alert allows the user to understand the importance and severity of the message at a glance.
 
-The four tones are `success`, `error`, `warning` and `info` that each have three supported levels: high, medium and low variants and are used by applying a suffix eg. `successHigh`, `successMedium`, `successLow`.
+The four tones are `success`, `error`, `warning` and `info`. Each tone has three supported levels: high, medium and low variants and can be applied with a suffix eg. `successHigh`, `successMedium` and `successLow`.
 
 ### Success
 
@@ -91,7 +91,7 @@ Use warning section alerts (orange) to tell the user something urgent. Only use 
 
 ### Info
 
-The information section alert (blue) can be used to alert the user on neutral informative messages.
+The information section alert (blue) can be used to alert the user on neutral messages.
 
 ```jsx live
 <Stack gap={1}>

--- a/packages/react/src/section-alert/utils.tsx
+++ b/packages/react/src/section-alert/utils.tsx
@@ -21,7 +21,7 @@ export const sectionAlertToneMap = {
 	errorLow: {
 		background: 'body',
 		border: true,
-		borderColor: 'muted',
+		borderColor: 'border',
 		Icon: AlertIcon,
 		iconColor: 'muted',
 	},
@@ -42,7 +42,7 @@ export const sectionAlertToneMap = {
 	infoLow: {
 		background: 'body',
 		border: true,
-		borderColor: 'muted',
+		borderColor: 'border',
 		Icon: InfoIcon,
 		iconColor: 'muted',
 	},
@@ -63,7 +63,7 @@ export const sectionAlertToneMap = {
 	successLow: {
 		background: 'body',
 		border: true,
-		borderColor: 'muted',
+		borderColor: 'border',
 		Icon: SuccessIcon,
 		iconColor: 'muted',
 	},
@@ -84,7 +84,7 @@ export const sectionAlertToneMap = {
 	warningLow: {
 		background: 'body',
 		border: true,
-		borderColor: 'muted',
+		borderColor: 'border',
 		Icon: WarningCircleIcon,
 		iconColor: 'muted',
 	},

--- a/packages/react/src/section-alert/utils.tsx
+++ b/packages/react/src/section-alert/utils.tsx
@@ -1,13 +1,121 @@
 import {
 	AlertFilledIcon,
+	AlertIcon,
+	InfoFilledIcon,
+	InfoIcon,
 	SuccessFilledIcon,
+	SuccessIcon,
+	WarningCircleIcon,
 	WarningFilledIcon,
+	WarningIcon,
 } from '@ag.ds-next/react/icon';
 
-export const sectionAlertIconMap = {
-	error: <AlertFilledIcon color="error" />,
-	success: <SuccessFilledIcon color="success" />,
-	warning: <WarningFilledIcon color="warning" />,
-};
+export const sectionAlertToneMap = {
+	errorHigh: {
+		background: 'error',
+		border: false,
+		borderColor: 'error',
+		Icon: AlertFilledIcon,
+		iconColor: 'error',
+	},
+	errorLow: {
+		background: 'body',
+		border: true,
+		borderColor: 'muted',
+		Icon: AlertIcon,
+		iconColor: 'muted',
+	},
+	errorMedium: {
+		background: 'body',
+		border: true,
+		borderColor: 'error',
+		Icon: AlertIcon,
+		iconColor: 'error',
+	},
+	infoHigh: {
+		background: 'info',
+		border: false,
+		borderColor: 'info',
+		Icon: InfoFilledIcon,
+		iconColor: 'info',
+	},
+	infoLow: {
+		background: 'body',
+		border: true,
+		borderColor: 'muted',
+		Icon: InfoIcon,
+		iconColor: 'muted',
+	},
+	infoMedium: {
+		background: 'body',
+		border: true,
+		borderColor: 'info',
+		Icon: InfoIcon,
+		iconColor: 'info',
+	},
+	successHigh: {
+		background: 'success',
+		border: false,
+		borderColor: 'success',
+		Icon: SuccessFilledIcon,
+		iconColor: 'success',
+	},
+	successLow: {
+		background: 'body',
+		border: true,
+		borderColor: 'muted',
+		Icon: SuccessIcon,
+		iconColor: 'muted',
+	},
+	successMedium: {
+		background: 'body',
+		border: true,
+		borderColor: 'success',
+		Icon: SuccessIcon,
+		iconColor: 'success',
+	},
+	warningHigh: {
+		background: 'warning',
+		border: false,
+		borderColor: 'warning',
+		Icon: WarningFilledIcon,
+		iconColor: 'warning',
+	},
+	warningLow: {
+		background: 'body',
+		border: true,
+		borderColor: 'muted',
+		Icon: WarningCircleIcon,
+		iconColor: 'muted',
+	},
+	warningMedium: {
+		background: 'body',
+		border: true,
+		borderColor: 'warning',
+		Icon: WarningIcon,
+		iconColor: 'warning',
+	},
+} as const;
 
-export type SectionAlertTone = keyof typeof sectionAlertIconMap;
+export type SectionAlertVariantTone = keyof typeof sectionAlertToneMap;
+
+export const sectionAlertLegacyTonesMap = {
+	error: 'errorHigh',
+	success: 'successHigh',
+	warning: 'warningHigh',
+} as const;
+
+type SectionAlertLegacyTone = keyof typeof sectionAlertLegacyTonesMap;
+
+export type SectionAlertTone = SectionAlertVariantTone | SectionAlertLegacyTone;
+
+// Legacy tones will default to high variants
+export function getUpdatedLegacyTone(
+	tone: SectionAlertTone
+): SectionAlertVariantTone {
+	if (tone in sectionAlertLegacyTonesMap) {
+		return sectionAlertLegacyTonesMap[tone as SectionAlertLegacyTone];
+	}
+
+	return tone as SectionAlertVariantTone;
+}

--- a/packages/react/src/section-alert/utils.tsx
+++ b/packages/react/src/section-alert/utils.tsx
@@ -14,121 +14,119 @@ import {
 export const sectionAlertToneMap = {
 	errorHigh: {
 		background: 'error',
-		border: false,
 		borderColor: 'error',
-		Icon: AlertFilledIcon,
+		enclosedBorder: false,
+		icon: AlertFilledIcon,
 		iconColor: 'error',
 		iconLabel: 'error',
 	},
 	errorLow: {
 		background: 'body',
-		border: true,
 		borderColor: 'border',
-		Icon: AlertCircleIcon,
+		enclosedBorder: true,
+		icon: AlertCircleIcon,
 		iconColor: 'muted',
 		iconLabel: 'error',
 	},
 	errorMedium: {
 		background: 'body',
-		border: true,
 		borderColor: 'error',
-		Icon: AlertIcon,
+		enclosedBorder: true,
+		icon: AlertIcon,
 		iconColor: 'error',
 		iconLabel: 'error',
 	},
 	infoHigh: {
 		background: 'info',
-		border: false,
 		borderColor: 'info',
-		Icon: InfoFilledIcon,
+		enclosedBorder: false,
+		icon: InfoFilledIcon,
 		iconColor: 'info',
 		iconLabel: 'information',
 	},
 	infoLow: {
 		background: 'body',
-		border: true,
 		borderColor: 'border',
-		Icon: InfoIcon,
+		enclosedBorder: true,
+		icon: InfoIcon,
 		iconColor: 'muted',
 		iconLabel: 'information',
 	},
 	infoMedium: {
 		background: 'body',
-		border: true,
 		borderColor: 'info',
-		Icon: InfoIcon,
+		enclosedBorder: true,
+		icon: InfoIcon,
 		iconColor: 'info',
 		iconLabel: 'information',
 	},
 	successHigh: {
 		background: 'success',
-		border: false,
 		borderColor: 'success',
-		Icon: SuccessFilledIcon,
+		enclosedBorder: false,
+		icon: SuccessFilledIcon,
 		iconColor: 'success',
 		iconLabel: 'success',
 	},
 	successLow: {
 		background: 'body',
-		border: true,
 		borderColor: 'border',
-		Icon: SuccessIcon,
+		enclosedBorder: true,
+		icon: SuccessIcon,
 		iconColor: 'muted',
 		iconLabel: 'success',
 	},
 	successMedium: {
 		background: 'body',
-		border: true,
 		borderColor: 'success',
-		Icon: SuccessIcon,
+		enclosedBorder: true,
+		icon: SuccessIcon,
 		iconColor: 'success',
 		iconLabel: 'success',
 	},
 	warningHigh: {
 		background: 'warning',
-		border: false,
 		borderColor: 'warning',
-		Icon: WarningFilledIcon,
+		enclosedBorder: false,
+		icon: WarningFilledIcon,
 		iconColor: 'warning',
 		iconLabel: 'warning',
 	},
 	warningLow: {
 		background: 'body',
-		border: true,
 		borderColor: 'border',
-		Icon: WarningCircleIcon,
+		enclosedBorder: true,
+		icon: WarningCircleIcon,
 		iconColor: 'muted',
 		iconLabel: 'warning',
 	},
 	warningMedium: {
 		background: 'body',
-		border: true,
 		borderColor: 'warning',
-		Icon: WarningIcon,
+		enclosedBorder: true,
+		icon: WarningIcon,
 		iconColor: 'warning',
 		iconLabel: 'warning',
 	},
 } as const;
 
-export type SectionAlertVariantTone = keyof typeof sectionAlertToneMap;
+export type SectionAlertTones = keyof typeof sectionAlertToneMap;
 
-export const sectionAlertLegacyTonesMap = {
+export const sectionAlertLegacyToneMap = {
 	error: 'errorHigh',
 	success: 'successHigh',
 	warning: 'warningHigh',
 } as const;
 
-type SectionAlertLegacyTone = keyof typeof sectionAlertLegacyTonesMap;
+type SectionAlertLegacyTone = keyof typeof sectionAlertLegacyToneMap;
 
-export type SectionAlertTone = SectionAlertVariantTone | SectionAlertLegacyTone;
+export type SectionAlertTone = SectionAlertTones | SectionAlertLegacyTone;
 
 // Legacy tones will default to its high variant
-export function getUpdatedLegacyTone(
-	tone: SectionAlertTone
-): SectionAlertVariantTone {
-	if (tone in sectionAlertLegacyTonesMap) {
-		return sectionAlertLegacyTonesMap[tone as SectionAlertLegacyTone];
+export function getTone(tone: SectionAlertTone): SectionAlertTones {
+	if (tone in sectionAlertLegacyToneMap) {
+		return sectionAlertLegacyToneMap[tone as SectionAlertLegacyTone];
 	}
 
-	return tone as SectionAlertVariantTone;
+	return tone as SectionAlertTones;
 }

--- a/packages/react/src/section-alert/utils.tsx
+++ b/packages/react/src/section-alert/utils.tsx
@@ -1,4 +1,5 @@
 import {
+	AlertCircleIcon,
 	AlertFilledIcon,
 	AlertIcon,
 	InfoFilledIcon,
@@ -17,13 +18,15 @@ export const sectionAlertToneMap = {
 		borderColor: 'error',
 		Icon: AlertFilledIcon,
 		iconColor: 'error',
+		iconLabel: 'error',
 	},
 	errorLow: {
 		background: 'body',
 		border: true,
 		borderColor: 'border',
-		Icon: AlertIcon,
+		Icon: AlertCircleIcon,
 		iconColor: 'muted',
+		iconLabel: 'error',
 	},
 	errorMedium: {
 		background: 'body',
@@ -31,6 +34,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'error',
 		Icon: AlertIcon,
 		iconColor: 'error',
+		iconLabel: 'error',
 	},
 	infoHigh: {
 		background: 'info',
@@ -38,6 +42,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'info',
 		Icon: InfoFilledIcon,
 		iconColor: 'info',
+		iconLabel: 'information',
 	},
 	infoLow: {
 		background: 'body',
@@ -45,6 +50,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'border',
 		Icon: InfoIcon,
 		iconColor: 'muted',
+		iconLabel: 'information',
 	},
 	infoMedium: {
 		background: 'body',
@@ -52,6 +58,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'info',
 		Icon: InfoIcon,
 		iconColor: 'info',
+		iconLabel: 'information',
 	},
 	successHigh: {
 		background: 'success',
@@ -59,6 +66,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'success',
 		Icon: SuccessFilledIcon,
 		iconColor: 'success',
+		iconLabel: 'success',
 	},
 	successLow: {
 		background: 'body',
@@ -66,6 +74,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'border',
 		Icon: SuccessIcon,
 		iconColor: 'muted',
+		iconLabel: 'success',
 	},
 	successMedium: {
 		background: 'body',
@@ -73,6 +82,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'success',
 		Icon: SuccessIcon,
 		iconColor: 'success',
+		iconLabel: 'success',
 	},
 	warningHigh: {
 		background: 'warning',
@@ -80,6 +90,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'warning',
 		Icon: WarningFilledIcon,
 		iconColor: 'warning',
+		iconLabel: 'warning',
 	},
 	warningLow: {
 		background: 'body',
@@ -87,6 +98,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'border',
 		Icon: WarningCircleIcon,
 		iconColor: 'muted',
+		iconLabel: 'warning',
 	},
 	warningMedium: {
 		background: 'body',
@@ -94,6 +106,7 @@ export const sectionAlertToneMap = {
 		borderColor: 'warning',
 		Icon: WarningIcon,
 		iconColor: 'warning',
+		iconLabel: 'warning',
 	},
 } as const;
 
@@ -109,7 +122,7 @@ type SectionAlertLegacyTone = keyof typeof sectionAlertLegacyTonesMap;
 
 export type SectionAlertTone = SectionAlertVariantTone | SectionAlertLegacyTone;
 
-// Legacy tones will default to high variants
+// Legacy tones will default to its high variant
 export function getUpdatedLegacyTone(
 	tone: SectionAlertTone
 ): SectionAlertVariantTone {

--- a/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`StatusBadge Legacy weight: regular tone: warning renders correctly 1`] 
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9"
+        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5ZM12 14V9m0 9h0"
       />
     </svg>
     <span
@@ -276,7 +276,7 @@ exports[`StatusBadge Legacy weight: subtle tone: warning renders correctly 1`] =
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9"
+        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5ZM12 14V9m0 9h0"
       />
     </svg>
     <span
@@ -823,7 +823,7 @@ exports[`StatusBadge appearance: regular tone: warningMedium renders correctly 1
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9"
+        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5ZM12 14V9m0 9h0"
       />
     </svg>
     <span
@@ -1370,7 +1370,7 @@ exports[`StatusBadge appearance: subtle tone: warningMedium renders correctly 1`
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5Zm9-8V9m0 9"
+        d="M3 22h18c.7 0 1.2-.8.9-1.5l-9-17.8c-.4-.7-1.4-.7-1.8 0l-9 17.8c-.3.7.2 1.5.9 1.5ZM12 14V9m0 9h0"
       />
     </svg>
     <span


### PR DESCRIPTION
Added the `info` level tone to the section-alert components. This build also add level variants (`high`, `medium` and `low`) for each tone.

Refactor the component to differentiate the tone selection with the various options of levels from icon, border, border width, icon, icon fill colour and background. The new levels have compatibility with legacy tones `success`, `warning` and `error` which will fallback to `successHigh`, `warningHigh` and `errorHigh`.

This PR also contains two fixes:
- docs: components table-of-contents has `relatedComponents` and `relatedPatterns` in wrong order, [live example](https://design-system.agriculture.gov.au/components/section-alert)
- icon: `WarningIcon` reverted to pre [live icon](https://design-system.agriculture.gov.au/foundations/icons) and [PR update](https://design-system.agriculture.gov.au/pr-preview/pr-1993/foundations/icons)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1993)

[Section alert documentation](https://design-system.agriculture.gov.au/pr-preview/pr-1993/components/section-alert)

[Playroom preview](https://design-system.agriculture.gov.au/pr-preview/pr-1993/playroom/#?code=N4Igxg9gJgpiBcIA8BlALgQzAawAQHMMAHAXmAEYBfAPgB0A7WtVGMNASwnoEEAbGAE5pcHNPxK0QATQgBXAbjAALDPXwwAzrhUA3GLgBGMGPVwaMeqJJFcYEkBtlgwmjQAl2%2BJdYD0dRsworBxcfILCouKSMvKKKmqa2hb6RiZmyVYgNvR2ko7OrgCyMFDssgC2vv5MLGycPPxCIuxiudJyCsqq6lq6Kcam5pbWaLb2%2BS4aGgAyEADuVQxMNUF1oY1oS5tokW0AKkqC%2BnMYWqq4ggIQCkPsargAnh1x3ZqSW0yjOfaX1x5e7wCfi2tRCDXCHx2LSiIAOR1wJzOpl%2BNwsd3wj2eXQSGkByx2Y0kKOKpQqeLQwICoPqYSEkN29jhAmOp1w5xR6R06MxsWxPXJn0JIBRswWIC2lPx1PW4WarXs3ARGAE9G55VcGHUuAAZtcREp2FoNMF6iMhScVej-t4spLAiaZXSAp9oW1FRbVfd1VNNfpdQo0AajQ7GOLnQTvpIPeiSWVKmGmHbpeCmgzJO7lZ6Md7zFr-frDWYQ2bIyBo2pRYtw8naRFXfYAAr8U76ZkYKD6-SQcrq%2BhoLRgZUwbWyXi8B4ltp3XXWqsrEO1uUwpswFu4NsdwNdiA9kz9xRDkdjidZL5T%2Bi62Nk23Ve1rFN1%2BWSFdrjedxQ73v7wfMo-jyf2NOECVjeDBID46BYNg1AgAANGW7BQIGGgIAA2gAzAATAADLBACceGYQAupQQA)

![Screenshot 2025-03-28 at 1 32 59 pm](https://github.com/user-attachments/assets/47efb212-8f1d-4cff-8831-041411a6c302)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets