### PR TITLE
table: fix TableRow onHover not applying any styles, update onClick on TableRow when clicking Checkbox

### DIFF
--- a/.changeset/pink-cheetahs-report.md
+++ b/.changeset/pink-cheetahs-report.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-table: Fix `TableRow`'s `onHover` stylings to not be applied when the table layout is not `auto` or `fixed`. Add cursor change on hover row in fixed table.
+table: Fix `TableRow`’s `selected` and hover styles not getting applied when an incorrect `tableLayout` is set. Add `pointer` cursor for clickable rows in fixed tables.

--- a/.changeset/pink-cheetahs-report.md
+++ b/.changeset/pink-cheetahs-report.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+table: Fix `TableRow`'s `onHover` stylings to not be applied when the table layout is not `auto` or `fixed`. Add cursor change on hover row in fixed table.

--- a/.changeset/pink-cheetahs-report.md
+++ b/.changeset/pink-cheetahs-report.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-table: Fix `TableRow`’s `selected` and hover styles not getting applied when an incorrect `tableLayout` is set. Add `pointer` cursor for clickable rows in fixed tables.
+table: Fix `TableRow`’s `selected` and hover styles not getting applied when an incorrect `tableLayout` is set. Add `pointer` cursor for clickable rows in fixed tables.  Update `TableRow`’s `onClick` to disable firing the row function when clicking on a label element.

--- a/packages/react/src/table/TableRow.test.tsx
+++ b/packages/react/src/table/TableRow.test.tsx
@@ -8,6 +8,7 @@ import {
 	render,
 	screen,
 } from '../../../../test-utils';
+import { Checkbox } from '../checkbox';
 import { Table } from './Table';
 import { TableBody } from './TableBody';
 import { TableCaption } from './TableCaption';
@@ -23,7 +24,8 @@ afterEach(cleanup);
 
 function renderTable(
 	onClickTableRow: jest.Mock<unknown> | undefined = undefined,
-	onClickButton: jest.Mock<unknown> | undefined = undefined
+	onClickButton: jest.Mock<unknown> | undefined = undefined,
+	onClickCheckbox: jest.Mock<unknown> | undefined = undefined
 ) {
 	return render(
 		<TableWrapper>
@@ -48,6 +50,15 @@ function renderTable(
 				</TableHead>
 				<TableBody>
 					<TableRow onClick={onClickTableRow}>
+						<TableCell>
+							<Checkbox
+								id="nsw-checkbox"
+								onChange={onClickCheckbox}
+								value="nsw"
+							>
+								Select checkbox
+							</Checkbox>
+						</TableCell>
 						<TableCell as="th" scope="row">
 							New South Wales
 						</TableCell>
@@ -82,6 +93,7 @@ describe('TableRow', () => {
 			extends: ['html-validate:recommended'],
 			rules: {
 				'no-inline-style': 'off',
+				'no-redundant-for': 'off', // disabled for Checkbox component
 			},
 		});
 		expect(await axe(container)).toHaveNoViolations();
@@ -113,6 +125,21 @@ describe('TableRow', () => {
 			});
 
 			expect(mockOnClickButton).toHaveBeenCalledTimes(1);
+			expect(mockOnClickTableRow).toHaveBeenCalledTimes(0);
+		});
+
+		it('does not execute the `onClick` event on the table row when the Checkbox component in a table cell is clicked', async () => {
+			const mockOnClickTableRow = jest.fn(() => null);
+			const mockOnClickCheckbox = jest.fn(() => null);
+
+			renderTable(mockOnClickTableRow, undefined, mockOnClickCheckbox);
+
+			const checkboxElement = screen.getByLabelText('Select checkbox');
+			await act(() => {
+				fireEvent.click(checkboxElement);
+			});
+
+			expect(mockOnClickCheckbox).toHaveBeenCalledTimes(1);
 			expect(mockOnClickTableRow).toHaveBeenCalledTimes(0);
 		});
 	});

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -26,6 +26,7 @@ export function TableRow({
 	selected,
 }: TableRowProps) {
 	const { tableLayout } = useTableContext();
+	const isFixedTable = tableLayout === 'fixed';
 
 	function handleOnClick(event: React.MouseEvent<HTMLTableRowElement>) {
 		// Check if the the target has an interactive parent before running row onClick
@@ -55,7 +56,7 @@ export function TableRow({
 					? backgroundColorMap[background]
 					: undefined,
 				...(selected && {
-					...(tableLayout === 'auto' && {
+					...(!isFixedTable && {
 						backgroundColor: boxPalette.selectedMuted,
 						position: 'relative',
 
@@ -82,7 +83,7 @@ export function TableRow({
 					}),
 				}),
 				...(onClick && {
-					...(tableLayout === 'auto' && {
+					...(!isFixedTable && {
 						position: 'relative',
 
 						'&:hover': {
@@ -114,7 +115,7 @@ export function TableRow({
 				...((selected || onClick) && {
 					// Chrome and Firefox doesn't support ::after elements in fixed table layouts
 					// FIXME Once Chrome Firefox fixes this issue, these alternative styles should be removed
-					...(tableLayout === 'fixed' && {
+					...(isFixedTable && {
 						...(selected && alternativeSelectedStyles),
 						...(onClick && alternativeHoverStyles),
 					}),
@@ -148,6 +149,7 @@ const alternativeSelectedStyles = {
 
 const alternativeHoverStyles = {
 	'&:hover': {
+		cursor: 'pointer',
 		outlineColor: boxPalette.selected,
 		outlineOffset: -tokens.borderWidth.lg,
 		outlineStyle: 'solid',

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -33,7 +33,7 @@ export function TableRow({
 		const targetElement = event.target;
 		if (
 			(targetElement as HTMLElement).closest(
-				'a, button, input, select, textarea'
+				'a, button, input, label, select, textarea'
 			)
 		) {
 			return;

--- a/packages/react/src/table/__snapshots__/TableRow.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableRow.test.tsx.snap
@@ -63,6 +63,50 @@ exports[`TableRow renders correctly 1`] = `
           <tr
             class="css-1tx0oac-TableRow"
           >
+            <td
+              class="css-1qlct29-boxStyles-TableCell"
+            >
+              <label
+                class="css-hp3wbe-boxStyles-CheckboxContainer"
+                for="nsw-checkbox"
+              >
+                <span
+                  class="css-1246v4c-Checkbox"
+                >
+                  <input
+                    class="css-1iw6cs3-CheckboxInput"
+                    id="nsw-checkbox"
+                    type="checkbox"
+                    value="nsw"
+                  />
+                  <span
+                    class="css-5q1w1y-boxStyles-CheckboxIndicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-lewdp2-Icon"
+                      clip-rule="evenodd"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="24"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20 6 9 17l-5-5"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  class="css-1f6xqkn-boxStyles-CheckboxLabel"
+                >
+                  Select checkbox
+                </span>
+              </label>
+            </td>
             <th
               class="css-1qlct29-boxStyles-TableCell"
               scope="row"


### PR DESCRIPTION
There was a bug where if the `tableLayout` prop on `<Table>` component was not exactly `auto` or `fixed`, no hover styles would be applied. Change checking logic to default to `auto`. Additionally the hover mouse cursor was missing from the onHover row for fixed table styled.

There was a bug where clicking on a `<Checkbox>` component would fire the row event. This was because the `input` was not a parent of the clicked target. Added `label` to selection.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2048)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
