### PR TITLE
file-upload: Update the download type to also support strings

### DIFF
--- a/.changeset/new-papayas-help.md
+++ b/.changeset/new-papayas-help.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+file-upload: Update the `download` type for existing and uploaded files to also support strings.

--- a/packages/react/src/file-upload/test-utils.ts
+++ b/packages/react/src/file-upload/test-utils.ts
@@ -1,7 +1,7 @@
 import { FileStatus, FileWithStatus } from './utils';
 
 export function createExampleFile(args?: {
-	download?: boolean;
+	download?: boolean | string;
 	href?: string;
 	lastModified?: number;
 	name?: string;
@@ -38,7 +38,7 @@ export function createExampleFile(args?: {
 }
 
 export function createExampleImageFile(args?: {
-	download?: boolean;
+	download?: boolean | string;
 	href?: string;
 	name?: string;
 	status?: FileStatus;

--- a/packages/react/src/file-upload/utils.test.tsx
+++ b/packages/react/src/file-upload/utils.test.tsx
@@ -42,7 +42,33 @@ describe('createExampleFile', () => {
 			})
 		);
 	});
-	test('custom file data', () => {
+
+	test('custom file data with boolean `download`', () => {
+		expect(
+			JSON.stringify(
+				createExampleFile({
+					download: true,
+					href: '/',
+					lastModified: 100,
+					name: 'example',
+					status: 'success',
+					type: 'image/png',
+				})
+			)
+		).toBe(
+			JSON.stringify({
+				lastModified: 100,
+				name: 'example',
+				size: 100,
+				type: 'image/png',
+				download: true,
+				href: '/',
+				status: 'success',
+			})
+		);
+	});
+
+	test('custom file data with string `download`', () => {
 		expect(
 			JSON.stringify(
 				createExampleFile({

--- a/packages/react/src/file-upload/utils.test.tsx
+++ b/packages/react/src/file-upload/utils.test.tsx
@@ -46,7 +46,7 @@ describe('createExampleFile', () => {
 		expect(
 			JSON.stringify(
 				createExampleFile({
-					download: true,
+					download: 'renamed.png',
 					href: '/',
 					lastModified: 100,
 					name: 'example',
@@ -60,7 +60,7 @@ describe('createExampleFile', () => {
 				name: 'example',
 				size: 100,
 				type: 'image/png',
-				download: true,
+				download: 'renamed.png',
 				href: '/',
 				status: 'success',
 			})

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -4,8 +4,8 @@ import { filesize } from './filesize';
 export type FileStatus = 'none' | 'uploading' | 'success';
 
 export type FileWithStatus = FileWithPath & {
-	/** If true, causes the browser to treat the linked href as a download. */
-	download?: boolean;
+	/** Makes the browser treat the linked href as a download. */
+	download?: boolean | string;
 	/** Used to link to a webpage where the user can view/download the existing file. */
 	href?: string;
 	/** Use to indicate the upload status of a file. */
@@ -18,8 +18,8 @@ export type RejectedFile = {
 };
 
 export type ExistingFile = {
-	/** If true, causes the browser to treat the linked href as a download. */
-	download?: boolean;
+	/** Makes the browser treat the linked href as a download. */
+	download?: boolean | string;
 	/** The file name. */
 	name: string;
 	/** Link to a webpage where the user can view/download the existing file (optional) */


### PR DESCRIPTION
In 1.26 we added `download` support as a boolean, but it that attribute also supports strings which will download the file as the name in the string.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2000)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
