### PR TITLE
conditional-field-container: Update to use left border. Modify Field

### DIFF
--- a/.changeset/few-apples-breathe.md
+++ b/.changeset/few-apples-breathe.md
@@ -1,0 +1,10 @@
+---
+'@ag.ds-next/react': minor
+'@ag.ds-next/docs': minor
+---
+
+conditional-field-container: Update style to use a left border instead of a horizontal divider.
+
+field: `<FieldContainer>`: Update style to support invalid fields within `<ConditionalFieldContainer>`.
+
+grouped-fields: Update style to support invalid fields within `<ConditionalFieldContainer>`.

--- a/docs/content/patterns/conditional-reveal/index.mdx
+++ b/docs/content/patterns/conditional-reveal/index.mdx
@@ -195,7 +195,7 @@ If there a small number of items, use [Radio](/components/radio) instead.
 
 ## Invalid
 
-When a conditionally revealed question is invalid, include an error message on the invalid field that is clearly related to the initial question.
+When a conditionally revealed field is invalid, its left border is automatically changed to the error colour token. The indentation remains unchanged to maintain the visual alignment and preserve horizontal space.
 
 ```jsx live
 () => {

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`Autocomplete renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`Combobox renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`ComboboxAsync renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`ComboboxAsyncMulti renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`ComboboxMulti renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/conditional-field-container/ConditionalFieldContainer.tsx
+++ b/packages/react/src/conditional-field-container/ConditionalFieldContainer.tsx
@@ -1,6 +1,5 @@
 import { PropsWithChildren } from 'react';
-import { Divider } from '../divider';
-import { FormStack } from '../form-stack';
+import { Flex } from '../flex';
 
 export type ConditionalFieldContainerProps = PropsWithChildren<{
 	/** Controls the visibility and render state of the children */
@@ -16,9 +15,20 @@ export function ConditionalFieldContainer({
 	}
 
 	return (
-		<FormStack>
-			<Divider />
+		// Duplicates FormStack's spacing with additional properties
+		<Flex
+			{...{ [CONDITIONAL_FIELD_CONTAINER_DATA_ATTR]: true }}
+			borderColor="muted"
+			borderLeft
+			borderLeftWidth="xl"
+			flexDirection="column"
+			gap={2}
+			paddingLeft={1}
+		>
 			{children}
-		</FormStack>
+		</Flex>
 	);
 }
+
+export const CONDITIONAL_FIELD_CONTAINER_DATA_ATTR =
+	'data-conditional-field-container';

--- a/packages/react/src/conditional-field-container/__snapshots__/ConditionalFieldContainer.test.tsx.snap
+++ b/packages/react/src/conditional-field-container/__snapshots__/ConditionalFieldContainer.test.tsx.snap
@@ -8,12 +8,9 @@ exports[`ConditionalFieldContainer renders correctly 1`] = `
     Toggle visibility
   </button>
   <div
-    class="css-h0krvw-boxStyles"
+    class="css-2j0r52-boxStyles"
+    data-conditional-field-container="true"
   >
-    <hr
-      aria-hidden="true"
-      class="css-1th2zfi-Divider"
-    />
     <p
       data-testid="child-element"
     >

--- a/packages/react/src/conditional-field-container/docs/overview.mdx
+++ b/packages/react/src/conditional-field-container/docs/overview.mdx
@@ -223,3 +223,80 @@ If you require more than one field and/or content, place all relevant elements a
 	);
 };
 ```
+
+## Invalid fields
+
+When a conditionally revealed field is invalid, its left border is automatically changed to the error colour token. The indentation remains unchanged to maintain the visual alignment and preserve horizontal space.
+
+```jsx live
+<Stack gap={1}>
+	<ConditionalFieldContainer visible>
+		<TextInput
+			invalid
+			message="Text input is required"
+			label="Text input"
+			required
+			type="email"
+		/>
+
+		<DateRangePickerNext
+			value={{ from: undefined, to: undefined }}
+			onChange={console.log}
+			fromInvalid={true}
+			toInvalid={true}
+			legend="Date range picker 1"
+			message="Enter valid start and end dates"
+		/>
+
+		<DateRangePickerNext
+			value={{ from: undefined, to: undefined }}
+			onChange={console.log}
+			fromInvalid={true}
+			toInvalid={false}
+			legend="Date range picker 2"
+			message="Enter a valid start date"
+		/>
+
+		<DateRangePickerNext
+			value={{ from: undefined, to: undefined }}
+			onChange={console.log}
+			fromInvalid={false}
+			toInvalid={true}
+			legend="Date range picker 3"
+			message="Enter a valid end date"
+		/>
+
+		<GroupedFields legend="Grouped fields">
+			{({ field1Props, field2Props }) => (
+				<>
+					<TextInput
+						invalid
+						required
+						message="Weight is required"
+						label="Weight"
+						{...field1Props}
+					/>
+					<TextInput
+						invalid
+						required
+						message="Size is required"
+						label="Size"
+						{...field2Props}
+					/>
+				</>
+			)}
+		</GroupedFields>
+
+		<ControlGroup
+			label="Control group"
+			message="Please choose an option"
+			invalid
+			block
+		>
+			<Checkbox>Phone</Checkbox>
+			<Checkbox>Tablet</Checkbox>
+			<Checkbox>Laptop</Checkbox>
+		</ControlGroup>
+	</ConditionalFieldContainer>
+</Stack>
+```

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
     id="control-group-:r0:"
   >
     <fieldset
@@ -208,7 +209,8 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
 exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
     id="control-group-:ri:"
   >
     <fieldset
@@ -461,7 +463,8 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
 exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
     id="control-group-:rc:"
   >
     <fieldset
@@ -667,7 +670,8 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
 exports[`ControlGroup  With Radios renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
     id="control-group-:r14:"
   >
     <fieldset
@@ -820,7 +824,8 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
 exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
     id="control-group-:r1m:"
   >
     <fieldset
@@ -1021,7 +1026,8 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
 exports[`ControlGroup  With Radios renders correctly when required 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
     id="control-group-:r1g:"
   >
     <fieldset

--- a/packages/react/src/field/FieldContainer.tsx
+++ b/packages/react/src/field/FieldContainer.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren } from 'react';
 import { Stack } from '../stack';
-import { boxPalette } from '../core';
+import { boxPalette, mapSpacing, tokens } from '../core';
+import { CONDITIONAL_FIELD_CONTAINER_DATA_ATTR } from '../conditional-field-container';
+import { GROUPED_FIELDS_DATA_ATTR } from '../grouped-fields';
 
 export type FieldContainerProps = PropsWithChildren<{
 	/** If true, the invalid state will be rendered. */
@@ -15,10 +17,23 @@ export const FieldContainer = ({
 	id,
 }: FieldContainerProps) => (
 	<Stack
+		{...{ [FIELD_CONTAINER_DATA_ATTR]: true }}
 		borderLeft={invalid}
 		borderLeftWidth="xl"
 		css={{
 			borderLeftColor: invalid ? boxPalette.systemError : undefined,
+			[`[${CONDITIONAL_FIELD_CONTAINER_DATA_ATTR}] &[${FIELD_CONTAINER_DATA_ATTR}]`]:
+				{
+					marginLeft: invalid
+						? `calc(-${mapSpacing(1)} - ${tokens.borderWidth.xl}px)`
+						: undefined,
+					position: 'relative',
+				},
+			// Only negate the margin for the first grouped field
+			[`[${CONDITIONAL_FIELD_CONTAINER_DATA_ATTR}] [${GROUPED_FIELDS_DATA_ATTR}] &[${FIELD_CONTAINER_DATA_ATTR}]:not(:first-of-type)`]:
+				{
+					marginLeft: 0,
+				},
 		}}
 		gap={0.5}
 		id={id}
@@ -27,3 +42,5 @@ export const FieldContainer = ({
 		{children}
 	</Stack>
 );
+
+const FIELD_CONTAINER_DATA_ATTR = 'data-field-container';

--- a/packages/react/src/field/__snapshots__/Field.test.tsx.snap
+++ b/packages/react/src/field/__snapshots__/Field.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`Field Basic renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -35,7 +36,8 @@ exports[`Field Basic renders correctly 1`] = `
 exports[`Field Invalid renders correctly 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -101,7 +103,8 @@ exports[`Field Invalid renders correctly 1`] = `
 exports[`Field With hint renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -25,7 +25,8 @@ exports[`Fieldset Basic renders correctly 1`] = `
         class="css-h0krvw-boxStyles"
       >
         <div
-          class="css-1904cz9-boxStyles-FieldContainer"
+          class="css-12o2rsn-boxStyles-FieldContainer"
+          data-field-container="true"
         >
           <label
             class="css-79i25n-boxStyles"
@@ -50,7 +51,8 @@ exports[`Fieldset Basic renders correctly 1`] = `
           />
         </div>
         <div
-          class="css-1904cz9-boxStyles-FieldContainer"
+          class="css-12o2rsn-boxStyles-FieldContainer"
+          data-field-container="true"
         >
           <label
             class="css-79i25n-boxStyles"
@@ -111,7 +113,8 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
         class="css-h0krvw-boxStyles"
       >
         <div
-          class="css-1904cz9-boxStyles-FieldContainer"
+          class="css-12o2rsn-boxStyles-FieldContainer"
+          data-field-container="true"
         >
           <label
             class="css-79i25n-boxStyles"
@@ -136,7 +139,8 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           />
         </div>
         <div
-          class="css-1904cz9-boxStyles-FieldContainer"
+          class="css-12o2rsn-boxStyles-FieldContainer"
+          data-field-container="true"
         >
           <label
             class="css-79i25n-boxStyles"

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`FileInput invalid renders correctly 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -94,7 +95,8 @@ exports[`FileInput invalid renders correctly 1`] = `
 exports[`FileInput renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`FileUpload 1 selected file renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -208,7 +209,8 @@ exports[`FileUpload 1 selected file renders correctly 1`] = `
 exports[`FileUpload Basic renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -315,7 +317,8 @@ exports[`FileUpload Basic renders correctly 1`] = `
 exports[`FileUpload Existing files renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -737,7 +740,8 @@ exports[`FileUpload Existing files renders correctly 1`] = `
 exports[`FileUpload Multiple, maxSize and accepted file extensions renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/grouped-fields/GroupedFields.tsx
+++ b/packages/react/src/grouped-fields/GroupedFields.tsx
@@ -108,7 +108,12 @@ export function GroupedFields({
 					{message && invalid ? (
 						<FieldMessage id={messageId}>{message}</FieldMessage>
 					) : null}
-					<Flex flexWrap="wrap" gap={1} inline>
+					<Flex
+						{...{ [GROUPED_FIELDS_DATA_ATTR]: true }}
+						flexWrap="wrap"
+						gap={1}
+						inline
+					>
 						{children({ field1Props, field2Props })}
 					</Flex>
 				</Stack>
@@ -116,6 +121,8 @@ export function GroupedFields({
 		</FieldContainer>
 	);
 }
+
+export const GROUPED_FIELDS_DATA_ATTR = 'data-grouped-fields';
 
 export function useGroupedFieldsIds(id?: string) {
 	const autoId = useId(id);

--- a/packages/react/src/grouped-fields/__snapshots__/GroupedFields.test.tsx.snap
+++ b/packages/react/src/grouped-fields/__snapshots__/GroupedFields.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`GroupedFields invalid: can render an invalid state when both fields are invalid 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <fieldset
       class="css-79i25n-boxStyles"
@@ -61,9 +62,11 @@ exports[`GroupedFields invalid: can render an invalid state when both fields are
         </div>
         <div
           class="css-72257o-boxStyles"
+          data-grouped-fields="true"
         >
           <div
-            class="css-1904cz9-boxStyles-FieldContainer"
+            class="css-12o2rsn-boxStyles-FieldContainer"
+            data-field-container="true"
           >
             <label
               class="css-79i25n-boxStyles"
@@ -95,7 +98,8 @@ exports[`GroupedFields invalid: can render an invalid state when both fields are
             />
           </div>
           <div
-            class="css-1904cz9-boxStyles-FieldContainer"
+            class="css-12o2rsn-boxStyles-FieldContainer"
+            data-field-container="true"
           >
             <label
               class="css-79i25n-boxStyles"
@@ -176,7 +180,8 @@ exports[`GroupedFields invalid: can render an invalid state when both fields are
 exports[`GroupedFields renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <fieldset
       class="css-79i25n-boxStyles"
@@ -201,9 +206,11 @@ exports[`GroupedFields renders correctly 1`] = `
       >
         <div
           class="css-72257o-boxStyles"
+          data-grouped-fields="true"
         >
           <div
-            class="css-1904cz9-boxStyles-FieldContainer"
+            class="css-12o2rsn-boxStyles-FieldContainer"
+            data-field-container="true"
           >
             <label
               class="css-79i25n-boxStyles"
@@ -234,7 +241,8 @@ exports[`GroupedFields renders correctly 1`] = `
             />
           </div>
           <div
-            class="css-1904cz9-boxStyles-FieldContainer"
+            class="css-12o2rsn-boxStyles-FieldContainer"
+            data-field-container="true"
           >
             <label
               class="css-79i25n-boxStyles"

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -6,7 +6,8 @@ exports[`PasswordInput renders correctly 1`] = `
     class="css-1lvzxao-boxStyles"
   >
     <div
-      class="css-1904cz9-boxStyles-FieldContainer"
+      class="css-12o2rsn-boxStyles-FieldContainer"
+      data-field-container="true"
     >
       <label
         class="css-79i25n-boxStyles"

--- a/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`SearchInput Basic renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -66,7 +67,8 @@ exports[`SearchInput Basic renders correctly 1`] = `
 exports[`SearchInput Invalid renders correctly 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -163,7 +165,8 @@ exports[`SearchInput Invalid renders correctly 1`] = `
 exports[`SearchInput With hint renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react/src/select/__snapshots__/Select.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`Select Basic renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -74,7 +75,8 @@ exports[`Select Basic renders correctly 1`] = `
 exports[`Select Grouped options renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -168,7 +170,8 @@ exports[`Select Grouped options renders correctly 1`] = `
 exports[`Select Invalid renders correctly 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -273,7 +276,8 @@ exports[`Select Invalid renders correctly 1`] = `
 exports[`Select With hint renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`TextInput Basic renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -39,7 +40,8 @@ exports[`TextInput Basic renders correctly 1`] = `
 exports[`TextInput Invalid renders correctly 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -109,7 +111,8 @@ exports[`TextInput Invalid renders correctly 1`] = `
 exports[`TextInput With hint renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`Textarea Basic renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -38,7 +39,8 @@ exports[`Textarea Basic renders correctly 1`] = `
 exports[`Textarea Invalid renders correctly 1`] = `
 <div>
   <div
-    class="css-1n67ua0-boxStyles-FieldContainer"
+    class="css-9biixk-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -107,7 +109,8 @@ exports[`Textarea Invalid renders correctly 1`] = `
 exports[`Textarea With hint renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/time-input/__snapshots__/TimeInput.test.tsx.snap
+++ b/packages/react/src/time-input/__snapshots__/TimeInput.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`TimeInput renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -40,7 +41,8 @@ exports[`TimeInput renders correctly 1`] = `
 exports[`TimeInput updates correctly based on the \`value\` prop 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"

--- a/packages/react/src/time-picker/__snapshots__/TimePicker.test.tsx.snap
+++ b/packages/react/src/time-picker/__snapshots__/TimePicker.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`TimePicker renders correctly 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"
@@ -96,7 +97,8 @@ exports[`TimePicker renders correctly 1`] = `
 exports[`TimePicker renders correctly when loading 1`] = `
 <div>
   <div
-    class="css-1904cz9-boxStyles-FieldContainer"
+    class="css-12o2rsn-boxStyles-FieldContainer"
+    data-field-container="true"
   >
     <label
       class="css-79i25n-boxStyles"


### PR DESCRIPTION
This changes the conditional field containe to use a thick left border instead of the a horizontal divider.

To support this, we now negatively offset any invalid fields within the CFC

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2075)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
