### PR TITLE
app-layout, drawer: Fix hydration mismatch when using App Router

### DIFF
--- a/.changeset/lucky-bikes-buy.md
+++ b/.changeset/lucky-bikes-buy.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: `AppLayoutSidebar` - Fix hydration mismatch warning when using Next.js’ App Router. 
+
+drawer: Fix hydration mismatch warning when using Next.js’ App Router. 

--- a/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
@@ -41,6 +41,7 @@ export function AppLayoutSidebarDialog({
 	const { isMobileMenuOpen, closeMobileMenu } = useAppLayoutContext();
 	const prefersReducedMotion = usePrefersReducedMotion();
 	const [closeTransitionEnded, setCloseTransitionEnded] = useState(true);
+	// We need to check if the component is mounted to avoid hydration mismatch errors
 	const isMounted = useIsMounted();
 
 	useEffect(() => {

--- a/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
@@ -20,6 +20,7 @@ import {
 	packs,
 } from '../core';
 import { BaseButton } from '../button';
+import { useIsMounted } from '../core/utils/useIsMounted';
 import { Flex } from '../flex';
 import { CloseIcon } from '../icon';
 import { scaleIconOnHover } from '../icon/Icon';
@@ -40,6 +41,7 @@ export function AppLayoutSidebarDialog({
 	const { isMobileMenuOpen, closeMobileMenu } = useAppLayoutContext();
 	const prefersReducedMotion = usePrefersReducedMotion();
 	const [closeTransitionEnded, setCloseTransitionEnded] = useState(true);
+	const isMounted = useIsMounted();
 
 	useEffect(() => {
 		if (isMobileMenuOpen) {
@@ -61,11 +63,13 @@ export function AppLayoutSidebarDialog({
 	}, [closeMobileMenu]);
 
 	// Polyfill usage of `aria-modal`
-	const { modalContainerRef } = useAriaModalPolyfill(isMobileMenuOpen);
+	const { modalContainerRef } = useAriaModalPolyfill(
+		!isMounted ? false : isMobileMenuOpen
+	);
 
 	// Since react portals can not be rendered on the server and this component is always closed by default
 	// This component doesn't need to be server side rendered
-	if (!canUseDOM()) return null;
+	if (!isMounted || !canUseDOM()) return null;
 
 	const showDrawer = isMobileMenuOpen ? true : !closeTransitionEnded;
 

--- a/packages/react/src/core/utils/useIsMounted.ts
+++ b/packages/react/src/core/utils/useIsMounted.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export function useIsMounted() {
+	const [isMounted, setIsMounted] = useState(false);
+
+	useEffect(() => {
+		setIsMounted(true);
+	}, []);
+
+	return isMounted;
+}

--- a/packages/react/src/drawer/Drawer.tsx
+++ b/packages/react/src/drawer/Drawer.tsx
@@ -63,6 +63,7 @@ export const Drawer: FunctionComponent<DrawerProps> = ({
 	const scrollbarWidth = useRef<number>(0);
 	const prefersReducedMotion = usePrefersReducedMotion();
 	const [closeTransitionEnded, setCloseTransitionEnded] = useState(true);
+	// We need to check if the component is mounted to avoid hydration mismatch errors
 	const isMounted = useIsMounted();
 
 	useEffect(() => {

--- a/packages/react/src/drawer/Drawer.tsx
+++ b/packages/react/src/drawer/Drawer.tsx
@@ -18,6 +18,7 @@ import {
 	useAriaModalPolyfill,
 	usePrefersReducedMotion,
 } from '../core';
+import { useIsMounted } from '../core/utils/useIsMounted';
 import { getRequiredCloseHandler } from '../getCloseHandler';
 import { DrawerDialog } from './DrawerDialog';
 
@@ -62,6 +63,7 @@ export const Drawer: FunctionComponent<DrawerProps> = ({
 	const scrollbarWidth = useRef<number>(0);
 	const prefersReducedMotion = usePrefersReducedMotion();
 	const [closeTransitionEnded, setCloseTransitionEnded] = useState(true);
+	const isMounted = useIsMounted();
 
 	useEffect(() => {
 		scrollbarWidth.current =
@@ -88,11 +90,13 @@ export const Drawer: FunctionComponent<DrawerProps> = ({
 	}, [isOpen, handleClose]);
 
 	// Polyfill usage of `aria-modal`
-	const { modalContainerRef } = useAriaModalPolyfill(isOpen);
+	const { modalContainerRef } = useAriaModalPolyfill(
+		!isMounted ? false : isOpen
+	);
 
 	// Since react portals can not be rendered on the server and this component is always closed by default
 	// This component doesn't need to be server side rendered
-	if (!canUseDOM()) return null;
+	if (!isMounted || !canUseDOM()) return null;
 
 	const showDrawer = isOpen ? true : !closeTransitionEnded;
 


### PR DESCRIPTION
It was discovered that the Drawer changes to support React 19 caused hydration match issues when using Next's App Router. They do not surface in the pages router. Or is it a strict mode issue?

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2035)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
