### PR TITLE
drawer: Make the content area keyboard-accessible

### DIFF
--- a/.changeset/brown-moose-destroy.md
+++ b/.changeset/brown-moose-destroy.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+drawer: Make the content area keyboard-accessible.
+
+drawer: Prevent title from overlapping Close button.

--- a/packages/react/src/drawer/DrawerDialog.tsx
+++ b/packages/react/src/drawer/DrawerDialog.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, ReactNode } from 'react';
 import FocusLock from 'react-focus-lock';
 import { Box } from '../box';
 import { Flex } from '../flex';
-import { mapResponsiveProp, mapSpacing, mq, tokens } from '../core';
+import { mapResponsiveProp, mapSpacing, mq, packs, tokens } from '../core';
 import { CloseIcon } from '../icon';
 import { Button } from '../button';
 import { Text } from '../text';
@@ -50,9 +50,6 @@ export function DrawerDialog({
 					boxShadow: tokens.shadow.lg,
 					inset: 0,
 					position: 'fixed',
-					[tokens.mediaQuery.max.xs]: {
-						overflowY: 'auto',
-					},
 				}}
 				flexDirection="column"
 				highContrastOutline
@@ -60,18 +57,28 @@ export function DrawerDialog({
 			>
 				<DrawerHeader>
 					<DrawerHeaderTitle id={titleId}>{title}</DrawerHeaderTitle>
+					{/* This button is a non-functioning clone of the normal Close button just to reserve the correct space */}
+					<Button
+						aria-hidden
+						css={{ visibility: 'hidden' }}
+						iconAfter={CloseIcon}
+						tabIndex={-1}
+						variant="text"
+					>
+						Close
+					</Button>
 				</DrawerHeader>
-				<DrawerContent>{children}</DrawerContent>
+				<DrawerContent title={title}>{children}</DrawerContent>
 				{actions ? <DrawerFooter>{actions}</DrawerFooter> : null}
 				<Button
 					css={mq({
 						position: 'fixed',
-						zIndex: tokens.zIndex.elevated,
-						top: '1.25rem', // align with title
 						right: mapResponsiveProp({
 							xs: mapSpacing(0.75),
 							md: mapSpacing(1.5),
 						}),
+						top: '1.25rem', // align with title
+						zIndex: tokens.zIndex.elevated,
 					})}
 					iconAfter={CloseIcon}
 					onClick={onClose}
@@ -90,22 +97,14 @@ type DrawerHeaderProps = PropsWithChildren<{}>;
 
 function DrawerHeader({ children }: DrawerHeaderProps) {
 	return (
-		<Box
+		<Flex
 			background="body"
 			borderBottom
-			css={{
-				position: 'sticky',
-				top: 0,
-				zIndex: tokens.zIndex.elevated,
-				[tokens.mediaQuery.min.sm]: {
-					position: 'relative',
-				},
-			}}
 			paddingX={{ xs: 0.75, md: 1.5 }}
 			paddingY={1}
 		>
 			{children}
-		</Box>
+		</Flex>
 	);
 }
 
@@ -133,20 +132,23 @@ function DrawerHeaderTitle({ children, id }: DrawerHeaderTitleProps) {
 
 // Drawer content
 
-type DrawerContentProps = PropsWithChildren<{}>;
+type DrawerContentProps = PropsWithChildren<{ title: string }>;
 
-function DrawerContent({ children }: DrawerContentProps) {
+function DrawerContent({ children, title }: DrawerContentProps) {
 	return (
 		<Box
+			aria-label={`${title} content`}
+			as="section"
 			background="body"
 			css={{
-				[tokens.mediaQuery.min.sm]: {
-					overflowY: 'auto',
-				},
+				overflowY: 'auto',
+				':focus': { outlineOffset: `-${packs.outline.outlineWidth}` },
 			}}
 			flexGrow={1}
+			focusRingFor="keyboard"
 			paddingX={{ xs: 0.75, md: 1.5 }}
 			paddingY={{ xs: 1, md: 1.5 }}
+			tabIndex={0}
 		>
 			{children}
 		</Box>

--- a/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -27,11 +27,11 @@ exports[`Drawer renders correctly 1`] = `
         <div
           aria-labelledby="drawer-:r0:-title"
           aria-modal="true"
-          class="css-1nou9z3-boxStyles-DrawerDialog"
+          class="css-1j57htw-boxStyles-DrawerDialog"
           role="dialog"
         >
           <div
-            class="css-1fzj2hl-boxStyles-DrawerHeader"
+            class="css-akn2k1-boxStyles"
           >
             <h2
               class="css-1ri2f4k-boxStyles-DrawerHeaderTitle"
@@ -41,16 +41,51 @@ exports[`Drawer renders correctly 1`] = `
             >
               Drawer title
             </h2>
+            <button
+              aria-hidden="true"
+              class="css-19wwocd-BaseButton-DrawerDialog"
+              tabindex="-1"
+              type="button"
+            >
+              <span>
+                <span
+                  class="css-oobk4c-Button"
+                >
+                  Close
+                </span>
+                <span
+                  aria-live="assertive"
+                />
+              </span>
+              <svg
+                aria-hidden="true"
+                class="css-16yahzk-Button"
+                clip-rule="evenodd"
+                fill-rule="evenodd"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M18 6 6 18M6 6l12 12"
+                />
+              </svg>
+            </button>
           </div>
-          <div
-            class="css-1r9s54p-boxStyles-DrawerContent"
+          <section
+            aria-label="Drawer title content"
+            class="css-b7dlx0-boxStyles-DrawerContent"
+            tabindex="0"
           >
             <p
               class="css-dbscsh-boxStyles"
             >
               Example content.
             </p>
-          </div>
+          </section>
           <div
             class="css-10pjjkw-boxStyles-DrawerFooter"
           >
@@ -71,7 +106,7 @@ exports[`Drawer renders correctly 1`] = `
             </button>
           </div>
           <button
-            class="css-1jiaeqo-BaseButton-DrawerDialog"
+            class="css-f6b0ax-BaseButton-DrawerDialog"
             type="button"
           >
             <span>


### PR DESCRIPTION
I discovered that long Drawer content wasn't keyboard accessible, because it wasn't focusable. Had to add a label to it and inset the focus ring.

Also made Drawers consistent across breakpoints, so mobile now has a sticky footer.

We also had a bug where the title could overlap into the absolutely positioned Close button. The Close button is last in the DOM order, so have created a non-functioning clone in the title.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2076)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
