### PR TITLE
main-nav: Always close mobile dialog on link click

### DIFF
--- a/.changeset/neat-squids-grab.md
+++ b/.changeset/neat-squids-grab.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+main-nav: Always close mobile dialog on link click to support updating `activePath` with Next.js‘ `usePathname`.

--- a/packages/react/src/main-nav/MainNavDialogNavList.tsx
+++ b/packages/react/src/main-nav/MainNavDialogNavList.tsx
@@ -30,7 +30,7 @@ export function MainNavDialogNavList({
 							<MainNavDialogNavListItem
 								active={active}
 								key={index}
-								onClick={active ? closeMobileMenu : undefined} // Let the click event bubble up and close the menu on press of interactive item
+								onClick={closeMobileMenu} // Let the click event bubble up and close the menu on press of interactive item
 							>
 								<Link aria-current={active ? 'page' : undefined} {...item}>
 									<span>{label}</span>


### PR DESCRIPTION
…to support updating `activePath` with Next.js‘ `usePathname`.

Unlike in Pages Router, App Router's `usePathname` is async, so it doesn't update the `activePath` before updating the nav item and allowing the onClick to close the menu.

This changes it so every link click closes the menu immediately. The experience of the previous implementation basically waited for the new page to load and then the menu closed, so you looked at the same state for a second before anything happened. Now, you know something happens straight away as the menu closes, but then you have to wait for the new content to load. You can add your own loading indicator if you want to give more feedback.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-[PR_NUMBER])

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
