### PR TITLE
app-layout, side-nav: Simplify announcements of parent links

### DIFF
--- a/.changeset/dull-steaks-do.md
+++ b/.changeset/dull-steaks-do.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+app-layout: `AppLayoutSidebar` - Simplify announcements of parent links.
+
+side-nav: Simplify announcements of parent links.

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.test.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.test.tsx
@@ -109,7 +109,7 @@ describe('Given AppLayoutSidebarNav is rendered', () => {
 			test('then it should be the current page', () => {
 				expect(
 					screen.getByRole('link', {
-						name: 'Establishments . Sub-level links below.',
+						name: 'Establishments, has expanded sub links',
 						current: 'page',
 					})
 				).toBeVisible();

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -9,7 +9,7 @@ import {
 } from '../core';
 import { Box, focusStyles } from '../box';
 import { BaseButton, BaseButtonProps } from '../button';
-import { ChevronDownIcon, ChevronRightIcon, IconProps } from '../icon';
+import { ChevronRightIcon, IconProps } from '../icon';
 import { Stack } from '../stack';
 import { useAppLayoutContext } from './AppLayoutContext';
 import { AppLayoutSidebarProps } from './AppLayoutSidebar';

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -167,6 +167,13 @@ function AppLayoutSidebarNavListItem({
 			>
 				<Link
 					aria-current={isCurrentPage ? 'page' : undefined}
+					aria-label={
+						hasSubLevelItemsIndicator
+							? `${label}${
+									isActive ? ', has expanded sub links' : ', has sub links'
+							  }`
+							: undefined
+					}
 					{...(restItemProps as NavLink)}
 				>
 					{Icon && level === 1 && <Icon color="inherit" />}
@@ -177,24 +184,12 @@ function AppLayoutSidebarNavListItem({
 
 					{endElement}
 
-					{hasSubLevelItemsIndicator &&
-						(isActive ? (
-							<ChevronDownIcon
-								aria-hidden={false}
-								aria-label={`. Sub-level ${
-									numberOfItems === 1 ? 'link' : 'links'
-								} below.`}
-								size="md"
-							/>
-						) : (
-							<ChevronRightIcon
-								aria-hidden={false}
-								aria-label={`. Has ${numberOfItems} sub-level ${
-									numberOfItems === 1 ? 'link' : 'links'
-								}.`}
-								size="md"
-							/>
-						))}
+					{hasSubLevelItemsIndicator && (
+						<ChevronRightIcon
+							css={{ transform: isActive ? 'rotate(90deg)' : undefined }}
+							size="md"
+						/>
+					)}
 				</Link>
 
 				{Boolean(item.items?.length) && (isOpen || isCurrentPage) && (

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -335,6 +335,7 @@ exports[`AppLayout renders correctly 1`] = `
           >
             <a
               aria-current="page"
+              aria-label="Establishments, has expanded sub links"
               href="/establishments"
             >
               <svg
@@ -359,9 +360,8 @@ exports[`AppLayout renders correctly 1`] = `
                 Establishments
               </span>
               <svg
-                aria-hidden="false"
-                aria-label=". Sub-level links below."
-                class="css-lq07bo-Icon"
+                aria-hidden="true"
+                class="css-bisuz9-AppLayoutSidebarNavListItem"
                 clip-rule="evenodd"
                 fill-rule="evenodd"
                 focusable="false"
@@ -372,7 +372,7 @@ exports[`AppLayout renders correctly 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="m6 9 6 6 6-6"
+                  d="m9 18 6-6-6-6"
                 />
               </svg>
             </a>
@@ -450,6 +450,7 @@ exports[`AppLayout renders correctly 1`] = `
             class="css-1oxkyzz-AppLayoutSidebarNavItemInner"
           >
             <a
+              aria-label="Compliance, has sub links"
               href="/compliance"
             >
               <svg
@@ -477,9 +478,8 @@ exports[`AppLayout renders correctly 1`] = `
                 Compliance
               </span>
               <svg
-                aria-hidden="false"
-                aria-label=". Has 2 sub-level links."
-                class="css-lq07bo-Icon"
+                aria-hidden="true"
+                class="css-11xq89r-AppLayoutSidebarNavListItem"
                 clip-rule="evenodd"
                 fill-rule="evenodd"
                 focusable="false"

--- a/packages/react/src/app-layout/__snapshots__/AppLayoutSidebarNav.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayoutSidebarNav.test.tsx.snap
@@ -108,6 +108,7 @@ exports[`Given AppLayoutSidebarNav is rendered when subLevelVisible is "whenActi
         class="css-1u5pc1o-AppLayoutSidebarNavItemInner"
       >
         <a
+          aria-label="Establishments, has expanded sub links"
           href="/establishments"
         >
           <svg
@@ -132,9 +133,8 @@ exports[`Given AppLayoutSidebarNav is rendered when subLevelVisible is "whenActi
             Establishments
           </span>
           <svg
-            aria-hidden="false"
-            aria-label=". Sub-level links below."
-            class="css-lq07bo-Icon"
+            aria-hidden="true"
+            class="css-bisuz9-AppLayoutSidebarNavListItem"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -145,7 +145,7 @@ exports[`Given AppLayoutSidebarNav is rendered when subLevelVisible is "whenActi
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="m6 9 6 6 6-6"
+              d="m9 18 6-6-6-6"
             />
           </svg>
         </a>
@@ -224,6 +224,7 @@ exports[`Given AppLayoutSidebarNav is rendered when subLevelVisible is "whenActi
         class="css-1oxkyzz-AppLayoutSidebarNavItemInner"
       >
         <a
+          aria-label="Compliance, has sub links"
           href="/compliance"
         >
           <svg
@@ -251,9 +252,8 @@ exports[`Given AppLayoutSidebarNav is rendered when subLevelVisible is "whenActi
             Compliance
           </span>
           <svg
-            aria-hidden="false"
-            aria-label=". Has 2 sub-level links."
-            class="css-lq07bo-Icon"
+            aria-hidden="true"
+            class="css-11xq89r-AppLayoutSidebarNavListItem"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -151,7 +151,7 @@ describe('SideNav', () => {
 				});
 
 				test('aria-labels indicating hidden sub links should exist', async () => {
-					expect(screen.getAllByLabelText(', has sub links')).toHaveLength(2);
+					expect(screen.getAllByLabelText(/, has sub links/)).toHaveLength(2);
 				});
 			});
 

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -151,7 +151,7 @@ describe('SideNav', () => {
 				});
 
 				test('aria-labels indicating hidden sub links should exist', async () => {
-					expect(screen.getAllByLabelText(/\, has sub links/)).toHaveLength(2);
+					expect(screen.getAllByLabelText(/, has sub links/)).toHaveLength(2);
 				});
 			});
 

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import { act, render, screen, within } from '../../../../test-utils';
+import { act, render, screen } from '../../../../test-utils';
 import { SideNav, SideNavProps } from './SideNav';
 import { alwaysOpenItems, defaultTestingProps } from './test-utils';
 

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -193,7 +193,7 @@ describe('SideNav', () => {
 					expect(navItemPathnames).toEqual(itemHrefs);
 				});
 
-				test('aria-labels indicating visibe sub links should exist', async () => {
+				test('aria-labels indicating visible sub links should exist', async () => {
 					expect(
 						screen.getByLabelText('Lodge online, has sub links')
 					).toBeTruthy();

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -150,12 +150,8 @@ describe('SideNav', () => {
 					expect(navItemPathnames).toEqual(levelOneItemHrefs);
 				});
 
-				test('icons indicating hidden sub-level items should be visible', async () => {
-					expect(
-						await screen.findAllByRole('img', {
-							name: /. Has [2-9] sub-level links.|. Has 1 sub-level link./,
-						})
-					).toHaveLength(2);
+				test('aria-labels indicating hidden sub links should exist', async () => {
+					expect(screen.getAllByLabelText(/\, has sub links/)).toHaveLength(2);
 				});
 			});
 
@@ -197,12 +193,10 @@ describe('SideNav', () => {
 					expect(navItemPathnames).toEqual(itemHrefs);
 				});
 
-				test('an icon indicating visible sub-level items should be visible', async () => {
+				test('aria-labels indicating visibe sub links should exist', async () => {
 					expect(
-						await screen.findByRole('img', {
-							name: '. Sub-level links below.',
-						})
-					).toBeVisible();
+						screen.getByLabelText('Lodge online, has sub links')
+					).toBeTruthy();
 				});
 			});
 
@@ -250,89 +244,6 @@ describe('SideNav', () => {
 						.filter((href) => href !== '/'); // Remove the heading's link
 
 					expect(navItemPathnames).toEqual(itemHrefs);
-				});
-
-				// Skipping because this is failing only in CI
-				test.skip('an icon indicating visible sub-level items should be visible', async () => {
-					const link = await screen.findByRole('link', {
-						name: 'Record keeping. Sub-level links below.',
-					});
-
-					const chevronIcon = within(link).getByRole('img', {
-						name: '. Sub-level links below.',
-					});
-
-					expect(chevronIcon).toBeVisible();
-				});
-
-				// Skipping because this is failing only in CI
-				test.skip('its parent should have an icon indicating visible sub-level items', async () => {
-					const link = await screen.findByRole('link', {
-						name: 'In detail. Sub-level links below.',
-					});
-
-					const chevronIcon = within(link).getByRole('img', {
-						name: '. Sub-level links below.',
-					});
-
-					expect(chevronIcon).toBeVisible();
-				});
-			});
-
-			describe('when the active item is level three and has no sub-level items', () => {
-				beforeEach(() => {
-					render(
-						<SideNav
-							{...defaultTestingProps}
-							activePath="/in-detail/record-keeping/tax"
-							subLevelVisible="whenActive"
-						/>
-					);
-
-					const user = userEvent.setup();
-
-					user.click(
-						screen.getByRole('button', {
-							name: `${defaultTestingProps.title}`,
-						})
-					);
-				});
-
-				// Skipping because this is failing only in CI
-				test.skip('no icon indicating visible sub-level items should be visible', async () => {
-					const link = await screen.findByRole('link', {
-						name: 'Keeping your tax records',
-					});
-
-					const chevronIcon = within(link).queryByRole('img');
-
-					expect(chevronIcon).toBeNull();
-				});
-
-				// Skipping because this is failing only in CI
-				test.skip('its parent should have an icon indicating visible sub-level items', async () => {
-					const link = await screen.findByRole('link', {
-						name: 'Record keeping. Sub-level links below.',
-					});
-
-					const chevronIcon = within(link).getByRole('img', {
-						name: '. Sub-level links below.',
-					});
-
-					expect(chevronIcon).toBeVisible();
-				});
-
-				// Skipping because this is failing only in CI
-				test.skip('its grandparent should have an icon indicating visible sub-level items', async () => {
-					const link = await screen.findByRole('link', {
-						name: 'In detail. Sub-level links below.',
-					});
-
-					const chevronIcon = within(link).getByRole('img', {
-						name: '. Sub-level links below.',
-					});
-
-					expect(chevronIcon).toBeVisible();
 				});
 			});
 		});

--- a/packages/react/src/side-nav/SideNav.test.tsx
+++ b/packages/react/src/side-nav/SideNav.test.tsx
@@ -151,7 +151,7 @@ describe('SideNav', () => {
 				});
 
 				test('aria-labels indicating hidden sub links should exist', async () => {
-					expect(screen.getAllByLabelText(/, has sub links/)).toHaveLength(2);
+					expect(screen.getAllByLabelText(', has sub links')).toHaveLength(2);
 				});
 			});
 

--- a/packages/react/src/side-nav/SideNavLink.tsx
+++ b/packages/react/src/side-nav/SideNavLink.tsx
@@ -17,14 +17,12 @@ export const SideNavLink = ({
 	isCurrentPage,
 	isOpen,
 	label,
-	numberOfItems,
 	...props
 }: Omit<SideNavLinkProps, 'subLevelVisible'> & {
 	hasSubLevelItemsIndicator?: boolean;
 	isCurrentPage?: boolean;
 	isOpen: boolean;
 	label: ReactNode;
-	numberOfItems: number;
 }) => {
 	const Link = useLinkComponent();
 	const depth = useLinkListDepth();
@@ -32,6 +30,11 @@ export const SideNavLink = ({
 	return (
 		<Flex
 			aria-current={isCurrentPage ? 'page' : undefined}
+			aria-label={
+				hasSubLevelItemsIndicator
+					? `${label}${isOpen ? ', has expanded sub links' : ', has sub links'}`
+					: undefined
+			}
 			as={Link}
 			borderBottom
 			borderBottomWidth="sm"
@@ -79,14 +82,6 @@ export const SideNavLink = ({
 
 			{hasSubLevelItemsIndicator && (
 				<ChevronRightIcon
-					aria-hidden={false}
-					aria-label={
-						isOpen
-							? `. Sub-level ${numberOfItems === 1 ? 'link' : 'links'} below.`
-							: `. Has ${numberOfItems} sub-level ${
-									numberOfItems === 1 ? 'link' : 'links'
-							  }.`
-					}
 					css={{
 						transform: isOpen ? 'rotate(90deg)' : undefined,
 						...(depth > 1

--- a/packages/react/src/side-nav/SideNavLinkList.tsx
+++ b/packages/react/src/side-nav/SideNavLinkList.tsx
@@ -97,7 +97,6 @@ const LinkList = ({
 							isCurrentPage={item.href === activePath}
 							isOpen={isOpen(items, isActive)}
 							key={item.href}
-							numberOfItems={numberOfItems}
 							{...item}
 						/>
 

--- a/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`SideNav renders correctly 1`] = `
               class="css-0"
             >
               <a
+                aria-label="Lodge online, has sub links"
                 class="css-1xapbrs-boxStyles-SideNavLink"
                 href="/lodge-online"
               >
@@ -126,8 +127,7 @@ exports[`SideNav renders correctly 1`] = `
                   Lodge online
                 </span>
                 <svg
-                  aria-hidden="false"
-                  aria-label=". Has 1 sub-level link."
+                  aria-hidden="true"
                   class="css-o9hgvz-SideNavLink"
                   clip-rule="evenodd"
                   fill-rule="evenodd"
@@ -177,6 +177,7 @@ exports[`SideNav renders correctly 1`] = `
             >
               <a
                 aria-current="page"
+                aria-label="In detail, has expanded sub links"
                 class="css-johbbs-boxStyles-SideNavLink"
                 href="/in-detail"
               >
@@ -186,8 +187,7 @@ exports[`SideNav renders correctly 1`] = `
                   In detail
                 </span>
                 <svg
-                  aria-hidden="false"
-                  aria-label=". Sub-level links below."
+                  aria-hidden="true"
                   class="css-1759y9a-SideNavLink"
                   clip-rule="evenodd"
                   fill-rule="evenodd"
@@ -210,6 +210,7 @@ exports[`SideNav renders correctly 1`] = `
                   class="css-0"
                 >
                   <a
+                    aria-label="Record keeping, has sub links"
                     class="css-esqyjf-boxStyles-SideNavLink"
                     href="/in-detail/record-keeping"
                   >
@@ -224,8 +225,7 @@ exports[`SideNav renders correctly 1`] = `
                       Record keeping
                     </span>
                     <svg
-                      aria-hidden="false"
-                      aria-label=". Has 2 sub-level links."
+                      aria-hidden="true"
                       class="css-1n1bumd-SideNavLink"
                       clip-rule="evenodd"
                       fill-rule="evenodd"


### PR DESCRIPTION
Our a11y user testing found the announcements of our parent chevrons weird. They were on a different element, so could be reached twice, and the full stop would be read as "dot". NVDA was particularly annoying.

This PR changes them so that the SVG is hidden, and `aria-label` is used. This has the benefit of announcing the change to the label when you activate the link so users now know it's been expanded (tested in NVDA)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2072)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
