### PR TITLE
checkbox: Remove space beneath when in the normal document flow

### DIFF
--- a/.changeset/young-penguins-press.md
+++ b/.changeset/young-penguins-press.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+checkbox: Remove space beneath when in the normal document flow.
+
+radio: Remove space beneath when in the normal document flow.

--- a/packages/react/src/checkbox/CheckboxInput.tsx
+++ b/packages/react/src/checkbox/CheckboxInput.tsx
@@ -11,6 +11,7 @@ export const CheckboxInput = forwardRef<HTMLInputElement, ControlInputProps>(
 					height,
 					margin: 0,
 					opacity: 0,
+					verticalAlign: 'middle',
 					width,
 					// When this component is focused, outline the `CheckboxIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Checkbox renders correctly 1`] = `
       class="css-1246v4c-Checkbox"
     >
       <input
-        class="css-1iw6cs3-CheckboxInput"
+        class="css-beu66l-CheckboxInput"
         data-testid="example"
         id="checkbox-:r0:"
         name="my-checkbox"

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:r2:"
                 name=":r1:"
@@ -82,7 +82,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:r3:"
                 name=":r1:"
@@ -124,7 +124,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:r4:"
                 name=":r1:"
@@ -166,7 +166,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:r5:"
                 name=":r1:"
@@ -288,7 +288,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:rk:"
                 name=":rj:"
@@ -332,7 +332,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:rl:"
                 name=":rj:"
@@ -376,7 +376,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:rm:"
                 name=":rj:"
@@ -420,7 +420,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:ri:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:rn:"
                 name=":rj:"
@@ -501,7 +501,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-a"
                 id="checkbox-:re:"
                 name=":rd:"
@@ -543,7 +543,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-b"
                 id="checkbox-:rf:"
                 name=":rd:"
@@ -585,7 +585,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-c"
                 id="checkbox-:rg:"
                 name=":rd:"
@@ -627,7 +627,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-1iw6cs3-CheckboxInput"
+                class="css-beu66l-CheckboxInput"
                 data-testid="option-d"
                 id="checkbox-:rh:"
                 name=":rd:"
@@ -707,7 +707,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-a"
                 id="radio-:r16:"
                 name=":r15:"
@@ -736,7 +736,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-b"
                 id="radio-:r17:"
                 name=":r15:"
@@ -765,7 +765,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-c"
                 id="radio-:r18:"
                 name=":r15:"
@@ -794,7 +794,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             >
               <input
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-d"
                 id="radio-:r19:"
                 name=":r15:"
@@ -903,7 +903,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-a"
                 id="radio-:r1o:"
                 name=":r1n:"
@@ -934,7 +934,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-b"
                 id="radio-:r1p:"
                 name=":r1n:"
@@ -965,7 +965,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-c"
                 id="radio-:r1q:"
                 name=":r1n:"
@@ -996,7 +996,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
                 aria-describedby="control-group-:r1m:-message"
                 aria-invalid="true"
                 aria-required="false"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-d"
                 id="radio-:r1r:"
                 name=":r1n:"
@@ -1064,7 +1064,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-a"
                 id="radio-:r1i:"
                 name=":r1h:"
@@ -1093,7 +1093,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-b"
                 id="radio-:r1j:"
                 name=":r1h:"
@@ -1122,7 +1122,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-c"
                 id="radio-:r1k:"
                 name=":r1h:"
@@ -1151,7 +1151,7 @@ exports[`ControlGroup  With Radios renders correctly when required 1`] = `
             >
               <input
                 aria-required="true"
-                class="css-w4mqhh-RadioInput"
+                class="css-187ng6g-RadioInput"
                 data-testid="option-d"
                 id="radio-:r1l:"
                 name=":r1h:"

--- a/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/password-input/__snapshots__/PasswordInput.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`PasswordInput renders correctly 1`] = `
       >
         <input
           aria-controls="password-input-:r0:"
-          class="css-7v4krt-CheckboxInput"
+          class="css-k2wv6v-CheckboxInput"
           id="checkbox-:r2:"
           type="checkbox"
         />

--- a/packages/react/src/radio/RadioInput.tsx
+++ b/packages/react/src/radio/RadioInput.tsx
@@ -11,6 +11,7 @@ export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
 					height,
 					margin: 0,
 					opacity: 0,
+					verticalAlign: 'middle',
 					width,
 					// When this component is focused, outline the `RadioIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Radio renders correctly 1`] = `
       class="css-7y4mhc-Radio"
     >
       <input
-        class="css-w4mqhh-RadioInput"
+        class="css-187ng6g-RadioInput"
         data-testid="example"
         id="radio-:r2:"
         name="my-radio"

--- a/packages/react/src/table/__snapshots__/TableRow.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableRow.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`TableRow renders correctly 1`] = `
                   class="css-1246v4c-Checkbox"
                 >
                   <input
-                    class="css-1iw6cs3-CheckboxInput"
+                    class="css-beu66l-CheckboxInput"
                     id="nsw-checkbox"
                     type="checkbox"
                     value="nsw"


### PR DESCRIPTION
The a11y fix for checkboxes in 1.27 accidentally added space beneath when they're not in Stacks etc.

Also added the same fix to radios to make them consistent, but they're never used that way anyway.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2084)

## Comparison with short labels:

<img width="434" alt="image" src="https://github.com/user-attachments/assets/1d5131f7-4f27-4510-aca7-9d15fb4f9bbd" />

## Identical with long labels:

<img width="294" alt="image" src="https://github.com/user-attachments/assets/1fc3a802-8dea-4e7f-95c7-15075bc37b4d" />

## Comparison in tables:

<img width="312" alt="image" src="https://github.com/user-attachments/assets/efba70f5-d203-45b0-89b8-7858617e42cb" />


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
