### PR TITLE
core: Apply use client directive to only the files that need it

### DIFF
--- a/.changeset/plenty-pens-perform.md
+++ b/.changeset/plenty-pens-perform.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+core: Selectively apply the `'use-client'` directive to only the files that need it.

--- a/packages/react/src/core/Core.tsx
+++ b/packages/react/src/core/Core.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { PropsWithChildren } from 'react';
 import { Global } from '@emotion/react';
 import { goldTheme } from './goldTheme';

--- a/packages/react/src/core/CoreProvider.tsx
+++ b/packages/react/src/core/CoreProvider.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	forwardRef,
 	createContext,

--- a/packages/react/src/core/boxPalette.ts
+++ b/packages/react/src/core/boxPalette.ts
@@ -1,3 +1,4 @@
+'use client';
 import { css } from '@emotion/react';
 import { RefObject, useEffect, useState } from 'react';
 import { themeVars } from './theme';

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -1,4 +1,3 @@
-'use client';
 export * from './Core';
 export * from './CoreProvider';
 export * from './tokens';

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -1,10 +1,47 @@
-export * from './Core';
-export * from './CoreProvider';
-export * from './tokens';
-export * from './packs';
-export * from './utils';
-export * from './theme';
-export * from './goldTheme';
-export * from './boxPalette';
-export * from './globalPalette';
-export * from './responsive';
+export { boxPalette, boxPalettes, useBoxPalette } from './boxPalette';
+export { type BoxPalette } from './boxPalette';
+export { Core } from './Core';
+export { type CoreProps } from './Core';
+export { CoreProvider, coreContext, useLinkComponent } from './CoreProvider';
+export {
+	type CoreProviderProps,
+	type LinkComponent,
+	type LinkProps,
+	type NativeLinkProps,
+} from './CoreProvider';
+export { globalPalette } from './globalPalette';
+export { goldTheme } from './goldTheme';
+export { packs, print } from './packs';
+export { breakpointNames, mapResponsiveProp, mq } from './responsive';
+export { type ResponsiveProp } from './responsive';
+export { mergeTheme, themeVars } from './theme';
+export { mapSpacing, tokens } from './tokens';
+export { type Theme } from './theme';
+export {
+	type BorderWidth,
+	type FieldMaxWidth,
+	type Font,
+	type FontSize,
+	type FontWeight,
+	type LineHeight,
+	type MaxWidth,
+	type Shadow,
+	type Spacing,
+	type ZIndex,
+} from './tokens';
+export {
+	canUseDOM,
+	findBestMatch,
+	fontGrid,
+	forwardRefWithAs,
+	mergeRefs,
+	useAriaModalPolyfill,
+	useClickOutside,
+	useElementSize,
+	useId,
+	usePrefersReducedMotion,
+	useTernaryState,
+	useToggleState,
+	useTransitionHeight,
+	useWindowSize,
+} from './utils';

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -1,23 +1,32 @@
-export { boxPalette, boxPalettes, useBoxPalette } from './boxPalette';
-export { type BoxPalette } from './boxPalette';
-export { Core } from './Core';
-export { type CoreProps } from './Core';
-export { CoreProvider, coreContext, useLinkComponent } from './CoreProvider';
 export {
+	boxPalette,
+	boxPalettes,
+	type BoxPalette,
+	useBoxPalette,
+} from './boxPalette';
+export { Core, type CoreProps } from './Core';
+export {
+	CoreProvider,
+	coreContext,
 	type CoreProviderProps,
 	type LinkComponent,
 	type LinkProps,
 	type NativeLinkProps,
+	useLinkComponent,
 } from './CoreProvider';
 export { globalPalette } from './globalPalette';
 export { goldTheme } from './goldTheme';
 export { packs, print } from './packs';
-export { breakpointNames, mapResponsiveProp, mq } from './responsive';
-export { type ResponsiveProp } from './responsive';
-export { mergeTheme, themeVars } from './theme';
-export { mapSpacing, tokens } from './tokens';
-export { type Theme } from './theme';
 export {
+	breakpointNames,
+	mapResponsiveProp,
+	mq,
+	type ResponsiveProp,
+} from './responsive';
+export { mergeTheme, themeVars, type Theme } from './theme';
+export {
+	mapSpacing,
+	tokens,
 	type BorderWidth,
 	type FieldMaxWidth,
 	type Font,

--- a/packages/react/src/core/packs.ts
+++ b/packages/react/src/core/packs.ts
@@ -1,3 +1,4 @@
+'use client';
 import { boxPalette } from './boxPalette';
 import { mapSpacing, tokens } from './tokens';
 import { fontGrid } from './utils';

--- a/packages/react/src/core/utils/fontGrid.ts
+++ b/packages/react/src/core/utils/fontGrid.ts
@@ -1,4 +1,3 @@
-'use client';
 import { CSSObject } from '@emotion/react';
 import { FontSize, tokens, LineHeight } from '../tokens';
 

--- a/packages/react/src/core/utils/fontGrid.ts
+++ b/packages/react/src/core/utils/fontGrid.ts
@@ -1,3 +1,4 @@
+'use client';
 import { CSSObject } from '@emotion/react';
 import { FontSize, tokens, LineHeight } from '../tokens';
 

--- a/packages/react/src/core/utils/useAriaModalPolyfill.ts
+++ b/packages/react/src/core/utils/useAriaModalPolyfill.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useRef } from 'react';
 
 /**

--- a/packages/react/src/core/utils/useClickOutside.ts
+++ b/packages/react/src/core/utils/useClickOutside.ts
@@ -1,3 +1,4 @@
+'use client';
 import { RefObject, useEffect } from 'react';
 
 /**

--- a/packages/react/src/core/utils/useElementSize.ts
+++ b/packages/react/src/core/utils/useElementSize.ts
@@ -1,3 +1,4 @@
+'use client';
 import { RefObject, useCallback, useEffect, useState } from 'react';
 
 export function useElementSize<T extends HTMLElement = HTMLDivElement>(

--- a/packages/react/src/core/utils/useFocus.ts
+++ b/packages/react/src/core/utils/useFocus.ts
@@ -1,3 +1,4 @@
+'use client';
 import { ForwardedRef, useEffect, useRef } from 'react';
 
 export type UseFocusParams<T> = {

--- a/packages/react/src/core/utils/useId/useId.ts
+++ b/packages/react/src/core/utils/useId/useId.ts
@@ -1,3 +1,4 @@
+'use client';
 /**
  * This file use to just be a simple re-export of `useId` from @reach/auto-id
  * We can not just use `useId` from React as we need to provide support for React 16, 17 and 18

--- a/packages/react/src/core/utils/useId/useIsomorphicLayoutEffect.ts
+++ b/packages/react/src/core/utils/useId/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,4 @@
+'use client';
 // The contents of this file has been copied from https://github.com/reach/reach-ui/blob/dev/packages/utils/src/use-isomorphic-layout-effect.ts
 
 import { useEffect, useLayoutEffect } from 'react';

--- a/packages/react/src/core/utils/useIsMounted.ts
+++ b/packages/react/src/core/utils/useIsMounted.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 
 export function useIsMounted() {

--- a/packages/react/src/core/utils/usePrefersReducedMotion.ts
+++ b/packages/react/src/core/utils/usePrefersReducedMotion.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useState, useEffect } from 'react';
 
 export function usePrefersReducedMotion() {

--- a/packages/react/src/core/utils/useTernaryState.ts
+++ b/packages/react/src/core/utils/useTernaryState.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useCallback, useState } from 'react';
 
 /**

--- a/packages/react/src/core/utils/useToggleState.ts
+++ b/packages/react/src/core/utils/useToggleState.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useState, useCallback } from 'react';
 /**
  * useToggleState

--- a/packages/react/src/core/utils/useTransitionHeight.ts
+++ b/packages/react/src/core/utils/useTransitionHeight.ts
@@ -1,3 +1,4 @@
+'use client';
 import { css } from '@emotion/react';
 import { usePrefersReducedMotion } from './usePrefersReducedMotion';
 

--- a/packages/react/src/core/utils/useWindowSize.ts
+++ b/packages/react/src/core/utils/useWindowSize.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useState, useEffect } from 'react';
 
 type Size = {


### PR DESCRIPTION
When adding things to the new starter kit, I discovered that any time you wanted to use `tokens`, it had to be a client component.

So, instead of adding 1 `'use client'` to main Core export, all of the files that need it have them added and are exported individually so the build works.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2052)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
