### PR TITLE
yourgov: Bypass auth to allow navigating through the app

### DIFF
--- a/.changeset/wicked-grapes-hammer.md
+++ b/.changeset/wicked-grapes-hammer.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/yourgov': minor
+---
+
+yourgov: Bypass auth to allow navigating through the app.

--- a/yourgov/lib/useAuth.tsx
+++ b/yourgov/lib/useAuth.tsx
@@ -5,6 +5,7 @@ import {
 	useContext,
 	PropsWithChildren,
 } from 'react';
+import { mockUser } from '../data/mockUsers';
 import { safeSessionStorage } from './useSessionFormState';
 
 export type User = {
@@ -38,6 +39,10 @@ export function AuthProvider({ children }: PropsWithChildren<{}>) {
 
 	useEffect(() => {
 		if (!safeSessionStorage) return;
+
+		// MAINTENANCE MODE: Bypass auth to allow navigating through the app
+		signIn(mockUser);
+
 		const value = safeSessionStorage.getItem('user');
 		const parsedValue = value ? (JSON.parse(value) as User) : null;
 		setUserState(parsedValue);

--- a/yourgov/lib/useLinkedBusinesses.tsx
+++ b/yourgov/lib/useLinkedBusinesses.tsx
@@ -40,6 +40,10 @@ export function LinkedBusinessesProvider({ children }: PropsWithChildren<{}>) {
 
 	useEffect(() => {
 		if (!safeSessionStorage) return;
+
+		// MAINTENANCE MODE: Bypass auth to allow navigating through the app
+		setSelectedBusiness(mockBusinesses[0]);
+
 		const value = safeSessionStorage.getItem('selectedBusiness');
 		const parsedValue = value ? (JSON.parse(value) as Business) : null;
 		setSelectedBusinessState(parsedValue);


### PR DESCRIPTION
To allow our new pattern demos to link to sections, set auth and the selected business by default. Login and logout still work should you want to use them and test those flows. Reloading the page would immediately log back in

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2069/yourgov)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
