### PR TITLE
docs, footer, app-layout: update copyright from 2024 to 2025

### DIFF
--- a/.changeset/five-months-agree.md
+++ b/.changeset/five-months-agree.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+docs: Update copyright to year 2025 in code snippets.
+
+footer: Update copyright to year 2025 in docs.

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -357,7 +357,7 @@ const snippets: Array<Snippet> = [
 				We pay our respects to their Elders past, present and emerging.
 			</Text>
 			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-				&copy; 2024 Department of Agriculture, Fisheries and Forestry
+				&copy; 2025 Department of Agriculture, Fisheries and Forestry
 			</Text>
 		</Footer></Box>`,
 	},
@@ -481,7 +481,7 @@ const snippets: Array<Snippet> = [
 				We pay our respects to their Elders past, present and emerging.
 			</Text>
 			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-				&copy; 2024 Department of Agriculture, Fisheries and Forestry
+				&copy; 2025 Department of Agriculture, Fisheries and Forestry
 			</Text>
 		</Footer></Box>`,
 	},

--- a/packages/react/src/app-layout/AppLayout.test.tsx
+++ b/packages/react/src/app-layout/AppLayout.test.tsx
@@ -78,7 +78,7 @@ function renderAppLayout({
 						emerging.
 					</Text>
 					<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-						&copy; 2024 Department of Agriculture, Fisheries and Forestry
+						&copy; 2025 Department of Agriculture, Fisheries and Forestry
 					</Text>
 				</AppLayoutFooter>
 			</AppLayoutContent>

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -625,7 +625,7 @@ exports[`AppLayout renders correctly 1`] = `
               <span
                 class="css-1oewark-boxStyles"
               >
-                © 2024 Department of Agriculture, Fisheries and Forestry
+                © 2025 Department of Agriculture, Fisheries and Forestry
               </span>
             </div>
           </div>

--- a/packages/react/src/footer/Footer.test.tsx
+++ b/packages/react/src/footer/Footer.test.tsx
@@ -33,7 +33,7 @@ function renderFooter(props?: Partial<FooterProps>) {
 				We pay our respects to their Elders past, present and emerging.
 			</Text>
 			<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-				&copy; 2024 Department of Agriculture, Fisheries and Forestry
+				&copy; 2025 Department of Agriculture, Fisheries and Forestry
 			</Text>
 		</Footer>
 	);

--- a/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/footer/__snapshots__/Footer.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Footer renders correctly 1`] = `
       <span
         class="css-1oewark-boxStyles"
       >
-        © 2024 Department of Agriculture, Fisheries and Forestry
+        © 2025 Department of Agriculture, Fisheries and Forestry
       </span>
     </div>
   </footer>

--- a/packages/react/src/footer/docs/overview.mdx
+++ b/packages/react/src/footer/docs/overview.mdx
@@ -74,7 +74,7 @@ figmaGalleryNodeId: 11978%3A103355
 		</Box>
 		<FooterDivider />
 		<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-			&copy; 2024 Department of Agriculture, Fisheries and Forestry
+			&copy; 2025 Department of Agriculture, Fisheries and Forestry
 		</Text>
 	</Footer>
 </Box>
@@ -125,7 +125,7 @@ The footer at the bottom of a page. Usually contains copyright information and l
 			our respects to their Elders past, present and emerging.
 		</Text>
 		<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-			&copy; 2024 Department of Agriculture, Fisheries and Forestry
+			&copy; 2025 Department of Agriculture, Fisheries and Forestry
 		</Text>
 	</Footer>
 </Box>


### PR DESCRIPTION
Update copyright from year `2024` to `2025`. Only in docs and tests.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2081)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets