### PR TITLE
docs: Fix various React and deprecation warnings throughout examples

### DIFF
--- a/.changeset/tall-months-repair.md
+++ b/.changeset/tall-months-repair.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/react': patch
+'@ag.ds-next/yourgov': patch
+'@ag.ds-next/docs': patch
+---
+
+docs: Fix various React and deprecation warnings throughout examples.
+
+yourgov: Fix error for staff with no training when filtering by `trainingCompleted`.

--- a/docs/content/guides/custom-theme.mdx
+++ b/docs/content/guides/custom-theme.mdx
@@ -59,7 +59,7 @@ In the example below, change the palette prop in the parent Stack to see this be
 						ABC123
 					</Text>
 					<StatusBadge
-						tone="info"
+						tone="infoMedium"
 						label={
 							<Fragment>
 								<VisuallyHidden>{'Status: '}</VisuallyHidden>

--- a/docs/content/patterns/conditional-reveal/index.mdx
+++ b/docs/content/patterns/conditional-reveal/index.mdx
@@ -123,7 +123,7 @@ If there a small number of items, use [Radio](/components/radio) instead.
 
 ```jsx live
 () => {
-	const [value, setValue] = React.useState(null);
+	const [value, setValue] = React.useState('');
 	const handlerForKey = React.useCallback((e) => setValue(e.target.value), []);
 	const isChecked = (key) => value === key;
 

--- a/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
+++ b/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
@@ -112,7 +112,7 @@ Unlike the checkboxes in each row, the ‘Select all rows’ checkbox above the 
 						{Array.from(new Array(3).keys()).map((idx) => {
 							const isRowSelected = selectedRows.includes(idx);
 							return (
-								<TableRow selected={isRowSelected}>
+								<TableRow key={idx} selected={isRowSelected}>
 									<TableCell>
 										<Checkbox
 											size="sm"
@@ -214,7 +214,7 @@ Only small [Buttons](/components/button) should be placed inside of the `TableBa
 							{Array.from(new Array(3).keys()).map((idx) => {
 								const isRowSelected = selectedRows.includes(idx);
 								return (
-									<TableRow selected={isRowSelected}>
+									<TableRow key={idx} selected={isRowSelected}>
 										<TableCell>
 											<Checkbox
 												size="sm"

--- a/packages/react/src/a11y/docs/overview.mdx
+++ b/packages/react/src/a11y/docs/overview.mdx
@@ -33,11 +33,8 @@ function Example() {
 `ExternalLinkCallout` announces to a screen reader user that a link will open in a new tab.
 
 <PageAlert tone="warning">
-	<p>
-		Please use the <strong>TextLinkExternal</strong> component from{' '}
-		<a href="/components/text-link#TextLinkExternal">@ag.ds-next/text</a>{' '}
-		instead.
-	</p>
+	Please use the <strong>TextLinkExternal</strong> component from{' '}
+	<a href="/components/text-link#TextLinkExternal">@ag.ds-next/text</a> instead.
 </PageAlert>
 
 As a rule, links that open in a new tab should indicate this visually with an icon. This is why we recommend using the [TextLinkExternal](https://design-system.agriculture.gov.au/components/text-link#TextLinkExternal) component instead.

--- a/packages/react/src/conditional-field-container/docs/overview.mdx
+++ b/packages/react/src/conditional-field-container/docs/overview.mdx
@@ -64,7 +64,7 @@ Where one input value can be selected (eg. radio or select inputs), you can use 
 
 ```jsx live
 () => {
-	const [value, setValue] = React.useState(null);
+	const [value, setValue] = React.useState('');
 	const handlerForKey = React.useCallback((e) => setValue(e.target.value), []);
 	const isChecked = (key) => value === key;
 

--- a/packages/react/src/section-alert/SectionAlert.stories.tsx
+++ b/packages/react/src/section-alert/SectionAlert.stories.tsx
@@ -96,7 +96,7 @@ export const Progress: Story = {
 export const WithDescription: Story = {
 	args: {
 		title: 'There was an error saving your changes',
-		tone: 'error',
+		tone: 'errorHigh',
 		children: 'Please try again later.',
 	},
 };
@@ -104,7 +104,7 @@ export const WithDescription: Story = {
 export const Dismissable: Story = {
 	args: {
 		title: 'Your changes have been saved',
-		tone: 'success',
+		tone: 'successHigh',
 		onClose: fn(),
 	},
 };

--- a/yourgov/components/Staff/lib/getDisplayData.ts
+++ b/yourgov/components/Staff/lib/getDisplayData.ts
@@ -56,8 +56,8 @@ export const doesStaffMemberMatchFilters = (
 	}
 
 	if (trainingCompleted && Object.values(trainingCompleted).some(Boolean)) {
-		isValid = staffMember.trainingCompleted
-			.map((training) => trainingCompleted[training])
+		isValid = staffMember?.trainingCompleted
+			?.map((training) => trainingCompleted[training])
 			.some(Boolean)
 			? isValid
 			: false;


### PR DESCRIPTION
While testing everything in React 19, I came across a few small errors.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2021)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
