### PR TITLE
accordion: Add indent prop to apply horizontal padding to Accordion els

### DIFF
--- a/.changeset/strange-lobsters-enjoy.md
+++ b/.changeset/strange-lobsters-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+accordion: Add `indent` prop to add horizontal padding to `AccordionTitle` and `AccordionBody`.

--- a/.changeset/strange-lobsters-enjoy.md
+++ b/.changeset/strange-lobsters-enjoy.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': minor
 ---
 
-accordion: Add `indent` prop to add horizontal padding to `AccordionTitle` and `AccordionBody`.
+accordion: Add `indent` prop to apply horizontal padding to `AccordionTitle` and `AccordionBody`.

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -651,6 +651,38 @@ const snippets: Array<Snippet> = [
 		</Accordion>`,
 	},
 	{
+		group: 'Accordion',
+		name: 'Indented',
+		code: `<Accordion indent>
+			<AccordionItem title="Accordion">
+				<AccordionItemContent>
+					<Text as="p">This is some text inside an Accordion</Text>
+				</AccordionItemContent>
+			</AccordionItem>
+		</Accordion>`,
+	},
+	{
+		group: 'Accordion',
+		name: 'Group',
+		code: `<Accordion>
+			<AccordionItem title="Accordion title 1">
+				<AccordionItemContent>
+					<Text as="p">This is some text inside an Accordion 1</Text>
+				</AccordionItemContent>
+			</AccordionItem>
+			<AccordionItem title="Accordion title 2">
+				<AccordionItemContent>
+					<Text as="p">This is some text inside an Accordion 2</Text>
+				</AccordionItemContent>
+			</AccordionItem>
+			<AccordionItem title="Accordion title 3">
+				<AccordionItemContent>
+					<Text as="p">This is some text inside an Accordion 3</Text>
+				</AccordionItemContent>
+			</AccordionItem>
+		</Accordion>`,
+	},
+	{
 		group: 'ProgressIndicator',
 		name: 'Basic',
 		code: `<ProgressIndicator
@@ -1045,7 +1077,7 @@ const snippets: Array<Snippet> = [
 							<TableHeader scope="col">Actions</TableHeader>
 						</TableRow>
 					</TableHead>
-					<TableBody>		
+					<TableBody>
 						<TableRow selected={false}>
 							<TableCell>
 								<Checkbox
@@ -1079,7 +1111,7 @@ const snippets: Array<Snippet> = [
 								</Flex>
 							</TableCell>
 						</TableRow>
-						
+
 						<TableRow selected={false}>
 							<TableCell>
 								<Checkbox

--- a/packages/react/src/accordion/Accordion.stories.tsx
+++ b/packages/react/src/accordion/Accordion.stories.tsx
@@ -20,11 +20,15 @@ export default meta;
 
 type AccordionTemplateProps = {
 	background: 'body' | 'bodyAlt';
+	indent?: boolean;
 };
 
-const AccordionBasicTemplate = ({ background }: AccordionTemplateProps) => (
+const AccordionBasicTemplate = ({
+	background,
+	indent,
+}: AccordionTemplateProps) => (
 	<Box background={background} padding={1.5}>
-		<Accordion>
+		<Accordion indent={indent}>
 			<AccordionItem background={background} title="Accordion title">
 				<AccordionItemContent>
 					<Text as="p">This is some text inside an Accordion</Text>
@@ -38,14 +42,21 @@ export const Basic: Story = {
 	render: () => <AccordionBasicTemplate background="body" />,
 };
 
+export const Indented: Story = {
+	render: () => <AccordionBasicTemplate background="body" indent />,
+};
+
 export const onBodyAlt: Story = {
 	render: () => <AccordionBasicTemplate background="bodyAlt" />,
 	name: 'On bodyAlt background',
 };
 
-const AccordionGroupTemplate = ({ background }: AccordionTemplateProps) => (
+const AccordionGroupTemplate = ({
+	background,
+	indent,
+}: AccordionTemplateProps) => (
 	<Box background={background} padding={1.5}>
-		<Accordion>
+		<Accordion indent={indent}>
 			<AccordionItem background={background} title="Accordion 1">
 				<AccordionItemContent>
 					<Text as="p">This is some text inside an Accordion</Text>
@@ -96,6 +107,10 @@ const AccordionGroupTemplate = ({ background }: AccordionTemplateProps) => (
 
 export const Group: Story = {
 	render: () => <AccordionGroupTemplate background="body" />,
+};
+
+export const GroupIndented: Story = {
+	render: () => <AccordionGroupTemplate background="body" indent />,
 };
 
 export const GroupOnBodyAlt: Story = {

--- a/packages/react/src/accordion/Accordion.tsx
+++ b/packages/react/src/accordion/Accordion.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from 'react';
 import { Box } from '../box';
 
-export type AccordionProps = { children: ReactNode };
+export type AccordionProps = { children: ReactNode; indent?: boolean };
 
-export const Accordion = ({ children }: AccordionProps) => (
-	<Box borderTop width="100%">
+export const Accordion = ({ children, indent }: AccordionProps) => (
+	<Box borderTop data-accordion-indent={indent || undefined} width="100%">
 		{children}
 	</Box>
 );

--- a/packages/react/src/accordion/AccordionBody.tsx
+++ b/packages/react/src/accordion/AccordionBody.tsx
@@ -1,5 +1,5 @@
 import { type PropsWithChildren, useRef } from 'react';
-import { packs, useTransitionHeight } from '../core';
+import { mapSpacing, packs, useTransitionHeight } from '../core';
 
 export type AccordionBodyProps = PropsWithChildren<{
 	ariaLabelledBy: string;
@@ -20,7 +20,16 @@ export const AccordionBody = ({
 	return (
 		<div
 			aria-labelledby={ariaLabelledBy}
-			css={[transitionHeightStyles, packs.print.visible]}
+			css={[
+				{
+					'[data-accordion-indent="true"] &': {
+						paddingLeft: mapSpacing(1.5),
+						paddingRight: mapSpacing(1.5),
+					},
+				},
+				transitionHeightStyles,
+				packs.print.visible,
+			]}
 			id={id}
 			role="region"
 			{...transitionHeightProp}

--- a/packages/react/src/accordion/AccordionTitle.tsx
+++ b/packages/react/src/accordion/AccordionTitle.tsx
@@ -1,7 +1,7 @@
 import { MouseEventHandler, PropsWithChildren } from 'react';
 import { Box } from '../box';
 import { Flex } from '../flex';
-import { tokens } from '../core';
+import { mapSpacing, tokens } from '../core';
 import { ChevronDownIcon } from '../icon';
 import { BaseButton } from '../button/';
 import { hoverColorMap, AccordionBackground } from './utils';
@@ -34,6 +34,10 @@ export const AccordionTitle = ({
 				background={background}
 				color="action"
 				css={{
+					'[data-accordion-indent="true"] &': {
+						paddingLeft: mapSpacing(1.5),
+						paddingRight: mapSpacing(1.5),
+					},
 					'&:hover': {
 						backgroundColor: hoverColorMap[background],
 					},

--- a/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react/src/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r0:-body"
           aria-expanded="false"
-          class="css-1y8bkn8-BaseButton-boxStyles-AccordionTitle"
+          class="css-1px078u-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r0:-title"
           type="button"
         >
@@ -39,7 +39,7 @@ exports[`Accordion renders correctly 1`] = `
       </h3>
       <div
         aria-labelledby="accordion-:r0:-title"
-        class="css-16v4kax-useTransitionHeight-AccordionBody"
+        class="css-bpynof-useTransitionHeight-AccordionBody"
         data-transition-height="collapsed"
         id="accordion-:r0:-body"
         role="region"
@@ -66,7 +66,7 @@ exports[`Accordion renders correctly 1`] = `
         <button
           aria-controls="accordion-:r1:-body"
           aria-expanded="false"
-          class="css-1y8bkn8-BaseButton-boxStyles-AccordionTitle"
+          class="css-1px078u-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r1:-title"
           type="button"
         >
@@ -91,7 +91,7 @@ exports[`Accordion renders correctly 1`] = `
       </h3>
       <div
         aria-labelledby="accordion-:r1:-title"
-        class="css-16v4kax-useTransitionHeight-AccordionBody"
+        class="css-bpynof-useTransitionHeight-AccordionBody"
         data-transition-height="collapsed"
         id="accordion-:r1:-body"
         role="region"
@@ -127,7 +127,7 @@ exports[`Accordion to have correct aria attributes when toggling accordion item 
         <button
           aria-controls="accordion-:r4:-body"
           aria-expanded="true"
-          class="css-1y8bkn8-BaseButton-boxStyles-AccordionTitle"
+          class="css-1px078u-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r4:-title"
           type="button"
         >
@@ -152,7 +152,7 @@ exports[`Accordion to have correct aria attributes when toggling accordion item 
       </h3>
       <div
         aria-labelledby="accordion-:r4:-title"
-        class="css-16v4kax-useTransitionHeight-AccordionBody"
+        class="css-bpynof-useTransitionHeight-AccordionBody"
         data-transition-height="expanded"
         id="accordion-:r4:-body"
         role="region"
@@ -179,7 +179,7 @@ exports[`Accordion to have correct aria attributes when toggling accordion item 
         <button
           aria-controls="accordion-:r5:-body"
           aria-expanded="false"
-          class="css-1y8bkn8-BaseButton-boxStyles-AccordionTitle"
+          class="css-1px078u-BaseButton-boxStyles-AccordionTitle"
           id="accordion-:r5:-title"
           type="button"
         >
@@ -204,7 +204,7 @@ exports[`Accordion to have correct aria attributes when toggling accordion item 
       </h3>
       <div
         aria-labelledby="accordion-:r5:-title"
-        class="css-16v4kax-useTransitionHeight-AccordionBody"
+        class="css-bpynof-useTransitionHeight-AccordionBody"
         data-transition-height="collapsed"
         id="accordion-:r5:-body"
         role="region"

--- a/packages/react/src/accordion/docs/overview.mdx
+++ b/packages/react/src/accordion/docs/overview.mdx
@@ -139,7 +139,7 @@ Users can choose what content they want to see.
 
 ## Indented accordion
 
-The `indent` prop of the the accordion adds padding to the left and right of the label and content. This separates it from the edge of the container and can help to show hierarchy in complex layouts.
+The `indent` prop of the the accordion adds padding to the left and right of the title and content. This separates it from the edge of the container and can also help to show hierarchy in complex layouts.
 
 ```jsx live enableProse
 <Accordion indent>

--- a/packages/react/src/accordion/docs/overview.mdx
+++ b/packages/react/src/accordion/docs/overview.mdx
@@ -137,11 +137,75 @@ Users can choose what content they want to see.
 </Accordion>
 ```
 
+## Indented accordion
+
+The `indent` prop of the the accordion adds padding to the left and right of the label and content. This separates it from the edge of the container and can help to show hierarchy in complex layouts.
+
+```jsx live enableProse
+<Accordion indent>
+	<AccordionItem title="Accordion 1">
+		<AccordionItemContent>
+			<Prose>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce a
+					libero vel dolor sollicitudin pretium quis quis mi. Fusce sapien mi,
+					efficitur sit amet ex et, bibendum efficitur odio. Ut nec gravida
+					metus, nec suscipit nulla. Donec est nulla, dictum sed ultricies
+					congue, suscipit at velit. Integer ut leo lectus. Nullam volutpat ex
+					quis imperdiet scelerisque. Etiam ultrices et nisi eget pulvinar. Cras
+					ultrices lectus ut nisl gravida, eu rutrum sem luctus. Praesent
+					vulputate eu dolor commodo tempor. Sed nec lorem consectetur, maximus
+					justo at, tincidunt quam. Suspendisse pellentesque accumsan accumsan.
+					Cras in odio leo. Nam pharetra, lorem eget aliquam gravida, felis ex
+					tempor sapien, a ornare leo nulla eget magna. Quisque tempus ipsum eu
+					elit bibendum, nec bibendum ligula posuere. Nam porttitor est eros, ac
+					maximus nisl euismod nec.
+				</p>
+			</Prose>
+		</AccordionItemContent>
+	</AccordionItem>
+	<AccordionItem title="Accordion 2">
+		<AccordionItemContent>
+			<Prose>
+				<p>
+					Curabitur urna erat, ornare in nulla vitae, tempor porttitor dolor.
+					Nam luctus fermentum tellus, vitae maximus turpis viverra eget.
+					Phasellus hendrerit tortor eu mauris ultricies congue. Suspendisse
+					cursus, purus quis viverra pharetra, purus quam hendrerit magna,
+					condimentum cursus massa nisi ut est. Mauris in tristique augue.
+					Phasellus tellus ante, fermentum eget fringilla eget, tempor nec nunc.
+					Ut nec dui vitae ex dignissim tempus ac et ante. Donec imperdiet
+					suscipit leo. Suspendisse mattis quis nisl id mattis. Sed dictum
+					tempus nibh, quis feugiat magna efficitur in. Sed vulputate et dui eu
+					malesuada.
+				</p>
+			</Prose>
+		</AccordionItemContent>
+	</AccordionItem>
+	<AccordionItem title="Accordion 3">
+		<AccordionItemContent>
+			<Prose>
+				<p>
+					Curabitur urna erat, ornare in nulla vitae, tempor porttitor dolor.
+					Nam luctus fermentum tellus, vitae maximus turpis viverra eget.
+					Phasellus hendrerit tortor eu mauris ultricies congue. Suspendisse
+					cursus, purus quis viverra pharetra, purus quam hendrerit magna,
+					condimentum cursus massa nisi ut est. Mauris in tristique augue.
+					Phasellus tellus ante, fermentum eget fringilla eget, tempor nec nunc.
+					Ut nec dui vitae ex dignissim tempus ac et ante. Donec imperdiet
+					suscipit leo. Suspendisse mattis quis nisl id mattis. Sed dictum
+					tempus nibh, quis feugiat magna efficitur in. Sed vulputate et dui eu
+					malesuada.
+				</p>
+			</Prose>
+		</AccordionItemContent>
+	</AccordionItem>
+</Accordion>
+```
+
 ## Accordion edge-to-edge image
 
 An accordion can open to reveal an image the full width of the panel.
-
-Remove the default padding from the accordion to display an edge-to-edge image.
 
 This text is wrapped in the `AccordionContent` component.
 


### PR DESCRIPTION
This adds an indent prop to inset the title and body content of accordions.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2068)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
