### PR TITLE
tag: Prevent border radius from scaling when tag label wraps

### DIFF
--- a/.changeset/spotty-readers-relax.md
+++ b/.changeset/spotty-readers-relax.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+tag: Prevent border radius from scaling when tag label wraps on multiple lines.

--- a/packages/react/src/tags/Tag.tsx
+++ b/packages/react/src/tags/Tag.tsx
@@ -31,7 +31,7 @@ export const Tag = ({
 			border
 			color={href ? 'action' : 'text'}
 			css={{
-				borderRadius: 999,
+				borderRadius: '0.75rem',
 				paddingBottom: '0.0625rem',
 				paddingTop: '0.0625rem',
 			}}

--- a/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
+++ b/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Tags With links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-1l8g3ew-boxStyles-Tag"
+          class="css-60nykq-boxStyles-Tag"
         >
           <a
             class="css-4w3gkw-TextLink-boxStyles"
@@ -31,7 +31,7 @@ exports[`Tags With links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-1l8g3ew-boxStyles-Tag"
+          class="css-60nykq-boxStyles-Tag"
         >
           <a
             class="css-4w3gkw-TextLink-boxStyles"
@@ -45,7 +45,7 @@ exports[`Tags With links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-1l8g3ew-boxStyles-Tag"
+          class="css-60nykq-boxStyles-Tag"
         >
           <a
             class="css-4w3gkw-TextLink-boxStyles"
@@ -77,7 +77,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-1l8g3ew-boxStyles-Tag"
+          class="css-60nykq-boxStyles-Tag"
         >
           <a
             class="css-4w3gkw-TextLink-boxStyles"
@@ -113,7 +113,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-1l8g3ew-boxStyles-Tag"
+          class="css-60nykq-boxStyles-Tag"
         >
           <a
             class="css-4w3gkw-TextLink-boxStyles"
@@ -149,7 +149,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-1l8g3ew-boxStyles-Tag"
+          class="css-60nykq-boxStyles-Tag"
         >
           <a
             class="css-4w3gkw-TextLink-boxStyles"
@@ -203,7 +203,7 @@ exports[`Tags Without links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-impmck-boxStyles-Tag"
+          class="css-1pfvdue-boxStyles-Tag"
         >
           <span
             class="css-79i25n-boxStyles"
@@ -216,7 +216,7 @@ exports[`Tags Without links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-impmck-boxStyles-Tag"
+          class="css-1pfvdue-boxStyles-Tag"
         >
           <span
             class="css-79i25n-boxStyles"
@@ -229,7 +229,7 @@ exports[`Tags Without links renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <span
-          class="css-impmck-boxStyles-Tag"
+          class="css-1pfvdue-boxStyles-Tag"
         >
           <span
             class="css-79i25n-boxStyles"


### PR DESCRIPTION
We previously used `999` borderRadius, but when tag text wrapped, it scaled and looked super weird. This PR changes it to be 12px.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2018)

## Before

<img width="641" alt="image" src="https://github.com/user-attachments/assets/e722a738-a8dd-450c-a376-481156a7eeb3" />

## After

<img width="626" alt="image" src="https://github.com/user-attachments/assets/f63bbf64-729f-470c-8c08-af0a07a2dd21" />


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
