### PR TITLE
checkbox, radio: Fix scrolling into view when focused

### DIFF
--- a/.changeset/clean-pens-talk.md
+++ b/.changeset/clean-pens-talk.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+checkbox: Change approach of hiding native input to fix scrolling into view when receiving focus.
+
+radio: Change approach of hiding native input to fix scrolling into view when receiving focus.

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -105,10 +105,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 						aria-required={required}
 						checked={checked}
 						disabled={disabled}
+						height={height}
 						id={id}
 						name={name}
 						ref={mergeRefs([forwardedRef, ref])}
 						type="checkbox"
+						width={width}
 						{...props}
 					/>
 					<CheckboxIndicator

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import {
 	useEffect,
 	useRef,
 } from 'react';
-import { mergeRefs, useId } from '../core';
+import { mergeRefs, packs, useId } from '../core';
 import { useControlGroupContext } from '../control-group/ControlGroupProvider';
 import { CheckboxIndicator } from './CheckboxIndicator';
 import { CheckboxInput } from './CheckboxInput';
@@ -59,6 +59,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 		const id = useCheckboxId(props.id);
 		const ref = useRef<HTMLInputElement>(null);
 		const controlGroupContext = useControlGroupContext();
+		const { height, width } = packs.control[size];
 
 		// The invalid prop should override the context value
 		const invalid =
@@ -87,27 +88,36 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
 		return (
 			<CheckboxContainer disabled={disabled} htmlFor={id}>
-				<CheckboxInput
-					aria-checked={indeterminate ? 'mixed' : undefined}
-					aria-describedby={
-						invalid ? controlGroupContext?.messageId : undefined
-					}
-					aria-invalid={invalid || undefined}
-					aria-required={required}
-					checked={checked}
-					disabled={disabled}
-					id={id}
-					name={name}
-					ref={mergeRefs([forwardedRef, ref])}
-					type="checkbox"
-					{...props}
-				/>
-				<CheckboxIndicator
-					disabled={disabled}
-					indeterminate={indeterminate}
-					invalid={invalid}
-					size={size}
-				/>
+				<span
+					css={{
+						display: 'inline-block',
+						position: 'relative',
+						height,
+						width,
+					}}
+				>
+					<CheckboxInput
+						aria-checked={indeterminate ? 'mixed' : undefined}
+						aria-describedby={
+							invalid ? controlGroupContext?.messageId : undefined
+						}
+						aria-invalid={invalid || undefined}
+						aria-required={required}
+						checked={checked}
+						disabled={disabled}
+						id={id}
+						name={name}
+						ref={mergeRefs([forwardedRef, ref])}
+						type="checkbox"
+						{...props}
+					/>
+					<CheckboxIndicator
+						disabled={disabled}
+						indeterminate={indeterminate}
+						invalid={invalid}
+						size={size}
+					/>
+				</span>
 				<CheckboxLabel disabled={disabled} size={size}>
 					{children}
 				</CheckboxLabel>

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -91,8 +91,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 				<span
 					css={{
 						display: 'inline-block',
-						position: 'relative',
 						height,
+						position: 'relative',
 						width,
 					}}
 				>

--- a/packages/react/src/checkbox/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/CheckboxIndicator.tsx
@@ -22,11 +22,13 @@ export const CheckboxIndicator = ({
 			alignItems="center"
 			as="span"
 			css={{
-				borderWidth,
-				borderStyle: 'solid',
-				borderColor: boxPalette.border,
 				backgroundColor: boxPalette.backgroundBody,
+				borderColor: boxPalette.border,
+				borderStyle: 'solid',
+				borderWidth,
 				color: boxPalette.foregroundText,
+				inset: 0,
+				position: 'absolute',
 
 				...(disabled && {
 					color: boxPalette.borderMuted,

--- a/packages/react/src/checkbox/CheckboxInput.tsx
+++ b/packages/react/src/checkbox/CheckboxInput.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, InputHTMLAttributes } from 'react';
-import { visuallyHiddenStyles } from '../a11y';
 import { packs } from '../core';
 
 export type ControlInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -9,7 +8,6 @@ export const CheckboxInput = forwardRef<HTMLInputElement, ControlInputProps>(
 		return (
 			<input
 				css={{
-					...visuallyHiddenStyles,
 					// When this component is focused, outline the `CheckboxIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked or indeterminate, show the indicator's active state

--- a/packages/react/src/checkbox/CheckboxInput.tsx
+++ b/packages/react/src/checkbox/CheckboxInput.tsx
@@ -4,11 +4,14 @@ import { packs } from '../core';
 export type ControlInputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const CheckboxInput = forwardRef<HTMLInputElement, ControlInputProps>(
-	function CheckboxInput(props, ref) {
+	function CheckboxInput({ height, width, ...props }, ref) {
 		return (
 			<input
 				css={{
+					height,
+					margin: 0,
 					opacity: 0,
+					width,
 					// When this component is focused, outline the `CheckboxIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked or indeterminate, show the indicator's active state

--- a/packages/react/src/checkbox/CheckboxInput.tsx
+++ b/packages/react/src/checkbox/CheckboxInput.tsx
@@ -8,6 +8,7 @@ export const CheckboxInput = forwardRef<HTMLInputElement, ControlInputProps>(
 		return (
 			<input
 				css={{
+					opacity: 0,
 					// When this component is focused, outline the `CheckboxIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked or indeterminate, show the indicator's active state

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Checkbox renders correctly 1`] = `
       class="css-lhbzwe-Checkbox"
     >
       <input
-        class="css-v5n1jg-CheckboxInput"
+        class="css-i6dzv4-CheckboxInput"
         data-testid="example"
         id="checkbox-:r0:"
         name="my-checkbox"

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Checkbox renders correctly 1`] = `
     for="checkbox-:r0:"
   >
     <span
-      class="css-lhbzwe-Checkbox"
+      class="css-1246v4c-Checkbox"
     >
       <input
         class="css-1iw6cs3-CheckboxInput"

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Checkbox renders correctly 1`] = `
       class="css-lhbzwe-Checkbox"
     >
       <input
-        class="css-i6dzv4-CheckboxInput"
+        class="css-1iw6cs3-CheckboxInput"
         data-testid="example"
         id="checkbox-:r0:"
         name="my-checkbox"

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -6,32 +6,36 @@ exports[`Checkbox renders correctly 1`] = `
     class="css-hp3wbe-boxStyles-CheckboxContainer"
     for="checkbox-:r0:"
   >
-    <input
-      class="css-142kh0r-CheckboxInput"
-      data-testid="example"
-      id="checkbox-:r0:"
-      name="my-checkbox"
-      type="checkbox"
-    />
     <span
-      class="css-fhfj02-boxStyles-CheckboxIndicator"
+      class="css-lhbzwe-Checkbox"
     >
-      <svg
-        aria-hidden="true"
-        class="css-lewdp2-Icon"
-        clip-rule="evenodd"
-        fill-rule="evenodd"
-        focusable="false"
-        height="24"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <input
+        class="css-v5n1jg-CheckboxInput"
+        data-testid="example"
+        id="checkbox-:r0:"
+        name="my-checkbox"
+        type="checkbox"
+      />
+      <span
+        class="css-5q1w1y-boxStyles-CheckboxIndicator"
       >
-        <path
-          d="M20 6 9 17l-5-5"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="css-lewdp2-Icon"
+          clip-rule="evenodd"
+          fill-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 6 9 17l-5-5"
+          />
+        </svg>
+      </span>
     </span>
     <span
       class="css-1f6xqkn-boxStyles-CheckboxLabel"

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:r2:"
                 name=":r1:"
@@ -81,7 +81,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:r3:"
                 name=":r1:"
@@ -123,7 +123,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:r4:"
                 name=":r1:"
@@ -165,7 +165,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:r5:"
                 name=":r1:"
@@ -286,7 +286,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:rk:"
                 name=":rj:"
@@ -330,7 +330,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:rl:"
                 name=":rj:"
@@ -374,7 +374,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:rm:"
                 name=":rj:"
@@ -418,7 +418,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:rn:"
                 name=":rj:"
@@ -498,7 +498,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:re:"
                 name=":rd:"
@@ -540,7 +540,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:rf:"
                 name=":rd:"
@@ -582,7 +582,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:rg:"
                 name=":rd:"
@@ -624,7 +624,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-i6dzv4-CheckboxInput"
+                class="css-1iw6cs3-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:rh:"
                 name=":rd:"
@@ -703,7 +703,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-a"
                 id="radio-:r16:"
                 name=":r15:"
@@ -732,7 +732,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-b"
                 id="radio-:r17:"
                 name=":r15:"
@@ -761,7 +761,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-c"
                 id="radio-:r18:"
                 name=":r15:"
@@ -790,7 +790,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-d"
                 id="radio-:r19:"
                 name=":r15:"
@@ -898,7 +898,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-a"
                 id="radio-:r1o:"
                 name=":r1n:"
@@ -929,7 +929,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-b"
                 id="radio-:r1p:"
                 name=":r1n:"
@@ -960,7 +960,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-c"
                 id="radio-:r1q:"
                 name=":r1n:"
@@ -991,7 +991,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-d"
                 id="radio-:r1r:"
                 name=":r1n:"
@@ -1058,7 +1058,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-a"
                 id="radio-:r1i:"
                 name=":r1h:"
@@ -1087,7 +1087,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-b"
                 id="radio-:r1j:"
                 name=":r1h:"
@@ -1116,7 +1116,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-c"
                 id="radio-:r1k:"
                 name=":r1h:"
@@ -1145,7 +1145,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1vibgq8-RadioInput"
+                class="css-w4mqhh-RadioInput"
                 data-testid="option-d"
                 id="radio-:r1l:"
                 name=":r1h:"

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -34,33 +34,37 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:r2:"
           >
-            <input
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-a"
-              id="checkbox-:r2:"
-              name=":r1:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-a"
+                id="checkbox-:r2:"
+                name=":r1:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -72,33 +76,37 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:r3:"
           >
-            <input
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-b"
-              id="checkbox-:r3:"
-              name=":r1:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-b"
+                id="checkbox-:r3:"
+                name=":r1:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -110,33 +118,37 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:r4:"
           >
-            <input
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-c"
-              id="checkbox-:r4:"
-              name=":r1:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-c"
+                id="checkbox-:r4:"
+                name=":r1:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -148,33 +160,37 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:r5:"
           >
-            <input
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-d"
-              id="checkbox-:r5:"
-              name=":r1:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-d"
+                id="checkbox-:r5:"
+                name=":r1:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -263,35 +279,39 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:rk:"
           >
-            <input
-              aria-describedby="control-group-:ri:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-a"
-              id="checkbox-:rk:"
-              name=":rj:"
-              type="checkbox"
-            />
             <span
-              class="css-7h9akr-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-describedby="control-group-:ri:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-a"
+                id="checkbox-:rk:"
+                name=":rj:"
+                type="checkbox"
+              />
+              <span
+                class="css-80qi0p-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -303,35 +323,39 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:rl:"
           >
-            <input
-              aria-describedby="control-group-:ri:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-b"
-              id="checkbox-:rl:"
-              name=":rj:"
-              type="checkbox"
-            />
             <span
-              class="css-7h9akr-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-describedby="control-group-:ri:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-b"
+                id="checkbox-:rl:"
+                name=":rj:"
+                type="checkbox"
+              />
+              <span
+                class="css-80qi0p-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -343,35 +367,39 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:rm:"
           >
-            <input
-              aria-describedby="control-group-:ri:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-c"
-              id="checkbox-:rm:"
-              name=":rj:"
-              type="checkbox"
-            />
             <span
-              class="css-7h9akr-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-describedby="control-group-:ri:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-c"
+                id="checkbox-:rm:"
+                name=":rj:"
+                type="checkbox"
+              />
+              <span
+                class="css-80qi0p-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -383,35 +411,39 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:rn:"
           >
-            <input
-              aria-describedby="control-group-:ri:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-d"
-              id="checkbox-:rn:"
-              name=":rj:"
-              type="checkbox"
-            />
             <span
-              class="css-7h9akr-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-describedby="control-group-:ri:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-d"
+                id="checkbox-:rn:"
+                name=":rj:"
+                type="checkbox"
+              />
+              <span
+                class="css-80qi0p-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -461,33 +493,37 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:re:"
           >
-            <input
-              aria-required="true"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-a"
-              id="checkbox-:re:"
-              name=":rd:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="true"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-a"
+                id="checkbox-:re:"
+                name=":rd:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -499,33 +535,37 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:rf:"
           >
-            <input
-              aria-required="true"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-b"
-              id="checkbox-:rf:"
-              name=":rd:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="true"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-b"
+                id="checkbox-:rf:"
+                name=":rd:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -537,33 +577,37 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:rg:"
           >
-            <input
-              aria-required="true"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-c"
-              id="checkbox-:rg:"
-              name=":rd:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="true"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-c"
+                id="checkbox-:rg:"
+                name=":rd:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -575,33 +619,37 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
             for="checkbox-:rh:"
           >
-            <input
-              aria-required="true"
-              class="css-142kh0r-CheckboxInput"
-              data-testid="option-d"
-              id="checkbox-:rh:"
-              name=":rd:"
-              type="checkbox"
-            />
             <span
-              class="css-fhfj02-boxStyles-CheckboxIndicator"
+              class="css-lhbzwe-Checkbox"
             >
-              <svg
-                aria-hidden="true"
-                class="css-lewdp2-Icon"
-                clip-rule="evenodd"
-                fill-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <input
+                aria-required="true"
+                class="css-v5n1jg-CheckboxInput"
+                data-testid="option-d"
+                id="checkbox-:rh:"
+                name=":rd:"
+                type="checkbox"
+              />
+              <span
+                class="css-5q1w1y-boxStyles-CheckboxIndicator"
               >
-                <path
-                  d="M20 6 9 17l-5-5"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="css-lewdp2-Icon"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M20 6 9 17l-5-5"
+                  />
+                </svg>
+              </span>
             </span>
             <span
               class="css-1f6xqkn-boxStyles-CheckboxLabel"
@@ -650,20 +698,24 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r16:"
           >
-            <input
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-a"
-              id="radio-:r16:"
-              name=":r15:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-a"
+                id="radio-:r16:"
+                name=":r15:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -675,20 +727,24 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r17:"
           >
-            <input
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-b"
-              id="radio-:r17:"
-              name=":r15:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-b"
+                id="radio-:r17:"
+                name=":r15:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -700,20 +756,24 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r18:"
           >
-            <input
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-c"
-              id="radio-:r18:"
-              name=":r15:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-c"
+                id="radio-:r18:"
+                name=":r15:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -725,20 +785,24 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r19:"
           >
-            <input
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-d"
-              id="radio-:r19:"
-              name=":r15:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-d"
+                id="radio-:r19:"
+                name=":r15:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -827,22 +891,26 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1o:"
           >
-            <input
-              aria-describedby="control-group-:r1m:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-a"
-              id="radio-:r1o:"
-              name=":r1n:"
-              type="radio"
-            />
             <span
-              class="css-ib2w54-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-describedby="control-group-:r1m:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-a"
+                id="radio-:r1o:"
+                name=":r1n:"
+                type="radio"
               />
+              <span
+                class="css-11u7vp8-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -854,22 +922,26 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1p:"
           >
-            <input
-              aria-describedby="control-group-:r1m:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-b"
-              id="radio-:r1p:"
-              name=":r1n:"
-              type="radio"
-            />
             <span
-              class="css-ib2w54-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-describedby="control-group-:r1m:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-b"
+                id="radio-:r1p:"
+                name=":r1n:"
+                type="radio"
               />
+              <span
+                class="css-11u7vp8-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -881,22 +953,26 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1q:"
           >
-            <input
-              aria-describedby="control-group-:r1m:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-c"
-              id="radio-:r1q:"
-              name=":r1n:"
-              type="radio"
-            />
             <span
-              class="css-ib2w54-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-describedby="control-group-:r1m:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-c"
+                id="radio-:r1q:"
+                name=":r1n:"
+                type="radio"
               />
+              <span
+                class="css-11u7vp8-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -908,22 +984,26 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1r:"
           >
-            <input
-              aria-describedby="control-group-:r1m:-message"
-              aria-invalid="true"
-              aria-required="false"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-d"
-              id="radio-:r1r:"
-              name=":r1n:"
-              type="radio"
-            />
             <span
-              class="css-ib2w54-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-describedby="control-group-:r1m:-message"
+                aria-invalid="true"
+                aria-required="false"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-d"
+                id="radio-:r1r:"
+                name=":r1n:"
+                type="radio"
               />
+              <span
+                class="css-11u7vp8-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -973,20 +1053,24 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1i:"
           >
-            <input
-              aria-required="true"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-a"
-              id="radio-:r1i:"
-              name=":r1h:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="true"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-a"
+                id="radio-:r1i:"
+                name=":r1h:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -998,20 +1082,24 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1j:"
           >
-            <input
-              aria-required="true"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-b"
-              id="radio-:r1j:"
-              name=":r1h:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="true"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-b"
+                id="radio-:r1j:"
+                name=":r1h:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -1023,20 +1111,24 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1k:"
           >
-            <input
-              aria-required="true"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-c"
-              id="radio-:r1k:"
-              name=":r1h:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="true"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-c"
+                id="radio-:r1k:"
+                name=":r1h:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"
@@ -1048,20 +1140,24 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
             for="radio-:r1l:"
           >
-            <input
-              aria-required="true"
-              class="css-o6md8t-RadioInput"
-              data-testid="option-d"
-              id="radio-:r1l:"
-              name=":r1h:"
-              type="radio"
-            />
             <span
-              class="css-osss6w-boxStyles-RadioIndicator"
+              class="css-1i46ndm-Radio"
             >
-              <span
-                class="css-erbirp-boxStyles-RadioIndicator"
+              <input
+                aria-required="true"
+                class="css-1keng9k-RadioInput"
+                data-testid="option-d"
+                id="radio-:r1l:"
+                name=":r1h:"
+                type="radio"
               />
+              <span
+                class="css-1ab3tn0-boxStyles-RadioIndicator"
+              >
+                <span
+                  class="css-erbirp-boxStyles-RadioIndicator"
+                />
+              </span>
             </span>
             <span
               class="css-1vx6497-boxStyles-RadioLabel"

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             for="checkbox-:r2:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="false"
@@ -77,7 +77,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             for="checkbox-:r3:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="false"
@@ -119,7 +119,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             for="checkbox-:r4:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="false"
@@ -161,7 +161,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             for="checkbox-:r5:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="false"
@@ -280,7 +280,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             for="checkbox-:rk:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-describedby="control-group-:ri:-message"
@@ -324,7 +324,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             for="checkbox-:rl:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-describedby="control-group-:ri:-message"
@@ -368,7 +368,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             for="checkbox-:rm:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-describedby="control-group-:ri:-message"
@@ -412,7 +412,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             for="checkbox-:rn:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-describedby="control-group-:ri:-message"
@@ -494,7 +494,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             for="checkbox-:re:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="true"
@@ -536,7 +536,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             for="checkbox-:rf:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="true"
@@ -578,7 +578,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             for="checkbox-:rg:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="true"
@@ -620,7 +620,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             for="checkbox-:rh:"
           >
             <span
-              class="css-lhbzwe-Checkbox"
+              class="css-1246v4c-Checkbox"
             >
               <input
                 aria-required="true"
@@ -699,7 +699,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             for="radio-:r16:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="false"
@@ -728,7 +728,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             for="radio-:r17:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="false"
@@ -757,7 +757,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             for="radio-:r18:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="false"
@@ -786,7 +786,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             for="radio-:r19:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="false"
@@ -892,7 +892,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             for="radio-:r1o:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-describedby="control-group-:r1m:-message"
@@ -923,7 +923,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             for="radio-:r1p:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-describedby="control-group-:r1m:-message"
@@ -954,7 +954,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             for="radio-:r1q:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-describedby="control-group-:r1m:-message"
@@ -985,7 +985,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             for="radio-:r1r:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-describedby="control-group-:r1m:-message"
@@ -1054,7 +1054,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             for="radio-:r1i:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="true"
@@ -1083,7 +1083,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             for="radio-:r1j:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="true"
@@ -1112,7 +1112,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             for="radio-:r1k:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="true"
@@ -1141,7 +1141,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             for="radio-:r1l:"
           >
             <span
-              class="css-1i46ndm-Radio"
+              class="css-7y4mhc-Radio"
             >
               <input
                 aria-required="true"

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:r2:"
                 name=":r1:"
@@ -81,7 +81,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:r3:"
                 name=":r1:"
@@ -123,7 +123,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:r4:"
                 name=":r1:"
@@ -165,7 +165,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:r5:"
                 name=":r1:"
@@ -286,7 +286,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:rk:"
                 name=":rj:"
@@ -330,7 +330,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:rl:"
                 name=":rj:"
@@ -374,7 +374,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:rm:"
                 name=":rj:"
@@ -418,7 +418,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:rn:"
                 name=":rj:"
@@ -498,7 +498,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:re:"
                 name=":rd:"
@@ -540,7 +540,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:rf:"
                 name=":rd:"
@@ -582,7 +582,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:rg:"
                 name=":rd:"
@@ -624,7 +624,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-v5n1jg-CheckboxInput"
+                class="css-i6dzv4-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:rh:"
                 name=":rd:"
@@ -703,7 +703,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-a"
                 id="radio-:r16:"
                 name=":r15:"
@@ -732,7 +732,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-b"
                 id="radio-:r17:"
                 name=":r15:"
@@ -761,7 +761,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-c"
                 id="radio-:r18:"
                 name=":r15:"
@@ -790,7 +790,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-d"
                 id="radio-:r19:"
                 name=":r15:"
@@ -898,7 +898,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-a"
                 id="radio-:r1o:"
                 name=":r1n:"
@@ -929,7 +929,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-b"
                 id="radio-:r1p:"
                 name=":r1n:"
@@ -960,7 +960,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-c"
                 id="radio-:r1q:"
                 name=":r1n:"
@@ -991,7 +991,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-d"
                 id="radio-:r1r:"
                 name=":r1n:"
@@ -1058,7 +1058,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-a"
                 id="radio-:r1i:"
                 name=":r1h:"
@@ -1087,7 +1087,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-b"
                 id="radio-:r1j:"
                 name=":r1h:"
@@ -1116,7 +1116,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-c"
                 id="radio-:r1k:"
                 name=":r1h:"
@@ -1145,7 +1145,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1keng9k-RadioInput"
+                class="css-1vibgq8-RadioInput"
                 data-testid="option-d"
                 id="radio-:r1l:"
                 name=":r1h:"

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`PasswordInput renders correctly 1`] = `
       >
         <input
           aria-controls="password-input-:r0:"
-          class="css-i6dzv4-CheckboxInput"
+          class="css-7v4krt-CheckboxInput"
           id="checkbox-:r2:"
           type="checkbox"
         />

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -40,31 +40,35 @@ exports[`PasswordInput renders correctly 1`] = `
       class="css-hp3wbe-boxStyles-CheckboxContainer"
       for="checkbox-:r2:"
     >
-      <input
-        aria-controls="password-input-:r0:"
-        class="css-142kh0r-CheckboxInput"
-        id="checkbox-:r2:"
-        type="checkbox"
-      />
       <span
-        class="css-1x4u8cx-boxStyles-CheckboxIndicator"
+        class="css-qhqecw-Checkbox"
       >
-        <svg
-          aria-hidden="true"
-          class="css-17xxus6-Icon"
-          clip-rule="evenodd"
-          fill-rule="evenodd"
-          focusable="false"
-          height="24"
-          role="img"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <input
+          aria-controls="password-input-:r0:"
+          class="css-v5n1jg-CheckboxInput"
+          id="checkbox-:r2:"
+          type="checkbox"
+        />
+        <span
+          class="css-1j2nz1m-boxStyles-CheckboxIndicator"
         >
-          <path
-            d="M20 6 9 17l-5-5"
-          />
-        </svg>
+          <svg
+            aria-hidden="true"
+            class="css-17xxus6-Icon"
+            clip-rule="evenodd"
+            fill-rule="evenodd"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 6 9 17l-5-5"
+            />
+          </svg>
+        </span>
       </span>
       <span
         class="css-1ezdn5f-boxStyles-CheckboxLabel"

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`PasswordInput renders correctly 1`] = `
       for="checkbox-:r2:"
     >
       <span
-        class="css-qhqecw-Checkbox"
+        class="css-ziyc0a-Checkbox"
       >
         <input
           aria-controls="password-input-:r0:"

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`PasswordInput renders correctly 1`] = `
       >
         <input
           aria-controls="password-input-:r0:"
-          class="css-v5n1jg-CheckboxInput"
+          class="css-i6dzv4-CheckboxInput"
           id="checkbox-:r2:"
           type="checkbox"
         />

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, InputHTMLAttributes, PropsWithChildren } from 'react';
-import { useId } from '../core';
+import { packs, useId } from '../core';
 import { useControlGroupContext } from '../control-group/ControlGroupProvider';
 import { RadioIndicator } from './RadioIndicator';
 import { RadioInput } from './RadioInput';
@@ -48,6 +48,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 ) {
 	const id = useRadioId(props.id);
 	const controlGroupContext = useControlGroupContext();
+	const { height, width } = packs.control[size];
 
 	// The invalid prop should override the context value
 	const invalid =
@@ -66,18 +67,29 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 
 	return (
 		<RadioContainer disabled={disabled} htmlFor={id}>
-			<RadioInput
-				aria-describedby={invalid ? controlGroupContext?.messageId : undefined}
-				aria-invalid={invalid || undefined}
-				aria-required={required}
-				disabled={disabled}
-				id={id}
-				name={name}
-				ref={ref}
-				type="radio"
-				{...props}
-			/>
-			<RadioIndicator disabled={disabled} invalid={invalid} size={size} />
+			<span
+				css={{
+					display: 'inline-block',
+					position: 'relative',
+					height,
+					width,
+				}}
+			>
+				<RadioInput
+					aria-describedby={
+						invalid ? controlGroupContext?.messageId : undefined
+					}
+					aria-invalid={invalid || undefined}
+					aria-required={required}
+					disabled={disabled}
+					id={id}
+					name={name}
+					ref={ref}
+					type="radio"
+					{...props}
+				/>
+				<RadioIndicator disabled={disabled} invalid={invalid} size={size} />
+			</span>
 			<RadioLabel disabled={disabled} size={size}>
 				{children}
 			</RadioLabel>

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -82,10 +82,12 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 					aria-invalid={invalid || undefined}
 					aria-required={required}
 					disabled={disabled}
+					height={height}
 					id={id}
 					name={name}
 					ref={ref}
 					type="radio"
+					width={width}
 					{...props}
 				/>
 				<RadioIndicator disabled={disabled} invalid={invalid} size={size} />

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -70,8 +70,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 			<span
 				css={{
 					display: 'inline-block',
-					position: 'relative',
 					height,
+					position: 'relative',
 					width,
 				}}
 			>

--- a/packages/react/src/radio/RadioIndicator.tsx
+++ b/packages/react/src/radio/RadioIndicator.tsx
@@ -20,11 +20,13 @@ export function RadioIndicator({
 			alignItems="center"
 			as="span"
 			css={{
-				borderWidth,
+				backgroundColor: boxPalette.backgroundBody,
+				borderColor: boxPalette.border,
 				borderRadius: '100%',
 				borderStyle: 'solid',
-				borderColor: boxPalette.border,
-				backgroundColor: boxPalette.backgroundBody,
+				borderWidth,
+				inset: 0,
+				position: 'absolute',
 
 				...(disabled && {
 					color: boxPalette.borderMuted,

--- a/packages/react/src/radio/RadioInput.tsx
+++ b/packages/react/src/radio/RadioInput.tsx
@@ -8,6 +8,7 @@ export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
 		return (
 			<input
 				css={{
+					opacity: 0,
 					// When this component is focused, outline the `RadioIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked, show the indicator's active state

--- a/packages/react/src/radio/RadioInput.tsx
+++ b/packages/react/src/radio/RadioInput.tsx
@@ -4,11 +4,14 @@ import { packs } from '../core';
 export type RadioInputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
-	function RadioInput(props, ref) {
+	function RadioInput({ height, width, ...props }, ref) {
 		return (
 			<input
 				css={{
+					height,
+					margin: 0,
 					opacity: 0,
+					width,
 					// When this component is focused, outline the `RadioIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked, show the indicator's active state

--- a/packages/react/src/radio/RadioInput.tsx
+++ b/packages/react/src/radio/RadioInput.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, InputHTMLAttributes } from 'react';
-import { visuallyHiddenStyles } from '../a11y';
 import { packs } from '../core';
 
 export type RadioInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -9,7 +8,6 @@ export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
 		return (
 			<input
 				css={{
-					...visuallyHiddenStyles,
 					// When this component is focused, outline the `RadioIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked, show the indicator's active state

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -6,19 +6,23 @@ exports[`Radio renders correctly 1`] = `
     class="css-6pplfb-boxStyles-RadioContainer"
     for="radio-:r2:"
   >
-    <input
-      class="css-o6md8t-RadioInput"
-      data-testid="example"
-      id="radio-:r2:"
-      name="my-radio"
-      type="radio"
-    />
     <span
-      class="css-osss6w-boxStyles-RadioIndicator"
+      class="css-1i46ndm-Radio"
     >
-      <span
-        class="css-erbirp-boxStyles-RadioIndicator"
+      <input
+        class="css-1keng9k-RadioInput"
+        data-testid="example"
+        id="radio-:r2:"
+        name="my-radio"
+        type="radio"
       />
+      <span
+        class="css-1ab3tn0-boxStyles-RadioIndicator"
+      >
+        <span
+          class="css-erbirp-boxStyles-RadioIndicator"
+        />
+      </span>
     </span>
     <span
       class="css-1vx6497-boxStyles-RadioLabel"

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Radio renders correctly 1`] = `
       class="css-1i46ndm-Radio"
     >
       <input
-        class="css-1keng9k-RadioInput"
+        class="css-1vibgq8-RadioInput"
         data-testid="example"
         id="radio-:r2:"
         name="my-radio"

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Radio renders correctly 1`] = `
       class="css-1i46ndm-Radio"
     >
       <input
-        class="css-1vibgq8-RadioInput"
+        class="css-w4mqhh-RadioInput"
         data-testid="example"
         id="radio-:r2:"
         name="my-radio"

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Radio renders correctly 1`] = `
     for="radio-:r2:"
   >
     <span
-      class="css-1i46ndm-Radio"
+      class="css-7y4mhc-Radio"
     >
       <input
         class="css-w4mqhh-RadioInput"


### PR DESCRIPTION
I noticed in yourgov that tabbing through the items in the staff table didn't scroll the checkbox back into view. The visually hidden styles were the cause, so I'm now hiding them behind the custom indicator.

Also realised that the screen reader virtual cursor wasn't indicative (or visible at all), so this fixes that too.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2006)

[broken behaviour on main](https://design-system.agriculture.gov.au/playroom/#?code=N4Igxg9gJgpiBcIA8BlALgQzAawAQHMMAHAXmAEYBfAPgB0A7XXJKASwDdcBnNATwBsYZYLgDurKGgAW8XACYADAoA0uCOxgAnAGb8Io2bRBcwmiP35HVoqazQwURLDEMh6%2BzcSO5KNBkyYkAGEIejQzfgBxMwBXIjpGAMC2Th4BIWARcUkZXHIlBR8-RKTAoKkYHAAjCAAPXHYMfhihIyIpUJgjagAFDvoYJAB6csrsGtqE0oDgiuq6hqaWkiNMKsE0boAVDHWYNGHR%2Bcn-aeYj8YXG5taQfmI0CCJugBkHp8O5y5OS0tmxiaLG4rEDtTrdPqdT4AupTM7-Y5A5arXYbbao-bQ45w6YI75I273IiPZ4gahvYkfEZfCY4mZDFJ0w6hcLmaIQOJMkJhCLszmnJIsDjcPiCYRiCTSWT5JRFOmCi6A67I0H9LpkyEDLHfeUzRVXJa3NZosk7PYHakwn5nc40g3AoxEkmvd5EbW0gV-fX1ZW3MEDCFq92wz0Ku0%2Bw0g437dHm4PWv4MjhMkYs3mxeKnYaMrMpEXpcXZKXyJSqdRaXT6VwmCKWEDWWz2RzOVzuUSeUlyz3BNNsjO6oWpUUZLKS3Iywq%2BXWBABKGDYEAJIP96t6QaGc4X0%2BYm9Yi99UYxm1NR%2BGu4g26Q56XjtdLspbo3873l%2BvB7aavIgahT63oZmb6Rii5pfieca-i%2B-6zs%2B%2B5AXcrqgeSrpnjBA5JuwKbcqyUT9t2WHphyma-MkwppGKmQSjk0oFF2xEATBN6qp0cjflqEEXlBO4Me%2BIDRmgLFgRsKF-nR0ELoxTpPAJSEPsJkGiVx4k8SuADMrGDOxr7cXBfFqYJmKaf%2B2bJt2qY8n2hFwsZGEMMM6BYNgCT1iARZSFwCAANrkAAbKWih%2BQALEoAC6lBAA)

[fixed behaviour](https://design-system.agriculture.gov.au/pr-preview/pr-2006/playroom/#?code=N4Igxg9gJgpiBcIA8BlALgQzAawAQHMMAHAXmAEYBfAPgB0A7XXJKASwDdcBnNATwBsYZYLgDurKGgAW8XACYADAoA0uCOxgAnAGb8Io2bRBcwmiP35HVoqazQwURLDEMh6%2BzcSO5KNBkyYkAGEIejQzfgBxMwBXIjpGAMC2Th4BIWARcUkZXHIlBR8-RKTAoKkYHAAjCAAPXHYMfhihIyIpUJgjagAFDvoYJAB6csrsGtqE0oDgiuq6hqaWkiNMKsE0boAVDHWYNGHR%2Bcn-aeYj8YXG5taQfmI0CCJugBkHp8O5y5OS0tmxiaLG4rEDtTrdPqdT4AupTM7-Y5A5arXYbbao-bQ45w6YI75I273IiPZ4gahvYkfEZfCY4mZDFJ0w6hcLmaIQOJMkJhCLszmnJIsDjcPiCYRiCTSWT5JRFOmCi6A67I0H9LpkyEDLHfeUzRVXJa3NZosk7PYHakwn5nc40g3AoxEkmvd5EbW0gV-fX1ZW3MEDCFq92wz0Ku0%2Bw0g437dHm4PWv4MjhMkYs3mxeKnYaMrMpEXpcXZKXyJSqdRaXT6VwmCKWEDWWz2RzOVzuUSeUlyz3BNNsjO6oWpUUZLKS3Iywq%2BXWBABKGDYEAJIP96t6QaGc4X0%2BYm9Yi99UYxm1NR%2BGu4g26Q56XjtdLspbo3873l%2BvB7aavIgahT63oZmb6Rii5pfieca-i%2B-6zs%2B%2B5AXcrqgeSrpnjBA5JuwKbcqyUT9t2WHphyma-MkwppGKmQSjk0oFF2xEATBN6qp0cjflqEEXlBO4Me%2BIDRmgLFgRsKF-nR0ELoxTpPAJSEPsJkGiVx4k8SuADMrGDOxr7cXBfFqYJmKaf%2B2bJt2qY8n2hFwsZGEMMM6BYNgCT1iARZSFwCAANrkAAbKWih%2BQALEoAC6lBAA)

## voiceover virtual cursor

### before

<img width="231" alt="image" src="https://github.com/user-attachments/assets/99306329-a9c5-4042-ba5c-1ff2bb7aca1b" />
<img width="236" alt="image" src="https://github.com/user-attachments/assets/af5b359b-3922-4bea-92cb-dc72322513ec" />


### after
<img width="243" alt="image" src="https://github.com/user-attachments/assets/4da481dc-e296-43b9-a9dd-5c80a5f86ab3" />
<img width="226" alt="image" src="https://github.com/user-attachments/assets/63daec34-8213-433f-b0ad-2a42c44358ba" />


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
