### PR TITLE
header: Make heading optional and conditionally render

### DIFF
--- a/.changeset/proud-bobcats-raise.md
+++ b/.changeset/proud-bobcats-raise.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+header: Make heading optional and conditionally render.

--- a/packages/react/src/header/Header.tsx
+++ b/packages/react/src/header/Header.tsx
@@ -12,7 +12,7 @@ export type HeaderProps = {
 	/** When using two logos, position the horizontal dividing line 'between' the logos or 'after' them. */
 	dividerPosition?: 'after' | 'between';
 	/** The heading should be set to the website or service title. */
-	heading: string;
+	heading?: string;
 	/** The href to link to, for example "/". */
 	href?: string;
 	/** The logo to display. */

--- a/packages/react/src/header/HeaderBrand.tsx
+++ b/packages/react/src/header/HeaderBrand.tsx
@@ -112,36 +112,42 @@ export function HeaderBrand({
 					<DividingLine dividerPosition={dividerPosition} />
 				)}
 
-				<Stack
-					as={Link}
-					color="text"
-					css={{
-						textDecoration: 'none',
-						':hover': packs.underline,
-					}}
-					focusRingFor="keyboard"
-					href={href}
-					justifyContent="center"
-				>
-					<Flex alignItems="flex-start" gap={0.5}>
-						<Text
-							fontSize={headingSizeMap[size]}
-							fontWeight="bold"
-							lineHeight="default"
-							maxWidth={tokens.maxWidth.bodyText}
-						>
-							{heading}
-						</Text>
+				{(heading || badgeLabel || subline) && (
+					<Stack
+						as={Link}
+						color="text"
+						css={{
+							textDecoration: 'none',
+							':hover': packs.underline,
+						}}
+						focusRingFor="keyboard"
+						href={href}
+						justifyContent="center"
+					>
+						{(heading || badgeLabel) && (
+							<Flex alignItems="flex-start" gap={0.5}>
+								{heading && (
+									<Text
+										fontSize={headingSizeMap[size]}
+										fontWeight="bold"
+										lineHeight="default"
+										maxWidth={tokens.maxWidth.bodyText}
+									>
+										{heading}
+									</Text>
+								)}
 
-						{badgeLabel && <HeaderBadge>{badgeLabel}</HeaderBadge>}
-					</Flex>
+								{badgeLabel && <HeaderBadge>{badgeLabel}</HeaderBadge>}
+							</Flex>
+						)}
 
-					{subline && (
-						<Text color="muted" fontSize={subHeadingSizeMap[size]}>
-							{subline}
-						</Text>
-					)}
-				</Stack>
+						{subline && (
+							<Text color="muted" fontSize={subHeadingSizeMap[size]}>
+								{subline}
+							</Text>
+						)}
+					</Stack>
+				)}
 			</Flex>
 		</Flex>
 	) : (

--- a/packages/react/src/header/docs/overview.mdx
+++ b/packages/react/src/header/docs/overview.mdx
@@ -58,17 +58,16 @@ The `size` prop can be used to control the vertical height of the Header. Use th
 
 ## Co-branding
 
-The header component can be used with no logo, one logo, or two logos when the [Australian Government Brand Guidelines](https://www.pmc.gov.au/publications/australian-government-branding-guildelines) for Program or International branding are met. Each logo can be a link when an `href` and `secondHref` are defined.
+The header component can be used with no logo, one logo, or two logos when the [Australian Government Brand Guidelines](https://www.pmc.gov.au/resources/australian-government-branding-guidelines) for Program or International branding are met. Each logo can be a link when an `href` and `secondHref` are defined.
 
-_Note: The first logo’s `href` will be assigned to the `heading` and `subline` text as well._
+_Note: If provided, the first logo’s `href` will be assigned to the `heading` and `subline` text as well._
 
 ```jsx live
 <Box palette="dark">
 	<Header
-		heading="Co-branding header"
-		subline="Co-branding subline"
 		logo={<Logo />}
 		background="bodyAlt"
+		dividerPosition="between"
 		size="sm"
 		href="#first-href"
 		secondLogo={


### PR DESCRIPTION
Another government department does not need to use the `heading` prop, but this unfortunately creates an accessibility violation of rendering an empty link.

This PR makes `heading` optional, and updates the conditional rendering as necessary.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-[PR_NUMBER])

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
- [ ] Verify hard-coded anchor links and hashes are correct. Check existing links when renaming pages and headings.
