### PR TITLE
filter-sidebar, process-indicator, side-nav: update colour on chevron to `action`

### DIFF
--- a/.changeset/quiet-kids-help.md
+++ b/.changeset/quiet-kids-help.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/react': patch
+---
+
+filter-sidebar: Update `CollapsingSideBar` chevron to `action` colour.
+
+process-indicator: Update `CollapsingSideBar` chevron to `action` colour.
+
+side-nav: Update `CollapsingSideBar` chevron to `action` colour.

--- a/packages/react/src/_collapsing-side-bar/CollapsingSideBar.tsx
+++ b/packages/react/src/_collapsing-side-bar/CollapsingSideBar.tsx
@@ -148,7 +148,7 @@ export function CollapsingSideBar({
 								</Text>
 							)}
 						</Stack>
-						<ChevronDownIcon weight="bold" />
+						<ChevronDownIcon color="action" weight="bold" />
 					</Flex>
 				</Box>
 			</Box>

--- a/packages/react/src/_collapsing-side-bar/__snapshots__/CollapsingSideBar.test.tsx.snap
+++ b/packages/react/src/_collapsing-side-bar/__snapshots__/CollapsingSideBar.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`CollapsingSideBar renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -125,7 +125,7 @@ exports[`CollapsingSideBar renders customTitleElement correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"

--- a/packages/react/src/filter-sidebar/__snapshots__/FilterSidebar.test.tsx.snap
+++ b/packages/react/src/filter-sidebar/__snapshots__/FilterSidebar.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`FilterSidebar renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"

--- a/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -558,7 +558,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -1066,7 +1066,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -1574,7 +1574,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied blocked status 
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -2082,7 +2082,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -2590,7 +2590,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied doing status ac
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -3098,7 +3098,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"
@@ -3606,7 +3606,7 @@ exports[`ProgressIndicator legacy handlers With isActive applied started status 
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"

--- a/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/react/src/side-nav/__snapshots__/SideNav.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`SideNav renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-lewdp2-Icon"
+            class="css-1nxnaym-Icon"
             clip-rule="evenodd"
             fill-rule="evenodd"
             focusable="false"


### PR DESCRIPTION
The Chevron on the `CollapsingSideBar` component had issues with the colour on a `dark` background. Updated the Chevron to match the `Accordion` component with `action` colour.

Affected components:
- filter-sidebar:
  - [before](https://design-system.agriculture.gov.au/playroom/#?code=N4Igxg9gJgpiBcIA8AlGA7WAnAfAHXQAJjDgAKASkIF4dSCTC8AXLGZgVyyLIZJZZIAwhAA2HALboAzoQDmAQwAO1YMEIAPafEIBGADSEJUHQGZCAXwv4i-ZgObCxkopHFSAykoXpV6rTq6AEyGxjoALJbWfMQODkgAYgCWoswwWB5JsABGCliECmDMSQBuMMmp6dIiHOjMqqbRtrH2rfEJEFgSHsyFANY2jHFtrUgAKjAazACS6EoczITZohBgfYSiCtkwotR4IACiGgoSSqIwhElzC3r7hAD0g3bD8RNTs-OLy6vrm9u7%2ByOJzOFyun0IQTujxiTBGw3Gkxm1y%2BKzWGy2Oz2h2Op3Ol2RhFMUKeLReozeSPB3zRf0xgJxIPx4PCxJhZME9w6XR6-RJsPhnJSaQyWRguVwMMYUqlSAAQhANIQoHkBpLperGIkhelMjk8gUiqVytqsNUILV6sBGnz2Y4ud1emsbXCRgj3gTqb8MQDscC8WCbrpWc1%2BS7BBSPjdPej-ligbjQQTISAHs7bW7KVHUV7Y-S-YnwUSU9CQ7bw4jIyifjG6b6E0ybizi2mXUhOZ0Hby2a3BZURXqJSGNRq2-KNC2OSJ3OgJ-ZS6N7lOXNJnRQANwwqwENtoTDpHAgfQgADuWWYAAtpAgANqmIIABgAuhYgA)
  - [after](https://design-system.agriculture.gov.au/pr-preview/pr-2082/playroom/#?code=N4Igxg9gJgpiBcIA8AlGA7WAnAfAHXQAJjDgAKASkIF4dSCTC8AXLGZgVyyLIZJZZIAwhAA2HALboAzoQDmAQwAO1YMEIAPafEIBGADSEJUHQGZCAXwv4i-ZgObCxkopHFSAykoXpV6rTq6AEyGxjoALJbWfMQODkgAYgCWoswwWB5JsABGCliECmDMSQBuMMmp6dIiHOjMqqbRtrH2rfEJEFgSHsyFANY2jHFtrUgAKjAazACS6EoczITZohBgfYSiCtkwotR4IACiGgoSSqIwhElzC3r7hAD0g3bD8RNTs-OLy6vrm9u7%2ByOJzOFyun0IQTujxiTBGw3Gkxm1y%2BKzWGy2Oz2h2Op3Ol2RhFMUKeLReozeSPB3zRf0xgJxIPx4PCxJhZME9w6XR6-RJsPhnJSaQyWRguVwMMYUqlSAAQhANIQoHkBpLperGIkhelMjk8gUiqVytqsNUILV6sBGnz2Y4ud1emsbXCRgj3gTqb8MQDscC8WCbrpWc1%2BS7BBSPjdPej-ligbjQQTISAHs7bW7KVHUV7Y-S-YnwUSU9CQ7bw4jIyifjG6b6E0ybizi2mXUhOZ0Hby2a3BZURXqJSGNRq2-KNC2OSJ3OgJ-ZS6N7lOXNJnRQANwwqwENtoTDpHAgfQgADuWWYAAtpAgANqmIIABgAuhYgA)
- process-indicator: 
  - [before](https://design-system.agriculture.gov.au/playroom/#?code=N4Igxg9gJgpiBcIA8AFAThA5mmBnXAkgHZQCWYAhgC4RoA6RdVFYVpAbjCtQBYC8dEAGJamCkVK5qpCEVwB6ClCgBaUeMnTZghk1JUYAW1x9gAbV1UmwAAQ8cAM3g2A5ENJEqGKAFdWMohcAGhsAGwoAIxhQ5xdiL2g-Nllgm1xmKh9cWKhZGBcbAF8gy2tSqyp7GCdXETQxCSlkuWDypnComNcAeXqNJoDcVsYKpnTqLNjxtAMoYaYFtgNjZwsRxbL10YqO6NiAQWUbcRt1Rq1Akq2NysdYuobNZoUlVTOngPntpmK2qgBdK6LX5bWxVGpuHDsUgwADuqV2XRcACUYNC4ccSGkfBFDPpUuNMtlXBFQhAwABrGBzIpAgGFBjyAB8DCQACEIAAPGxQChoCksoioDDYPCEEjkai0SwsNicbiVATCd4DWQvZRqPrnZo6Eb6IwmczlMF3WoeBK%2BfwpEKI2LxbxJT4hQmTVy5Ij5WnGv7g%2B4qi5DOmLW09LUfNVfRYu4kuaazSMVfUrGxrG6bNM7SJ7VyHKCY05h1WXP6LX21f3PRQaitOktUEE3QHlBsVE3Ve5QmHwm1ZpGo9GwzF53A4vFUAkZV0uUnkqk0lv-BlEZms%2BQczlMkBBECw0hQSq4BBmADMACYAAyLoA)
  - [after](https://design-system.agriculture.gov.au/pr-preview/pr-2082/playroom/#?code=N4Igxg9gJgpiBcIA8AFAThA5mmBnXAkgHZQCWYAhgC4RoA6RdVFYVpAbjCtQBYC8dEAGJamCkVK5qpCEVwB6ClCgBaUeMnTZghk1JUYAW1x9gAbV1UmwAAQ8cAM3g2A5ENJEqGKAFdWMohcAGhsAGwoAIxhQ5xdiL2g-Nllgm1xmKh9cWKhZGBcbAF8gy2tSqyp7GCdXETQxCSlkuWDypnComNcAeXqNJoDcVsYKpnTqLNjxtAMoYaYFtgNjZwsRxbL10YqO6NiAQWUbcRt1Rq1Akq2NysdYuobNZoUlVTOngPntpmK2qgBdK6LX5bWxVGpuHDsUgwADuqV2XRcACUYNC4ccSGkfBFDPpUuNMtlXBFQhAwABrGBzIpAgGFBjyAB8DCQACEIAAPGxQChoCksoioDDYPCEEjkai0SwsNicbiVATCd4DWQvZRqPrnZo6Eb6IwmczlMF3WoeBK%2BfwpEKI2LxbxJT4hQmTVy5Ij5WnGv7g%2B4qi5DOmLW09LUfNVfRYu4kuaazSMVfUrGxrG6bNM7SJ7VyHKCY05h1WXP6LX21f3PRQaitOktUEE3QHlBsVE3Ve5QmHwm1ZpGo9GwzF53A4vFUAkZV0uUnkqk0lv-BlEZms%2BQczlMkBBECw0hQSq4BBmADMACYAAyLoA)
- side-nav
  - [before](https://design-system.agriculture.gov.au/playroom/#?code=N4Igxg9gJgpiBcJgHoBUqA6A7ABKnAchAC4zw4DuMOAhgE7URYA2AnjgwM7F0CWYxXlgDmOYgAtenHDAAeNALYAHZtWIQcANhyRm0gGYQ6Y8dSgQwnADTY8OAIwAmHRD04pJ6g0gKFMLFA0gkw4hsYARjDcHFEArszE0kK0Sir8QbwhkLC2qMgAvtgAPADKvLAENABu2BjEdXU0ArxVMAAKQeIAvBggAMRKNMIwALT2vbX1U5yx4QAyMK3MAGpSvOGqPSA0zBQ0rJwTWA1TgsSbvZVVvMIZTEcndWeqc0IA1lt9D1N1vKQKnC6wAA2pNHsRgGCflNxAx9OQAOQDIajewImzHaEnZg0SLMRFzGgBISiQbDBzoqEnfIY8F1SGYukSOGI5HDEaOSmMrHnXEwfE4BGE4kiHBk6ic2k837-TjkUHcpkMpng2EweGCvpYOTEEbi5DijljLkq6E4vGIjrkxwAOjRUtNNKpPOV0uhao1SO1sl1%2BsNjg5Jrd2L5AoRVolNslzvBTsV0IAug7oXHwQnCtzkAA%2BYoAYVcsQUWGkukBwE0%2BRwgTobxzmKK%2BeYhdwumbJUGWCBwBwsjlDkcVhwCig5AALIPmMJyABmHD5fJ1k6lcowK7OpqCVodCSfQ3jEDOmbzRb81acdYXba7faHA-x54wLZXG53Y538EP15YD69L7v6F-DAAJAgqSoxjCLKanuQZMua-IEkSUAkmKKIUsm1LoVMrpMh6rL%2BjBPJwWGwpIaK4o4NG8YnIBALyuBJzYcGzLqqy3q%2BiiBooka9r0WaoaWqhto8VRKaYeCjGmrhmpsXqHH%2BoGYmEfxgoRhRUYEUyqZukm4FaSc6ZQtmkxFMgjbNnWJlmUWnBZiAVggBQ5QSJwCDAtOjgAAzpkAA)
  - [after](https://design-system.agriculture.gov.au/pr-preview/pr-2082/playroom/#?code=N4Igxg9gJgpiBcJgHoBUqA6A7ABKnAchAC4zw4DuMOAhgE7URYA2AnjgwM7F0CWYxXlgDmOYgAtenHDAAeNALYAHZtWIQcANhyRm0gGYQ6Y8dSgQwnADTY8OAIwAmHRD04pJ6g0gKFMLFA0gkw4hsYARjDcHFEArszE0kK0Sir8QbwhkLC2qMgAvtgAPADKvLAENABu2BjEdXU0ArxVMAAKQeIAvBggAMRKNMIwALT2vbX1U5yx4QAyMK3MAGpSvOGqPSA0zBQ0rJwTWA1TgsSbvZVVvMIZTEcndWeqc0IA1lt9D1N1vKQKnC6wAA2pNHsRgGCflNxAx9OQAOQDIajewImzHaEnZg0SLMRFzGgBISiQbDBzoqEnfIY8F1SGYukSOGI5HDEaOSmMrHnXEwfE4BGE4kiHBk6ic2k837-TjkUHcpkMpng2EweGCvpYOTEEbi5DijljLkq6E4vGIjrkxwAOjRUtNNKpPOV0uhao1SO1sl1%2BsNjg5Jrd2L5AoRVolNslzvBTsV0IAug7oXHwQnCtzkAA%2BYoAYVcsQUWGkukBwE0%2BRwgTobxzmKK%2BeYhdwumbJUGWCBwBwsjlDkcVhwCig5AALIPmMJyABmHD5fJ1k6lcowK7OpqCVodCSfQ3jEDOmbzRb81acdYXba7faHA-x54wLZXG53Y538EP15YD69L7v6F-DAAJAgqSoxjCLKanuQZMua-IEkSUAkmKKIUsm1LoVMrpMh6rL%2BjBPJwWGwpIaK4o4NG8YnIBALyuBJzYcGzLqqy3q%2BiiBooka9r0WaoaWqhto8VRKaYeCjGmrhmpsXqHH%2BoGYmEfxgoRhRUYEUyqZukm4FaSc6ZQtmkxFMgjbNnWJlmUWnBZiAVggBQ5QSJwCDAtOjgAAzpkAA)

![Screenshot 2025-06-26 at 10 32 32 am](https://github.com/user-attachments/assets/2467fe14-31ef-43aa-8775-cd1878e74a91)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2082)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
