### PR TITLE
button: Hide icons when loading

### DIFF
--- a/.changeset/lucky-radios-behave.md
+++ b/.changeset/lucky-radios-behave.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+button: Hide icons when `loading`.

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -67,7 +67,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 			<BaseButton css={styles} ref={ref} type={type} {...props}>
 				{IconBefore ? (
 					<IconBefore
-						css={{ flexShrink: 0 }}
+						css={{ flexShrink: 0, opacity: loading ? 0 : 1 }}
 						size={iconSize[size]}
 						weight="regular"
 					/>
@@ -84,7 +84,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 				) : null}
 				{IconAfter ? (
 					<IconAfter
-						css={{ flexShrink: 0 }}
+						css={{ flexShrink: 0, opacity: loading ? 0 : 1 }}
 						size={iconSize[size]}
 						weight="regular"
 					/>

--- a/packages/react/src/button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/button/__snapshots__/Button.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Button With Icon renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"

--- a/packages/react/src/button/docs/overview.mdx
+++ b/packages/react/src/button/docs/overview.mdx
@@ -95,7 +95,7 @@ A Block button spans the full width of the container or parent element.
 
 ## Loading
 
-Use the loading property to let users know their action is being processed.
+Use the `loading` property to let users know their action is being processed.
 
 ```jsx live
 <Button type="submit" loading>
@@ -132,9 +132,10 @@ Use icons that accurately communicate the label meaning and describe the action.
 The icon should appear before the text except when the icon indicates direction, e.g. Next or external links.
 
 ```jsx live
-<ButtonLink href="/sign-out" iconBefore={AvatarIcon}>
-	Sign out
-</ButtonLink>
+<Stack alignItems="start" gap={1}>
+	<Button iconBefore={AvatarIcon}>Sign out</Button>
+	<Button iconAfter={ArrowRightIcon}>Next</Button>
+</Stack>
 ```
 
 ## Links

--- a/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`Drawer renders correctly 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="css-sbsftc-Button"
+              class="css-16yahzk-Button"
               clip-rule="evenodd"
               fill-rule="evenodd"
               focusable="false"

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"
@@ -202,7 +202,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"
@@ -291,7 +291,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"
@@ -423,7 +423,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`FileUpload 1 selected file renders correctly 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="css-aw6h11-Button"
+                  class="css-wfexcw-Button"
                   clip-rule="evenodd"
                   fill-rule="evenodd"
                   focusable="false"
@@ -486,7 +486,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="css-aw6h11-Button"
+                  class="css-wfexcw-Button"
                   clip-rule="evenodd"
                   fill-rule="evenodd"
                   focusable="false"
@@ -593,7 +593,7 @@ exports[`FileUpload Existing files renders correctly 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="css-aw6h11-Button"
+                  class="css-wfexcw-Button"
                   clip-rule="evenodd"
                   fill-rule="evenodd"
                   focusable="false"

--- a/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
+++ b/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`GlobalAlert Dismissable renders correctly 1`] = `
         </span>
         <svg
           aria-hidden="true"
-          class="css-sbsftc-Button"
+          class="css-16yahzk-Button"
           clip-rule="evenodd"
           fill-rule="evenodd"
           focusable="false"

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Modal renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-sbsftc-Button"
+            class="css-16yahzk-Button"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -271,7 +271,7 @@ exports[`PageAlert with a close button renders correctly 1`] = `
         </span>
         <svg
           aria-hidden="true"
-          class="css-sbsftc-Button"
+          class="css-16yahzk-Button"
           clip-rule="evenodd"
           fill-rule="evenodd"
           focusable="false"

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`SectionAlert which is closable renders correctly 1`] = `
       </span>
       <svg
         aria-hidden="true"
-        class="css-sbsftc-Button"
+        class="css-16yahzk-Button"
         clip-rule="evenodd"
         fill-rule="evenodd"
         focusable="false"

--- a/packages/react/src/toggle-button/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/react/src/toggle-button/__snapshots__/ToggleButton.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ToggleButton renders alternative icon and label when pressedLabel = tru
   >
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"
@@ -48,7 +48,7 @@ exports[`ToggleButton renders aria-label when hiddenLabel = true 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"
@@ -75,7 +75,7 @@ exports[`ToggleButton renders correctly 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="css-sbsftc-Button"
+      class="css-16yahzk-Button"
       clip-rule="evenodd"
       fill-rule="evenodd"
       focusable="false"


### PR DESCRIPTION
When button's were `loading`, the dots overlapped any icons. We have decided to hide any icons when loading now.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2028)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
