### PR TITLE
github: update ubuntu image for deploy-preview

### DIFF
--- a/.changeset/angry-owls-stare.md
+++ b/.changeset/angry-owls-stare.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/docs': patch
 ---
 
-github: Update build image for `deploy-preview` to use `ubuntu-latest`. `ubuntu-20.04` was depreciated on 15/04/2025. Changed to latest to match `build-and-deploy`.
+github: Update build image for `deploy-preview` to use `ubuntu-latest`. `ubuntu-20.04` was deprecated on 15/04/2025. Changed to `latest` to match `build-and-deploy`.

--- a/.changeset/angry-owls-stare.md
+++ b/.changeset/angry-owls-stare.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+github: Update build image for `deploy-preview` to `ubuntu-22.04`. `ubuntu-20.04` was depreciated on 15/04/2025.

--- a/.changeset/angry-owls-stare.md
+++ b/.changeset/angry-owls-stare.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/docs': patch
 ---
 
-github: Update build image for `deploy-preview` to `ubuntu-22.04`. `ubuntu-20.04` was depreciated on 15/04/2025.
+github: Update build image for `deploy-preview` to use `ubuntu-latest`. `ubuntu-20.04` was depreciated on 15/04/2025. Changed to latest to match `build-and-deploy`.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,7 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,7 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4


### PR DESCRIPTION
On the 15 of April, the Ubuntu image version we were using for the job `deploy-preview` was depreciated (v20.04). This PR changes the targeted version to `ubuntu-latest` to match `build-and-deploy` jobs.

[Reference Github runner ticket](https://github.com/actions/runner-images/issues/11101)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2007)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
