### PR TITLE
combobox: Prevent useIsIos from attempting to run on the server

### DIFF
--- a/.changeset/khaki-balloons-brush.md
+++ b/.changeset/khaki-balloons-brush.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+combobox: Prevent useIsIos from attempting to run on the server.

--- a/packages/react/src/combobox/utils.ts
+++ b/packages/react/src/combobox/utils.ts
@@ -1,5 +1,5 @@
 import { type CSSProperties, useMemo } from 'react';
-import { useId } from '../core';
+import { canUseDOM, useId } from '../core';
 
 export function useComboboxInputId(idProp?: string) {
 	const autoId = useId();
@@ -92,13 +92,16 @@ export function generateHighlightStyles(
 }
 
 export function useIsIos() {
-	const isIos = useMemo(
-		() =>
+	const isIos = useMemo(() => {
+		if (!canUseDOM()) return false;
+
+		return (
 			// See https://github.com/stowball/Layout-Engine/blob/master/layout.engine.js#L86
-			CSS.supports('-webkit-appearance', '-apple-pay-button') &&
-			CSS.supports('-webkit-overflow-scrolling', 'auto'),
-		[]
-	);
+			CSS &&
+			CSS?.supports('-webkit-appearance', '-apple-pay-button') &&
+			CSS?.supports('-webkit-overflow-scrolling', 'auto')
+		);
+	}, []);
 
 	return isIos;
 }


### PR DESCRIPTION
After working on the hydration mismatch issue, I discovered that comboboxes removed those warnings. That didn't feel right, and it turned out it wasn't. The `useIsIos` hook shouldn't have been allowed to run in non-DOM environments (like the server), so it was causing re-rendering issues.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2037)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
